### PR TITLE
Headless issue with root user

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,11 @@ CONFIGURATION:
    -fc, -form-config string      path to custom form configuration file
 
 HEADLESS:
-   -hl, -headless       enable headless hybrid crawling (experimental)
-   -sc, -system-chrome  use local installed chrome browser instead of katana installed
-   -sb, -show-browser   show the browser on the screen with headless mode
+   -hl, -headless                   enable headless hybrid crawling (experimental)
+   -sc, -system-chrome              use local installed chrome browser instead of katana installed
+   -sb, -show-browser               show the browser on the screen with headless mode
+   -ho, -headless-options string[]  start headless chrome with additional options
+   -nos, -no-sandbox                start headless chrome in --no-sandbox mode
 
 SCOPE:
    -cs, -crawl-scope string[]       in scope url regex to be followed by crawler

--- a/cmd/katana/main.go
+++ b/cmd/katana/main.go
@@ -77,8 +77,8 @@ pipelines offering both headless and non-headless crawling.`)
 		flagSet.BoolVarP(&options.Headless, "headless", "hl", false, "enable headless hybrid crawling (experimental)"),
 		flagSet.BoolVarP(&options.UseInstalledChrome, "system-chrome", "sc", false, "use local installed chrome browser instead of katana installed"),
 		flagSet.BoolVarP(&options.ShowBrowser, "show-browser", "sb", false, "show the browser on the screen with headless mode"),
-		flagSet.StringSliceVarP(&options.HeadlessOptionalArguments, "headless-optional-arguments", "hoa", nil, "pass optional arguments to chrome", goflags.FileCommaSeparatedStringSliceOptions),
-		flagSet.BoolVarP(&options.HeadlessNoSandbox, "headless-no-sandbox", "hns", false, "start chrome in --no-sandbox mode"),
+		flagSet.StringSliceVarP(&options.HeadlessOptionalArguments, "headless-options", "ho", nil, "start headless chrome with additional options", goflags.FileCommaSeparatedStringSliceOptions),
+		flagSet.BoolVarP(&options.HeadlessNoSandbox, "no-sandbox", "nos", false, "start headless chrome in --no-sandbox mode"),
 	)
 
 	flagSet.CreateGroup("scope", "Scope",

--- a/cmd/katana/main.go
+++ b/cmd/katana/main.go
@@ -77,6 +77,8 @@ pipelines offering both headless and non-headless crawling.`)
 		flagSet.BoolVarP(&options.Headless, "headless", "hl", false, "enable headless hybrid crawling (experimental)"),
 		flagSet.BoolVarP(&options.UseInstalledChrome, "system-chrome", "sc", false, "use local installed chrome browser instead of katana installed"),
 		flagSet.BoolVarP(&options.ShowBrowser, "show-browser", "sb", false, "show the browser on the screen with headless mode"),
+		flagSet.StringSliceVarP(&options.HeadlessOptionalArguments, "headless-optional-arguments", "hoa", nil, "pass optional arguments to chrome", goflags.FileCommaSeparatedStringSliceOptions),
+		flagSet.BoolVarP(&options.HeadlessNoSandbox, "headless-no-sandbox", "hns", false, "start chrome in --no-sandbox mode"),
 	)
 
 	flagSet.CreateGroup("scope", "Scope",

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -29,6 +29,9 @@ func validateOptions(options *types.Options) error {
 	if len(options.URLs) == 0 && !fileutil.HasStdin() {
 		return errors.New("no inputs specified for crawler")
 	}
+	if (options.HeadlessOptionalArguments != nil || options.HeadlessNoSandbox) && !options.Headless {
+		return errors.New("headless mode (-hl) is required if -hoa or -hns are set")
+	}
 	gologger.DefaultLogger.SetFormatter(formatter.NewCLI(options.NoColors))
 	return nil
 }

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -30,7 +30,7 @@ func validateOptions(options *types.Options) error {
 		return errors.New("no inputs specified for crawler")
 	}
 	if (options.HeadlessOptionalArguments != nil || options.HeadlessNoSandbox) && !options.Headless {
-		return errors.New("headless mode (-hl) is required if -hoa or -hns are set")
+		return errors.New("headless mode (-hl) is required if -ho or -nos are set")
 	}
 	gologger.DefaultLogger.SetFormatter(formatter.NewCLI(options.NoColors))
 	return nil

--- a/pkg/engine/hybrid/hybrid.go
+++ b/pkg/engine/hybrid/hybrid.go
@@ -14,6 +14,7 @@ import (
 	"github.com/PuerkitoBio/goquery"
 	"github.com/go-rod/rod"
 	"github.com/go-rod/rod/lib/launcher"
+	"github.com/go-rod/rod/lib/launcher/flags"
 	"github.com/pkg/errors"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/katana/pkg/engine/common"
@@ -74,6 +75,14 @@ func New(options *types.CrawlerOptions) (*Crawler, error) {
 		chromeLauncher = chromeLauncher.Headless(false)
 	} else {
 		chromeLauncher = chromeLauncher.Headless(true)
+	}
+
+	if options.Options.HeadlessNoSandbox {
+		chromeLauncher.Set("no-sandbox", "true")
+	}
+
+	for k, v := range options.Options.ParseHeadlessOptionalArguments() {
+		chromeLauncher.Set(flags.Flag(k), v)
 	}
 
 	launcherURL, err := chromeLauncher.Launch()

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -99,8 +99,8 @@ func (options *Options) ParseHeadlessOptionalArguments() map[string]string {
 	optionalArguments := make(map[string]string)
 	for _, v := range options.HeadlessOptionalArguments {
 		if argParts := strings.SplitN(v, "=", 2); len(argParts) >= 2 {
-			key := strings.Trim(argParts[0], " ")
-			value := strings.Trim(argParts[1], " ")
+			key := strings.TrimSpace(argParts[0])
+			value := strings.TrimSpace(argParts[1])
 			if key != "" && value != "" {
 				optionalArguments[key] = value
 			}

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -104,7 +104,6 @@ func (options *Options) ParseHeadlessOptionalArguments() map[string]string {
 			if key != "" && value != "" {
 				optionalArguments[key] = value
 			}
-
 		}
 	}
 	return optionalArguments

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -79,6 +79,10 @@ type Options struct {
 	UseInstalledChrome bool
 	// ShowBrowser specifies whether the show the browser in headless mode
 	ShowBrowser bool
+	// HeadlessOptionalArguments specifies optional arguments to pass to Chrome
+	HeadlessOptionalArguments goflags.StringSlice
+	// HeadlessNoSandbox specifies if chrome should be start in --no-sandbox mode
+	HeadlessNoSandbox bool
 }
 
 func (options *Options) ParseCustomHeaders() map[string]string {
@@ -89,4 +93,19 @@ func (options *Options) ParseCustomHeaders() map[string]string {
 		}
 	}
 	return customHeaders
+}
+
+func (options *Options) ParseHeadlessOptionalArguments() map[string]string {
+	optionalArguments := make(map[string]string)
+	for _, v := range options.HeadlessOptionalArguments {
+		if argParts := strings.SplitN(v, "=", 2); len(argParts) >= 2 {
+			key := strings.Trim(argParts[0], " ")
+			value := strings.Trim(argParts[1], " ")
+			if key != "" && value != "" {
+				optionalArguments[key] = value
+			}
+
+		}
+	}
+	return optionalArguments
 }

--- a/pkg/types/options_test.go
+++ b/pkg/types/options_test.go
@@ -25,24 +25,14 @@ func TestParseCustomHeaders(t *testing.T) {
 			want:  map[string]string{},
 		},
 		{
-			name:  "empty key",
-			input: ":b",
-			want:  map[string]string{},
-		},
-		{
 			name:  "empty value",
 			input: "a:",
-			want:  map[string]string{},
+			want:  map[string]string{"a": ""},
 		},
 		{
 			name:  "double input",
 			input: "a:b,c:d",
 			want:  map[string]string{"a": "b", "c": "d"},
-		},
-		{
-			name:  "duplicated input",
-			input: "a:b,a:b",
-			want:  map[string]string{"a": "b"},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/types/options_test.go
+++ b/pkg/types/options_test.go
@@ -49,6 +49,7 @@ func TestParseCustomHeaders(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			strsl := goflags.StringSlice{}
 			for _, v := range strings.Split(tt.input, ",") {
+				//nolint
 				strsl.Set(v)
 			}
 			opt := Options{CustomHeaders: strsl}
@@ -99,6 +100,7 @@ func TestParseHeadlessOptionalArguments(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			strsl := goflags.StringSlice{}
 			for _, v := range strings.Split(tt.input, ",") {
+				//nolint
 				strsl.Set(v)
 			}
 			opt := Options{HeadlessOptionalArguments: strsl}

--- a/pkg/types/options_test.go
+++ b/pkg/types/options_test.go
@@ -1,0 +1,109 @@
+package types
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/projectdiscovery/goflags"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCustomHeaders(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  map[string]string
+	}{
+		{
+			name:  "single value",
+			input: "a:b",
+			want:  map[string]string{"a": "b"},
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  map[string]string{},
+		},
+		{
+			name:  "empty key",
+			input: ":b",
+			want:  map[string]string{},
+		},
+		{
+			name:  "empty value",
+			input: "a:",
+			want:  map[string]string{},
+		},
+		{
+			name:  "double input",
+			input: "a:b,c:d",
+			want:  map[string]string{"a": "b", "c": "d"},
+		},
+		{
+			name:  "duplicated input",
+			input: "a:b,a:b",
+			want:  map[string]string{"a": "b"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			strsl := goflags.StringSlice{}
+			for _, v := range strings.Split(tt.input, ",") {
+				strsl.Set(v)
+			}
+			opt := Options{CustomHeaders: strsl}
+			got := opt.ParseCustomHeaders()
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseHeadlessOptionalArguments(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  map[string]string
+	}{
+		{
+			name:  "single value",
+			input: "a=b",
+			want:  map[string]string{"a": "b"},
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  map[string]string{},
+		},
+		{
+			name:  "empty key",
+			input: "=b",
+			want:  map[string]string{},
+		},
+		{
+			name:  "empty value",
+			input: "a=",
+			want:  map[string]string{},
+		},
+		{
+			name:  "double input",
+			input: "a=b,c=d",
+			want:  map[string]string{"a": "b", "c": "d"},
+		},
+		{
+			name:  "duplicated input",
+			input: "a=b,a=b",
+			want:  map[string]string{"a": "b"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			strsl := goflags.StringSlice{}
+			for _, v := range strings.Split(tt.input, ",") {
+				strsl.Set(v)
+			}
+			opt := Options{HeadlessOptionalArguments: strsl}
+			got := opt.ParseHeadlessOptionalArguments()
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Context: #131.
#### ⚠️⚠️I know the tests I have just added are failing, I would like to know if accepting custom headers with empty key or empty value is an intended implementation.⚠️⚠️

```
sudo /home/edoardottt/go/bin/katana -hl -u http://edoardottt.com
[sudo] password for edoardottt: 

   __        __                
  / /_____ _/ /____ ____  ___ _
 /  '_/ _  / __/ _  / _ \/ _  /
/_/\_\\_,_/\__/\_,_/_//_/\_,_/ v0.0.1							 

		projectdiscovery.io

[WRN] Use with caution. You are responsible for your actions.
[WRN] Developers assume no liability and are not responsible for any misuse or damage.
[FTL] could not create runner: could not create standard crawler: [launcher] Failed to get the debug url: [1107/180405.382126:ERROR:zygote_host_impl_linux.cc(90)] Running as root without --no-sandbox is not supported. See https://crbug.com/638180.
```

This PR adds two flags as suggested:
```
   -hoa, -headless-optional-arguments string[]  pass optional arguments to chrome
   -hns, -headless-no-sandbox                   start chrome in --no-sandbox mode
```
I don't know actually if this is the best solution possible, `-hns` seems redundant when `-hoa` is present. Another solution could be try to detect if the user has sudo privileges (only on Linux?).

However, now it seems to work well with both two new flags:

### Using -hoa
```
sudo ./cmd/katana/katana -hl -hoa no-sandbox=true -u http://edoardottt.com

   __        __                
  / /_____ _/ /____ ____  ___ _
 /  '_/ _  / __/ _  / _ \/ _  /
/_/\_\\_,_/\__/\_,_/_//_/\_,_/ v0.0.1							 

		projectdiscovery.io

[WRN] Use with caution. You are responsible for your actions.
[WRN] Developers assume no liability and are not responsible for any misuse or damage.
http://edoardottt.com/blog.html
http://edoardottt.com/cve.html
http://edoardottt.com/aboutme.html
http://edoardottt.com/cv.html
```

### Using -hns
```
sudo ./cmd/katana/katana -hl -hns -u http://edoardottt.com

   __        __                
  / /_____ _/ /____ ____  ___ _
 /  '_/ _  / __/ _  / _ \/ _  /
/_/\_\\_,_/\__/\_,_/_//_/\_,_/ v0.0.1							 

		projectdiscovery.io

[WRN] Use with caution. You are responsible for your actions.
[WRN] Developers assume no liability and are not responsible for any misuse or damage.
http://edoardottt.com/blog.html
http://edoardottt.com/cve.html
http://edoardottt.com/aboutme.html
http://edoardottt.com/cv.html
```

Moreover, I have added some tests in order to check errors in the new function `ParseHeadlessOptionalArguments()` and the function `ParseCustomHeaders()`. 

This PR closes #131.