### PR TITLE
Do not return error message in case of returning version

### DIFF
--- a/cmd/katana/main.go
+++ b/cmd/katana/main.go
@@ -27,7 +27,11 @@ func main() {
 
 	runner, err := runner.New(options)
 	if err != nil || runner == nil {
-		gologger.Fatal().Msgf("could not create runner: %s\n", err)
+		if options.Version {
+			return
+		} else {
+			gologger.Fatal().Msgf("could not create runner: %s\n", err)
+		}
 	}
 	defer runner.Close()
 


### PR DESCRIPTION
Closes #137

This will add a check to `main.go` if the version option is set to not return a fatal error message in that case.