### PR TITLE
improved logging

### DIFF
--- a/cmd/katana/main.go
+++ b/cmd/katana/main.go
@@ -7,12 +7,12 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/pkg/errors"
 	"github.com/projectdiscovery/goflags"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/katana/internal/runner"
 	"github.com/projectdiscovery/katana/pkg/output"
 	"github.com/projectdiscovery/katana/pkg/types"
+	errorutil "github.com/projectdiscovery/utils/errors"
 )
 
 var (
@@ -136,13 +136,20 @@ pipelines offering both headless and non-headless crawling.`)
 	)
 
 	if err := flagSet.Parse(); err != nil {
-		return nil, errors.Wrap(err, "could not parse flags")
+		return nil, errorutil.NewWithErr(err).Msgf("could not parse flags")
 	}
 
 	if cfgFile != "" {
 		if err := flagSet.MergeConfigFile(cfgFile); err != nil {
-			return nil, errors.Wrap(err, "could not read config file")
+			return nil, errorutil.NewWithErr(err).Msgf("could not read config file")
 		}
 	}
 	return flagSet, nil
+}
+
+func init() {
+	// show detailed stacktrace in debug mode
+	if os.Getenv("DEBUG") != "" {
+		errorutil.ShowStackTrace = true
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -8,14 +8,13 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/lukasbob/srcset v0.0.0-20190730101422-86b742e617f3
-	github.com/pkg/errors v0.9.1
 	github.com/projectdiscovery/fastdialer v0.0.21
 	github.com/projectdiscovery/goflags v0.1.6
 	github.com/projectdiscovery/gologger v1.1.7
 	github.com/projectdiscovery/hmap v0.0.2-0.20210917080408-0fd7bd286bfa
 	github.com/projectdiscovery/ratelimit v0.0.4
 	github.com/projectdiscovery/retryablehttp-go v1.0.8
-	github.com/projectdiscovery/utils v0.0.4-0.20221222195055-f7d250fc55af
+	github.com/projectdiscovery/utils v0.0.4
 	github.com/remeh/sizedwaitgroup v1.0.0
 	github.com/rs/xid v1.4.0
 	github.com/shirou/gopsutil/v3 v3.22.12
@@ -24,6 +23,8 @@ require (
 	golang.org/x/net v0.5.0
 	gopkg.in/yaml.v3 v3.0.1
 )
+
+require github.com/pkg/errors v0.9.1 // indirect
 
 require (
 	github.com/Mzack9999/go-http-digest-auth-client v0.6.1-0.20220414142836-eb8883508809 // indirect
@@ -53,7 +54,7 @@ require (
 	github.com/projectdiscovery/networkpolicy v0.0.3 // indirect
 	github.com/projectdiscovery/retryabledns v1.0.19 // indirect
 	github.com/projectdiscovery/sliceutil v0.0.1
-	github.com/projectdiscovery/stringsutil v0.0.2
+	github.com/projectdiscovery/stringsutil v0.0.2 // indirect
 	github.com/saintfish/chardet v0.0.0-20120816061221-3af4cd4741ca // indirect
 	github.com/syndtr/goleveldb v1.0.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,8 @@ github.com/projectdiscovery/sliceutil v0.0.1 h1:YoCqCMcdwz+gqNfW5hFY8UvNHoA6SfyB
 github.com/projectdiscovery/sliceutil v0.0.1/go.mod h1:0wBmhU5uTDwMfrEZfvwH9qa5k60Q4shPVOC9E6LGsDI=
 github.com/projectdiscovery/stringsutil v0.0.2 h1:uzmw3IVLJSMW1kEg8eCStG/cGbYYZAja8BH3LqqJXMA=
 github.com/projectdiscovery/stringsutil v0.0.2/go.mod h1:EJ3w6bC5fBYjVou6ryzodQq37D5c6qbAYQpGmAy+DC0=
-github.com/projectdiscovery/utils v0.0.4-0.20221222195055-f7d250fc55af h1:2t0pB8Dxj3yt87NGunXlp5lXRWY6nMHKHVh34E/dJx8=
-github.com/projectdiscovery/utils v0.0.4-0.20221222195055-f7d250fc55af/go.mod h1:PCwA5YuCYWPgHaGiZmr53/SA9iGQmAnw7DSHuhr8VPQ=
+github.com/projectdiscovery/utils v0.0.4 h1:eqEjsdIdeeLiHw28C6xyrL2dVdj/nY5ZtqFAmVNhaW8=
+github.com/projectdiscovery/utils v0.0.4/go.mod h1:PCwA5YuCYWPgHaGiZmr53/SA9iGQmAnw7DSHuhr8VPQ=
 github.com/remeh/sizedwaitgroup v1.0.0 h1:VNGGFwNo/R5+MJBf6yrsr110p0m4/OX4S3DCy7Kyl5E=
 github.com/remeh/sizedwaitgroup v1.0.0/go.mod h1:3j2R4OIe/SeS6YDhICBy22RWjJC5eNCJ1V+9+NVNYlo=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=

--- a/internal/runner/executer.go
+++ b/internal/runner/executer.go
@@ -1,8 +1,8 @@
 package runner
 
 import (
-	"github.com/pkg/errors"
 	"github.com/projectdiscovery/gologger"
+	errorutil "github.com/projectdiscovery/utils/errors"
 	"github.com/remeh/sizedwaitgroup"
 )
 
@@ -10,7 +10,7 @@ import (
 func (r *Runner) ExecuteCrawling() error {
 	inputs := r.parseInputs()
 	if len(inputs) == 0 {
-		return errors.New("no input provided for crawling")
+		return errorutil.New("no input provided for crawling")
 	}
 
 	defer r.crawler.Close()

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -1,12 +1,12 @@
 package runner
 
 import (
-	"github.com/pkg/errors"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/katana/pkg/engine"
 	"github.com/projectdiscovery/katana/pkg/engine/hybrid"
 	"github.com/projectdiscovery/katana/pkg/engine/standard"
 	"github.com/projectdiscovery/katana/pkg/types"
+	errorutil "github.com/projectdiscovery/utils/errors"
 	fileutil "github.com/projectdiscovery/utils/file"
 	"go.uber.org/multierr"
 )
@@ -31,10 +31,10 @@ func New(options *types.Options) (*Runner, error) {
 	}
 
 	if err := initExampleFormFillConfig(); err != nil {
-		return nil, errors.Wrap(err, "could not init default config")
+		return nil, errorutil.NewWithErr(err).Msgf("could not init default config")
 	}
 	if err := validateOptions(options); err != nil {
-		return nil, errors.Wrap(err, "could not validate options")
+		return nil, errorutil.NewWithErr(err).Msgf("could not validate options")
 	}
 	if options.FormConfig != "" {
 		if err := readCustomFormConfig(options); err != nil {
@@ -43,7 +43,7 @@ func New(options *types.Options) (*Runner, error) {
 	}
 	crawlerOptions, err := types.NewCrawlerOptions(options)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not create crawler options")
+		return nil, errorutil.NewWithErr(err).Msgf("could not create crawler options")
 	}
 
 	var (
@@ -57,7 +57,7 @@ func New(options *types.Options) (*Runner, error) {
 		crawler, err = standard.New(crawlerOptions)
 	}
 	if err != nil {
-		return nil, errors.Wrap(err, "could not create standard crawler")
+		return nil, errorutil.NewWithErr(err).Msgf("could not create standard crawler")
 	}
 	runner := &Runner{options: options, stdin: fileutil.HasStdin(), crawlerOptions: crawlerOptions, crawler: crawler}
 

--- a/pkg/engine/common/http.go
+++ b/pkg/engine/common/http.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"crypto/tls"
-	"errors"
 	"net/http"
 	"net/url"
 	"time"
@@ -11,6 +10,7 @@ import (
 	"github.com/projectdiscovery/katana/pkg/navigation"
 	"github.com/projectdiscovery/katana/pkg/types"
 	"github.com/projectdiscovery/retryablehttp-go"
+	errorutil "github.com/projectdiscovery/utils/errors"
 )
 
 // BuildClient builds a http client based on a profile
@@ -49,7 +49,7 @@ func BuildClient(dialer *fastdialer.Dialer, options *types.Options, redirectCall
 		Timeout:   time.Duration(options.Timeout) * time.Second,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) == 10 {
-				return errors.New("stopped after 10 redirects")
+				return errorutil.New("stopped after 10 redirects")
 			}
 			depth, ok := req.Context().Value(navigation.Depth{}).(int)
 			if !ok {

--- a/pkg/engine/parser/files/robotstxt.go
+++ b/pkg/engine/parser/files/robotstxt.go
@@ -7,10 +7,10 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/projectdiscovery/katana/pkg/navigation"
 	"github.com/projectdiscovery/katana/pkg/utils"
 	"github.com/projectdiscovery/retryablehttp-go"
+	errorutil "github.com/projectdiscovery/utils/errors"
 )
 
 type robotsTxtCrawler struct {
@@ -23,13 +23,13 @@ func (r *robotsTxtCrawler) Visit(URL string, callback func(navigation.Request)) 
 	requestURL := fmt.Sprintf("%s/robots.txt", URL)
 	req, err := retryablehttp.NewRequest(http.MethodGet, requestURL, nil)
 	if err != nil {
-		return errors.Wrap(err, "could not create request")
+		return errorutil.NewWithTag("robotscrawler", "could not create request").Wrap(err)
 	}
 	req.Header.Set("User-Agent", utils.WebUserAgent())
 
 	resp, err := r.httpclient.Do(req)
 	if err != nil {
-		return errors.Wrap(err, "could not do request")
+		return errorutil.NewWithTag("robotscrawler", "could not do request").Wrap(err)
 	}
 	defer resp.Body.Close()
 

--- a/pkg/engine/standard/crawl.go
+++ b/pkg/engine/standard/crawl.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
-	"github.com/pkg/errors"
 	"github.com/projectdiscovery/katana/pkg/navigation"
 	"github.com/projectdiscovery/katana/pkg/utils"
 	"github.com/projectdiscovery/retryablehttp-go"
+	errorutil "github.com/projectdiscovery/utils/errors"
 )
 
 // makeRequest makes a request to a URL returning a response interface.
@@ -74,7 +74,7 @@ func (c *Crawler) makeRequest(ctx context.Context, request navigation.Request, r
 	response.Resp = resp
 	response.Reader, err = goquery.NewDocumentFromReader(bytes.NewReader(data))
 	if err != nil {
-		return response, errors.Wrap(err, "could not make document from reader")
+		return response, errorutil.NewWithTag("standard", "could not make document from reader").Wrap(err)
 	}
 	return response, nil
 }

--- a/pkg/output/fields.go
+++ b/pkg/output/fields.go
@@ -7,8 +7,8 @@ import (
 	"path"
 	"strings"
 
-	"github.com/pkg/errors"
-	"github.com/projectdiscovery/stringsutil"
+	errorutil "github.com/projectdiscovery/utils/errors"
+	stringsutil "github.com/projectdiscovery/utils/strings"
 	"golang.org/x/net/publicsuffix"
 )
 
@@ -38,7 +38,7 @@ type fieldOutput struct {
 func validateFieldNames(names string) error {
 	parts := strings.Split(names, ",")
 	if len(parts) == 0 {
-		return errors.Errorf("no field names provided: %s", names)
+		return errorutil.NewWithTag("customfield", "no field names provided: %s", names)
 	}
 	uniqueFields := make(map[string]struct{})
 	for _, field := range FieldNames {
@@ -49,7 +49,7 @@ func validateFieldNames(names string) error {
 	}
 	for _, part := range parts {
 		if _, ok := uniqueFields[part]; !ok {
-			return errors.Errorf("invalid field %s specified: %s", part, names)
+			return errorutil.NewWithTag("customfield", "invalid field %s specified: %s", part, names)
 		}
 	}
 	return nil

--- a/pkg/output/responses.go
+++ b/pkg/output/responses.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
+	errorutil "github.com/projectdiscovery/utils/errors"
 	urlutil "github.com/projectdiscovery/utils/url"
 )
 
@@ -65,11 +65,10 @@ func (w *StandardWriter) formatResponse(resp *http.Response) ([]byte, error) {
 }
 
 func getResponseHost(URL string) (string, error) {
-	u, err := urlutil.ParseWithScheme(URL)
+	u, err := urlutil.Parse(URL)
 	if err != nil {
 		return "", err
 	}
-
 	return u.Host, nil
 }
 
@@ -85,7 +84,7 @@ func getResponseFile(storeResponseFolder, URL string) (*fileWriter, error) {
 	}
 	output, err := newFileOutputWriter(getResponseFileName(storeResponseFolder, domain, URL))
 	if err != nil {
-		return nil, errors.Wrap(err, "could not create output file")
+		return nil, errorutil.NewWithTag("output", "could not create output file").Wrap(err)
 	}
 
 	return output, nil
@@ -120,7 +119,7 @@ func updateIndex(storeResponseFolder string, resp *http.Response) error {
 	builder.WriteRune('\n')
 
 	if _, writeErr := index.Write(builder.Bytes()); writeErr != nil {
-		return errors.Wrap(err, "could not update index")
+		return errorutil.NewWithTag("output", "could not update index").Wrap(err)
 	}
 
 	return nil

--- a/pkg/types/crawler_options.go
+++ b/pkg/types/crawler_options.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/projectdiscovery/fastdialer/fastdialer"
 	"github.com/projectdiscovery/katana/pkg/output"
 	"github.com/projectdiscovery/katana/pkg/utils/extensions"
 	"github.com/projectdiscovery/katana/pkg/utils/filters"
 	"github.com/projectdiscovery/katana/pkg/utils/scope"
 	"github.com/projectdiscovery/ratelimit"
+	errorutil "github.com/projectdiscovery/utils/errors"
 )
 
 // CrawlerOptions contains helper utilities for the crawler
@@ -42,11 +42,11 @@ func NewCrawlerOptions(options *Options) (*CrawlerOptions, error) {
 	}
 	scopeManager, err := scope.NewManager(options.Scope, options.OutOfScope, options.FieldScope, options.NoScope)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not create scope manager")
+		return nil, errorutil.NewWithErr(err).Msgf("could not create scope manager")
 	}
 	itemFilter, err := filters.NewSimple()
 	if err != nil {
-		return nil, errors.Wrap(err, "could not create filter")
+		return nil, errorutil.NewWithErr(err).Msgf("could not create filter")
 	}
 
 	outputOptions := output.Options{
@@ -63,7 +63,7 @@ func NewCrawlerOptions(options *Options) (*CrawlerOptions, error) {
 	}
 	outputWriter, err := output.New(outputOptions)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not create output writer")
+		return nil, errorutil.NewWithErr(err).Msgf("could not create output writer")
 	}
 
 	var ratelimiter ratelimit.Limiter


### PR DESCRIPTION
# Proposed Changes

- Now log contains host/url in crawl warning/errors
- Improved Error logging using `utils/errors`
- removed deprecated `github.com/pkg/errors`
- Added debug mode support with env variable `DEBUG=1`
   - Prints stacktrace of error if `DEBUG` variable is not empty

closes #168 