### PR TITLE
Update regex.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,7 +653,7 @@ OUTPUT:
 
 <div align="center">
 
-katana is made with ❤️ by the [projectdiscovery](https://projectdiscovery.io) team and distributed under [MIT License](LICENSE).
+katana is made with ❤️ by the [projectdiscovery](https://projectdiscovery.io) team and distributed under [MIT License](LICENSE.md).
 
 
 <a href="https://discord.gg/projectdiscovery"><img src="https://raw.githubusercontent.com/projectdiscovery/nuclei-burp-plugin/main/static/join-discord.png" width="300" alt="Join Discord"></a>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,4 @@
+# Security Policy
+
+## Reporting a Vulnerability
+DO NOT CREATE AN ISSUE to report a security problem. Instead, please send an email to security@projectdiscovery.io, and we will acknowledge it within 3 working days.

--- a/pkg/utils/regex.go
+++ b/pkg/utils/regex.go
@@ -7,11 +7,11 @@ import (
 var (
 	// pageBodyRegex extracts endpoints from page body
 	pageBodyRegex = regexp.MustCompile(
-		`((?:(?:[\.]{1,2}/[A-Za-z0-9-_/\\?&@\.?=]+)|https?:\/\/[A-Za-z0-9_\-\.]+(?:[\.]{0,2})?\/[A-Za-z0-9-_/\\?&@\.?=]+|(?:/[A-Za-z0-9-_/\\?&@\.]+\.(?:aspx?|action|cfm|cgi|do|pl|css|x?html?|js(?:p|on)?|pdf|php5?|py|rss))))`,
+		`((?:(?:[\.]{1,2}/[A-Za-z0-9-_/\\?&@\.?=]+)|https?://[A-Za-z0-9_\-\.]+([\.]{0,2})?\/[A-Za-z0-9-_/\\?&@\.?=]+|(/[A-Za-z0-9-_/\\?&@\.]+\.(aspx?|action|cfm|cgi|do|pl|css|x?html?|js(p|on)?|pdf|php5?|py|rss))))`,
 	)
 	// relativeEndpointsRegex is the regex to find endpoints in js files.
 	relativeEndpointsRegex = regexp.MustCompile(
-		`(?:"|'| )((?:(?:(?:https?:\/\/[A-Za-z0-9_\-\.]+)+(?:[\.]{0,2})?\/[A-Za-z0-9\/\-_\.]+)|[A-Za-z0-9\-_\/]+\.(?:aspx?|js(?:on|p)?|html|php5?|html|action|do)(?:[\?|#][^"|']+)?))(?:"|'| )`,
+		`(?:"|'|\s)(((https?://[A-Za-z0-9_\-\.]+(:\d{1,5})?)+([\.]{1,2})?/[A-Za-z0-9/\-_\.\\]+([\?|#][^"']+)?)|((\.{1,2}/)?[a-zA-Z0-9\-_/\\]+\.(aspx?|js(on|p)?|html|php5?|html|action|do)([\?|#][^"']+)?)|((\.{0,2}/)[a-zA-Z0-9\-_/\\]+(/|\\)[a-zA-Z0-9\-_]{3,}([\?|#][^"|']+)?))(?:"|'|\s)`,
 	)
 )
 
@@ -47,6 +47,7 @@ func ExtractRelativeEndpoints(data string) []string {
 		if _, ok := unique[match[1]]; ok {
 			continue
 		}
+
 		unique[match[1]] = struct{}{}
 		matches = append(matches, match[1])
 	}

--- a/pkg/utils/regex.go
+++ b/pkg/utils/regex.go
@@ -7,11 +7,11 @@ import (
 var (
 	// pageBodyRegex extracts endpoints from page body
 	pageBodyRegex = regexp.MustCompile(
-		`((?:(?:[\.]{1,2}/[A-Za-z0-9-_/\\?&@\.?=]+)|https?://[A-Za-z0-9_\-\.]+([\.]{0,2})?\/[A-Za-z0-9-_/\\?&@\.?=]+|(/[A-Za-z0-9-_/\\?&@\.]+\.(aspx?|action|cfm|cgi|do|pl|css|x?html?|js(p|on)?|pdf|php5?|py|rss))))`,
+		`((?:(?:[\.]{1,2}/[A-Za-z0-9-_/\\?&@\.?=%]+)|https?://[A-Za-z0-9_\-\.]+([\.]{0,2})?\/[A-Za-z0-9-_/\\?&@\.?=%]+|(/[A-Za-z0-9-_/\\?&@\.%]+\.(aspx?|action|cfm|cgi|do|pl|css|x?html?|js(p|on)?|pdf|php5?|py|rss))))`,
 	)
 	// relativeEndpointsRegex is the regex to find endpoints in js files.
 	relativeEndpointsRegex = regexp.MustCompile(
-		`(?:"|'|\s)(((https?://[A-Za-z0-9_\-\.]+(:\d{1,5})?)+([\.]{1,2})?/[A-Za-z0-9/\-_\.\\]+([\?|#][^"']+)?)|((\.{1,2}/)?[a-zA-Z0-9\-_/\\]+\.(aspx?|js(on|p)?|html|php5?|html|action|do)([\?|#][^"']+)?)|((\.{0,2}/)[a-zA-Z0-9\-_/\\]+(/|\\)[a-zA-Z0-9\-_]{3,}([\?|#][^"|']+)?))(?:"|'|\s)`,
+		`(?:"|'|\s)(((https?://[A-Za-z0-9_\-\.]+(:\d{1,5})?)+([\.]{1,2})?/[A-Za-z0-9/\-_\.\\%]+([\?|#][^"']+)?)|((\.{1,2}/)?[a-zA-Z0-9\-_/\\%]+\.(aspx?|js(on|p)?|html|php5?|html|action|do)([\?|#][^"']+)?)|((\.{0,2}/)[a-zA-Z0-9\-_/\\%]+(/|\\)[a-zA-Z0-9\-_]{3,}([\?|#][^"|']+)?))(?:"|'|\s)`,
 	)
 )
 

--- a/pkg/utils/regex.go
+++ b/pkg/utils/regex.go
@@ -5,14 +5,26 @@ import (
 )
 
 var (
+	BodyA0 = `(?:`
+	BodyB0 = `(`
+	BodyC0 = `(?:[\.]{1,2}/[A-Za-z0-9-_/\\?&@\.?=%]+)`
+	BodyC1 = `|(https?://[A-Za-z0-9_\-\.]+([\.]{0,2})?\/[A-Za-z0-9-_/\\?&@\.?=%]+)`
+	BodyC2 = `|(/[A-Za-z0-9-_/\\?&@\.%]+\.(aspx?|action|cfm|cgi|do|pl|css|x?html?|js(p|on)?|pdf|php5?|py|rss))`
+	BodyB1 = `)`
+	BodyA1 = `)`
 	// pageBodyRegex extracts endpoints from page body
-	pageBodyRegex = regexp.MustCompile(
-		`((?:(?:[\.]{1,2}/[A-Za-z0-9-_/\\?&@\.?=%]+)|https?://[A-Za-z0-9_\-\.]+([\.]{0,2})?\/[A-Za-z0-9-_/\\?&@\.?=%]+|(/[A-Za-z0-9-_/\\?&@\.%]+\.(aspx?|action|cfm|cgi|do|pl|css|x?html?|js(p|on)?|pdf|php5?|py|rss))))`,
-	)
+	pageBodyRegex = regexp.MustCompile(BodyA0 + BodyB0 + BodyC0 + BodyC1 + BodyC2 + BodyB1 + BodyA1)
+
+	JsA0 = `(?:"|'|\s)`
+	JsB0 = `(`
+	JsC0 = `((https?://[A-Za-z0-9_\-\.]+(:\d{1,5})?)+([\.]{1,2})?/[A-Za-z0-9/\-_\.\\%]+([\?|#][^"']+)?)`
+	JsC1 = `|((\.{1,2}/)?[a-zA-Z0-9\-_/\\%]+\.(aspx?|js(on|p)?|html|php5?|html|action|do)([\?|#][^"']+)?)`
+	JsC2 = `|((\.{0,2}/)[a-zA-Z0-9\-_/\\%]+(/|\\)[a-zA-Z0-9\-_]{3,}([\?|#][^"|']+)?)`
+	JsC3 = `|((\.{0,2})[a-zA-Z0-9\-_/\\%]{3,}/)`
+	JsB1 = `)`
+	JsA1 = `(?:"|'|\s)`
 	// relativeEndpointsRegex is the regex to find endpoints in js files.
-	relativeEndpointsRegex = regexp.MustCompile(
-		`(?:"|'|\s)(((https?://[A-Za-z0-9_\-\.]+(:\d{1,5})?)+([\.]{1,2})?/[A-Za-z0-9/\-_\.\\%]+([\?|#][^"']+)?)|((\.{1,2}/)?[a-zA-Z0-9\-_/\\%]+\.(aspx?|js(on|p)?|html|php5?|html|action|do)([\?|#][^"']+)?)|((\.{0,2}/)[a-zA-Z0-9\-_/\\%]+(/|\\)[a-zA-Z0-9\-_]{3,}([\?|#][^"|']+)?))(?:"|'|\s)`,
-	)
+	relativeEndpointsRegex = regexp.MustCompile(JsA0 + JsB0 + JsC0 + JsC1 + JsC2 + JsC3 + JsB1 + JsA1)
 )
 
 // ExtractBodyEndpoints extracts body endpoints from a data item


### PR DESCRIPTION
### Increase crawling content by optimizing regular expressions
katana-main/katana-main/pkg/utils/regex.go   Connections in web pages are extracted by regular expressions
It's implemented by **pageBodyRegex** or **relativeEndpointsRegex**
But you will miss some endpoints 
### for example
http://www.google.com:8080
https://www.google.com/images/%E4%BA%A7%E5%93%81%E4%B8%AD%E5%BF%83/
/1.php

Then the following regular expressions will help you

        ((?:"|'|\s)                              # Start newline delimiter
      (
        ((?:[a-zA-Z]{1,10}://|//)           # Match a scheme [a-Z]*1-10 or //
        [^"'/]{1,}\.                        # Match a domainname (any character + dot)
        [a-zA-Z]{2,}[^"']{0,})              # The domainextension and/or path
        |
        ((?:/|\.\./|\./)                    # Start with /,../,./
        [^"'><,;| *()(%%$^/\\\[\]]          # Next character can't be...
        [^"'><,;|()]{1,})                   # Rest of the characters can't be
        |
        ([a-zA-Z0-9_\-/]{1,}/               # Relative endpoint with /
        [a-zA-Z0-9_\-/\.]{1,}                 # Resource name
        \.(?:[a-zA-Z]{1,4}|action)          # Rest + extension (length 1-4 or action)
        (?:[\?|#][^"|']{0,}|))              # ? mark with parameters
        |
        ([a-zA-Z0-9_\-/]{1,}/
        [a-zA-Z0-9_\-/]{3,}
        (?:[\?|#][^"|']{0,}|))
        |
        ([a-zA-Z0-9_\-\.]{1,}                 # filename
        \.(?:php|asp|aspx|jsp|json|
             action|html|js|txt|xml|do)             # . + extension
        (?:[\?|#][^"|']{0,}|))                  # ? mark with parameters
      )
      (?:"|'|\s)

[reference linking:  https://github.com/yuzhe-Mortal/tool/blob/main/Reptile.py](https://github.com/yuzhe-Mortal/tool/blob/main/Reptile.py)


