### PR TITLE
Add katana as lib

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,7 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     target-branch: "dev"
     commit-message:
       prefix: "chore"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ matrix.os }}
+          go-version: ${{ matrix.go-version }}
 
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
-
+        os: [ubuntu-latest, windows-latest, macOS-12]
+        go-version: [1.18.x, 1.19.x]
     steps:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: ${{ matrix.os }}
 
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -31,6 +31,12 @@ jobs:
         run: go build .
         working-directory: cmd/katana/
 
+      - name: Integration Tests
+        env:
+          GH_ACTION: true
+        run: bash run.sh
+        working-directory: integration_tests/
+
       - name: Install
         run: go install
         working-directory: cmd/katana/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+# Go parameters
+GOCMD=go
+GOBUILD=$(GOCMD) build
+GOMOD=$(GOCMD) mod
+GOTEST=$(GOCMD) test
+GOFLAGS := -v
+# This should be disabled if the binary uses pprof
+LDFLAGS := -s -w
+
+ifneq ($(shell go env GOOS),darwin)
+LDFLAGS := -extldflags "-static"
+endif
+
+all: build
+build:
+	$(GOBUILD) $(GOFLAGS) -ldflags '$(LDFLAGS)' -o "katana" cmd/katana/main.go
+test:
+	$(GOTEST) $(GOFLAGS) ./...
+integration:
+	cd integration_tests; bash run.sh cd ..
+tidy:
+	$(GOMOD) tidy

--- a/README.md
+++ b/README.md
@@ -677,12 +677,12 @@ func main() {
 	if err != nil {
 		gologger.Fatal().Msg(err.Error())
 	}
-   defer crawlerOptions.Close()
+	defer crawlerOptions.Close()
 	crawler, err := standard.New(crawlerOptions)
 	if err != nil {
 		gologger.Fatal().Msg(err.Error())
 	}
-   defer crawler.Close()
+	defer crawler.Close()
 	var input = "https://tesla.com"
 	err = crawler.Crawl(input)
 	if err != nil {

--- a/README.md
+++ b/README.md
@@ -659,6 +659,7 @@ package main
 import (
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/katana/pkg/engine/standard"
+	"github.com/projectdiscovery/katana/pkg/output"
 	"github.com/projectdiscovery/katana/pkg/types"
 )
 
@@ -668,6 +669,9 @@ func main() {
 		FieldScope:   "rdn",           // Crawling Scope Field
 		BodyReadSize: 2 * 1024 * 1024, // Maximum response size to read
 		RateLimit:    150,             // Maximum requests to send per second
+		OnResult: func(result output.Result) { // Callback function to execute for result
+			gologger.Info().Msg(result.URL)
+		},
 	}
 	crawlerOptions, err := types.NewCrawlerOptions(options)
 	if err != nil {

--- a/README.md
+++ b/README.md
@@ -677,10 +677,12 @@ func main() {
 	if err != nil {
 		gologger.Fatal().Msg(err.Error())
 	}
+   defer crawlerOptions.Close()
 	crawler, err := standard.New(crawlerOptions)
 	if err != nil {
 		gologger.Fatal().Msg(err.Error())
 	}
+   defer crawler.Close()
 	var input = "https://tesla.com"
 	err = crawler.Crawl(input)
 	if err != nil {

--- a/README.md
+++ b/README.md
@@ -649,6 +649,41 @@ OUTPUT:
    -version  
 ```
 
+## Katana as a library
+`katana` can be used as a library by creating an instance of the `Option` struct and populating it with the same options that would be specified via CLI. Using the options you can create `crawlerOptions` and so standard or hybrid `crawler`.
+`crawler.Crawl` method should be called to crawl the input.
+
+```
+package main
+
+import (
+	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/katana/pkg/engine/standard"
+	"github.com/projectdiscovery/katana/pkg/types"
+)
+
+func main() {
+	options := &types.Options{
+		MaxDepth:     1,               // Maximum depth to crawl
+		FieldScope:   "rdn",           // Crawling Scope Field
+		BodyReadSize: 2 * 1024 * 1024, // Maximum response size to read
+		RateLimit:    150,             // Maximum requests to send per second
+	}
+	crawlerOptions, err := types.NewCrawlerOptions(options)
+	if err != nil {
+		gologger.Fatal().Msg(err.Error())
+	}
+	crawler, err := standard.New(crawlerOptions)
+	if err != nil {
+		gologger.Fatal().Msg(err.Error())
+	}
+	var input = "https://tesla.com"
+	err = crawler.Crawl(input)
+	if err != nil {
+		gologger.Warning().Msgf("Could not crawl %s: %s", input, err.Error())
+	}
+}
+```
 --------
 
 <div align="center">

--- a/cmd/integration-test/integration-test.go
+++ b/cmd/integration-test/integration-test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/logrusorgru/aurora"
+)
+
+type TestCase interface {
+	// Execute executes a test case and returns any errors if occurred
+	Execute() error
+}
+
+var (
+	debug      = os.Getenv("DEBUG") == "true"
+	customTest = os.Getenv("TEST")
+
+	errored = false
+	success = aurora.Green("[✓]").String()
+	failed  = aurora.Red("[✘]").String()
+
+	tests = map[string]map[string]TestCase{
+		"code": libraryTestcases,
+	}
+)
+
+func main() {
+	for name, tests := range tests {
+		fmt.Printf("Running test cases for \"%s\"\n", aurora.Blue(name))
+		if customTest != "" && !strings.Contains(name, customTest) {
+			continue // only run tests user asked
+		}
+		for name, test := range tests {
+			err := test.Execute()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "%s Test \"%s\" failed: %s\n", failed, name, err)
+				errored = true
+			} else {
+				fmt.Printf("%s Test \"%s\" passed!\n", success, name)
+			}
+		}
+	}
+	if errored {
+		os.Exit(1)
+	}
+}

--- a/cmd/integration-test/library.go
+++ b/cmd/integration-test/library.go
@@ -31,6 +31,6 @@ func (h *goIntegrationTest) Execute() error {
 		return err
 	}
 	defer crawler.Close()
-	var input = "https://tesla.com"
+	var input = "https://public-firing-range.appspot.com"
 	return crawler.Crawl(input)
 }

--- a/cmd/integration-test/library.go
+++ b/cmd/integration-test/library.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"github.com/projectdiscovery/katana/pkg/engine/standard"
+	"github.com/projectdiscovery/katana/pkg/types"
+)
+
+var libraryTestcases = map[string]TestCase{
+	"katana as library": &goIntegrationTest{},
+}
+
+type goIntegrationTest struct{}
+
+// Execute executes a test case and returns an error if occurred
+// Execute the docs at ../README.md if the code stops working for integration.
+func (h *goIntegrationTest) Execute() error {
+	options := &types.Options{
+		MaxDepth:     1,
+		FieldScope:   "rdn",
+		BodyReadSize: 2 * 1024 * 1024,
+		RateLimit:    150,
+		Verbose:      debug,
+	}
+	crawlerOptions, err := types.NewCrawlerOptions(options)
+	if err != nil {
+		return err
+	}
+	defer crawlerOptions.Close()
+	crawler, err := standard.New(crawlerOptions)
+	if err != nil {
+		return err
+	}
+	defer crawler.Close()
+	var input = "https://tesla.com"
+	return crawler.Crawl(input)
+}

--- a/integration_tests/run.sh
+++ b/integration_tests/run.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+echo "::group::Build katana"
+rm integration-test katana 2>/dev/null
+cd ../cmd/katana
+go build
+mv katana ../../integration_tests/katana
+echo "::endgroup::"
+
+echo "::group::Build katana integration-test"
+cd ../integration-test
+go build
+mv integration-test ../../integration_tests/integration-test
+cd ../../integration_tests
+echo "::endgroup::"
+
+./integration-test
+if [ $? -eq 0 ]
+then
+  exit 0
+else
+  exit 1
+fi

--- a/pkg/engine/hybrid/hybrid.go
+++ b/pkg/engine/hybrid/hybrid.go
@@ -256,7 +256,9 @@ func (c *Crawler) makeParseResponseCallback(queue *queue.VarietyQueue) func(nr n
 		if scopeValidated || c.options.Options.DisplayOutScope {
 			_ = c.options.OutputWriter.Write(result)
 		}
-
+		if c.options.Options.OnResult != nil {
+			c.options.Options.OnResult(*result)
+		}
 		// Do not add to crawl queue if max items are reached
 		if nr.Depth >= c.options.Options.MaxDepth || !scopeValidated {
 			return

--- a/pkg/engine/standard/standard.go
+++ b/pkg/engine/standard/standard.go
@@ -166,7 +166,9 @@ func (c *Crawler) makeParseResponseCallback(queue *queue.VarietyQueue) func(nr n
 		if scopeValidated || c.options.Options.DisplayOutScope {
 			_ = c.options.OutputWriter.Write(result)
 		}
-
+		if c.options.Options.OnResult != nil {
+			c.options.Options.OnResult(*result)
+		}
 		// Do not add to crawl queue if max items are reached
 		if nr.Depth >= c.options.Options.MaxDepth || !scopeValidated {
 			return

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -4,7 +4,11 @@ import (
 	"strings"
 
 	"github.com/projectdiscovery/goflags"
+	"github.com/projectdiscovery/katana/pkg/output"
 )
+
+// OnResultCallback (output.Result)
+type OnResultCallback func(output.Result)
 
 type Options struct {
 	// URLs contains a list of URLs for crawling
@@ -83,6 +87,8 @@ type Options struct {
 	HeadlessOptionalArguments goflags.StringSlice
 	// HeadlessNoSandbox specifies if chrome should be start in --no-sandbox mode
 	HeadlessNoSandbox bool
+	// OnResult allows callback function on a result
+	OnResult OnResultCallback
 }
 
 func (options *Options) ParseCustomHeaders() map[string]string {


### PR DESCRIPTION
This PR adds

- [x] callback function for result found
- [x] katana as library example 
- [x] integration tests for library code

```go
package main

import (
	"github.com/projectdiscovery/gologger"
	"github.com/projectdiscovery/katana/pkg/engine/standard"
	"github.com/projectdiscovery/katana/pkg/output"
	"github.com/projectdiscovery/katana/pkg/types"
)

func main() {
	options := &types.Options{
		MaxDepth:     1,               // Maximum depth to crawl
		FieldScope:   "rdn",           // Crawling Scope Field
		BodyReadSize: 2 * 1024 * 1024, // Maximum response size to read
		RateLimit:    150,             // Maximum requests to send per second
		OnResult: func(result output.Result) { // Callback function to execute for result
			gologger.Info().Msg(result.URL)
		},
	}
	crawlerOptions, err := types.NewCrawlerOptions(options)
	if err != nil {
		gologger.Fatal().Msg(err.Error())
	}
	crawler, err := standard.New(crawlerOptions)
	if err != nil {
		gologger.Fatal().Msg(err.Error())
	}
	var input = "https://tesla.com"
	err = crawler.Crawl(input)
	if err != nil {
		gologger.Warning().Msgf("Could not crawl %s: %s", input, err.Error())
	}
}
```