### PR TITLE
Fixes #166

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,4 @@
+# Security Policy
+
+## Reporting a Vulnerability
+DO NOT CREATE AN ISSUE to report a security problem. Instead, please send an email to security@projectdiscovery.io, and we will acknowledge it within 3 working days.

--- a/pkg/engine/hybrid/hybrid.go
+++ b/pkg/engine/hybrid/hybrid.go
@@ -81,9 +81,8 @@ func New(options *types.CrawlerOptions) (*Crawler, error) {
 		chromeLauncher.Set("no-sandbox", "true")
 	}
 
-	var proxyURL *url.URL
 	if options.Options.Proxy != "" && options.Options.Headless {
-		proxyURL, err = url.Parse(options.Options.Proxy)
+		proxyURL, err := url.Parse(options.Options.Proxy)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/engine/hybrid/hybrid.go
+++ b/pkg/engine/hybrid/hybrid.go
@@ -80,15 +80,15 @@ func New(options *types.CrawlerOptions) (*Crawler, error) {
 	if options.Options.HeadlessNoSandbox {
 		chromeLauncher.Set("no-sandbox", "true")
 	}
-
-	for k, v := range options.Options.ParseHeadlessOptionalArguments() {
-		chromeLauncher.Set(flags.Flag(k), v)
-	}
-
+	
 	var proxyURL *url.URL
 	if (options.Options.Proxy != "" && options.Options.Headless == true ) {
 		proxyURL, err = url.Parse(options.Options.Proxy)
 		chromeLauncher.Set("proxy-server", proxyURL.String())
+	}
+
+	for k, v := range options.Options.ParseHeadlessOptionalArguments() {
+		chromeLauncher.Set(flags.Flag(k), v)
 	}
 	
 	if err != nil {

--- a/pkg/engine/hybrid/hybrid.go
+++ b/pkg/engine/hybrid/hybrid.go
@@ -85,6 +85,16 @@ func New(options *types.CrawlerOptions) (*Crawler, error) {
 		chromeLauncher.Set(flags.Flag(k), v)
 	}
 
+	var proxyURL *url.URL
+	if (options.Options.Proxy != "" && options.Options.Headless == true ) {
+		proxyURL, err = url.Parse(options.Options.Proxy)
+		chromeLauncher.Set("proxy-server", proxyURL.String())
+	}
+	
+	if err != nil {
+		return nil, err
+	}
+	
 	launcherURL, err := chromeLauncher.Launch()
 	if err != nil {
 		return nil, err

--- a/pkg/engine/hybrid/hybrid.go
+++ b/pkg/engine/hybrid/hybrid.go
@@ -86,14 +86,15 @@ func New(options *types.CrawlerOptions) (*Crawler, error) {
 		proxyURL, err = url.Parse(options.Options.Proxy)
 		chromeLauncher.Set("proxy-server", proxyURL.String())
 	}
+	
+	if err != nil {
+		return nil, err
+	}
 
 	for k, v := range options.Options.ParseHeadlessOptionalArguments() {
 		chromeLauncher.Set(flags.Flag(k), v)
 	}
 	
-	if err != nil {
-		return nil, err
-	}
 	
 	launcherURL, err := chromeLauncher.Launch()
 	if err != nil {

--- a/pkg/engine/hybrid/hybrid.go
+++ b/pkg/engine/hybrid/hybrid.go
@@ -80,22 +80,20 @@ func New(options *types.CrawlerOptions) (*Crawler, error) {
 	if options.Options.HeadlessNoSandbox {
 		chromeLauncher.Set("no-sandbox", "true")
 	}
-	
+
 	var proxyURL *url.URL
-	if (options.Options.Proxy != "" && options.Options.Headless == true ) {
+	if options.Options.Proxy != "" && options.Options.Headless {
 		proxyURL, err = url.Parse(options.Options.Proxy)
+		if err != nil {
+			return nil, err
+		}
 		chromeLauncher.Set("proxy-server", proxyURL.String())
-	}
-	
-	if err != nil {
-		return nil, err
 	}
 
 	for k, v := range options.Options.ParseHeadlessOptionalArguments() {
 		chromeLauncher.Set(flags.Flag(k), v)
 	}
-	
-	
+
 	launcherURL, err := chromeLauncher.Launch()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes #166 
Automatically pass proxy-server argument to chromium when both `-hl` and `-proxy` are set