### PR TITLE
increasing fault tolerance on redirects

### DIFF
--- a/pkg/engine/hybrid/hybrid.go
+++ b/pkg/engine/hybrid/hybrid.go
@@ -176,8 +176,7 @@ func (c *Crawler) makeRoutingHandler(queue *queue.VarietyQueue, depth int, parse
 		// here we can process raw request/response in one pass
 		err := ctx.LoadResponse(c.httpclient.HTTPClient, true)
 		if err != nil {
-			gologger.Warning().Msgf("%s\n", err)
-			return
+			gologger.Warning().Msgf("\"%s\" on load response: %s\n", reqURL, err)
 		}
 
 		body := ctx.Response.Body()


### PR DESCRIPTION
## Description
This PR improves error on redirects handling, turning them into non-fatal.

Notes:
- Broken crawling might be fixed indirectly with https://github.com/projectdiscovery/katana/pull/85
- Native headless proxy might drop the need of golang mitm proxy (ref: https://github.com/projectdiscovery/katana/issues/79)