### PR TITLE
Build from source when building Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
 FROM golang:1.19.4-alpine AS builder
 RUN apk add --no-cache git
-RUN go install -v github.com/projectdiscovery/katana/cmd/katana@latest
+WORKDIR /app
+COPY . /app
+RUN go mod download
+RUN go build ./cmd/katana
 
 FROM alpine:3.17.0
 RUN apk -U upgrade --no-cache \
     && apk add --no-cache bind-tools ca-certificates chromium
-COPY --from=builder /go/bin/katana /usr/local/bin/
+COPY --from=builder /app/katana /usr/local/bin/
 
 ENTRYPOINT ["katana"]


### PR DESCRIPTION
This change would build from source when building the Docker image instead of doing an install from GitHub. This should ensure the same version that is being released ends up in the Docker image with the correct tag, fixing issues like #275 

Fixes #275 