### PR TITLE
Adding support for error logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ CONFIGURATION:
    -config string                path to the katana configuration file
    -fc, -form-config string      path to custom form configuration file
 
+DEBUG:
+   -health-check, -hc        run diagnostic check up
+   -elog, -error-log string  file to write sent requests error log
+
 HEADLESS:
    -hl, -headless                   enable headless hybrid crawling (experimental)
    -sc, -system-chrome              use local installed chrome browser instead of katana installed

--- a/cmd/katana/main.go
+++ b/cmd/katana/main.go
@@ -86,6 +86,7 @@ pipelines offering both headless and non-headless crawling.`)
 
 	flagSet.CreateGroup("debug", "Debug",
 		flagSet.BoolVarP(&options.HealthCheck, "hc", "health-check", false, "run diagnostic check up"),
+		flagSet.StringVarP(&options.ErrorLogFile, "error-log", "elog", "", "file to write sent requests error log"),
 	)
 
 	flagSet.CreateGroup("headless", "Headless",

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -2,8 +2,6 @@ package runner
 
 import (
 	"bufio"
-	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,6 +13,7 @@ import (
 	"github.com/projectdiscovery/katana/pkg/types"
 	"github.com/projectdiscovery/katana/pkg/utils"
 	fileutil "github.com/projectdiscovery/utils/file"
+	logutil "github.com/projectdiscovery/utils/log"
 	"gopkg.in/yaml.v3"
 )
 
@@ -101,9 +100,8 @@ func configureOutput(options *types.Options) {
 	if options.Verbose {
 		gologger.DefaultLogger.SetMaxLevel(levels.LevelVerbose)
 	}
-	// disable standard logger (ref: https://github.com/golang/go/issues/19895)
-	log.SetFlags(0)
-	log.SetOutput(io.Discard)
+
+	logutil.DisableDefaultLogger()
 }
 
 func initExampleFormFillConfig() error {

--- a/pkg/engine/standard/standard.go
+++ b/pkg/engine/standard/standard.go
@@ -119,6 +119,13 @@ func (c *Crawler) Crawl(rootURL string) error {
 			resp, err := c.makeRequest(ctx, req, hostname, req.Depth, httpclient)
 			if err != nil {
 				gologger.Warning().Msgf("Could not request seed URL: %s\n", err)
+				outputError := &output.Error{
+					Timestamp: time.Now(),
+					Endpoint:  req.RequestURL(),
+					Source:    req.Source,
+					Error:     err.Error(),
+				}
+				_ = c.options.OutputWriter.WriteErr(outputError)
 				return
 			}
 			if resp.Resp == nil || resp.Reader == nil {

--- a/pkg/output/error.go
+++ b/pkg/output/error.go
@@ -1,0 +1,10 @@
+package output
+
+import "time"
+
+type Error struct {
+	Timestamp time.Time `json:"timestamp,omitempty"`
+	Endpoint  string    `json:"endpoint,omitempty"`
+	Source    string    `json:"source,omitempty"`
+	Error     string    `json:"error,omitempty"`
+}

--- a/pkg/output/options.go
+++ b/pkg/output/options.go
@@ -1,0 +1,15 @@
+package output
+
+// Options contains the configuration options for output writer
+type Options struct {
+	Colors           bool
+	JSON             bool
+	Verbose          bool
+	StoreResponse    bool
+	OutputFile       string
+	Fields           string
+	StoreFields      string
+	StoreResponseDir string
+	FieldConfig      string
+	ErrorLogFile     string
+}

--- a/pkg/output/result.go
+++ b/pkg/output/result.go
@@ -1,0 +1,23 @@
+package output
+
+import "time"
+
+// Result is a result structure for the crawler
+type Result struct {
+	// Timestamp is the current timestamp
+	Timestamp time.Time `json:"timestamp,omitempty"`
+	// Method is the method for the result
+	Method string `json:"method,omitempty"`
+	// Body contains the body for the request
+	Body string `json:"body,omitempty"`
+	// URL is the URL of the result
+	URL string `json:"endpoint,omitempty"`
+	// Source is the source for the result
+	Source string `json:"source,omitempty"`
+	// Tag is the tag for the result
+	Tag string `json:"tag,omitempty"`
+	// Attribute is the attribute for the result
+	Attribute string `json:"attribute,omitempty"`
+	// customField matched output
+	CustomFields map[string][]string `json:"-"`
+}

--- a/pkg/types/crawler_options.go
+++ b/pkg/types/crawler_options.go
@@ -49,7 +49,19 @@ func NewCrawlerOptions(options *Options) (*CrawlerOptions, error) {
 		return nil, errors.Wrap(err, "could not create filter")
 	}
 
-	outputWriter, err := output.New(!options.NoColors, options.JSON, options.Verbose, options.StoreResponse, options.OutputFile, options.Fields, options.StoreFields, options.StoreResponseDir, options.FieldConfig)
+	outputOptions := output.Options{
+		Colors:           !options.NoColors,
+		JSON:             options.JSON,
+		Verbose:          options.Verbose,
+		StoreResponse:    options.StoreResponse,
+		OutputFile:       options.OutputFile,
+		Fields:           options.Fields,
+		StoreFields:      options.StoreFields,
+		StoreResponseDir: options.StoreResponseDir,
+		FieldConfig:      options.FieldConfig,
+		ErrorLogFile:     options.ErrorLogFile,
+	}
+	outputWriter, err := output.New(outputOptions)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create output writer")
 	}

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -101,6 +101,8 @@ type Options struct {
 	HeadlessNoIncognito bool
 	// HealthCheck determines if a self-healthcheck should be performed
 	HealthCheck bool
+	// ErrorLogFile specifies a file to write with the errors of all requests
+	ErrorLogFile string
 }
 
 func (options *Options) ParseCustomHeaders() map[string]string {


### PR DESCRIPTION
## Example
```console
$ echo http://abcd | go run . -elog errors -v
$ cat errors
{"timestamp":"2023-01-10T00:16:14.318912+01:00","endpoint":"http://abcd","error":"GET http://abcd giving up after 2 attempts: Get \"http://abcd\": no address found for host"}
```

Closes #211 