### PR TITLE
Setting max tls1.2 with burp proxy

### DIFF
--- a/pkg/engine/common/http.go
+++ b/pkg/engine/common/http.go
@@ -11,6 +11,7 @@ import (
 	"github.com/projectdiscovery/katana/pkg/types"
 	"github.com/projectdiscovery/retryablehttp-go"
 	errorutil "github.com/projectdiscovery/utils/errors"
+	proxyutil "github.com/projectdiscovery/utils/http/proxy"
 )
 
 // BuildClient builds a http client based on a profile
@@ -41,6 +42,9 @@ func BuildClient(dialer *fastdialer.Dialer, options *types.Options, redirectCall
 
 	// Attempts to overwrite the dial function with the socks proxied version
 	if proxyURL != nil {
+		if ok, err := proxyutil.IsBurp(proxyURL.String()); err == nil && ok {
+			transport.TLSClientConfig.MaxVersion = tls.VersionTLS12
+		}
 		transport.Proxy = http.ProxyURL(proxyURL)
 	}
 


### PR DESCRIPTION
Closes #170 

Example:
```console
$ go run . -proxy http://127.0.0.1:8080 -u https://site.com -d 5 -jc  -v

   __        __
  / /_____ _/ /____ ____  ___ _
 /  '_/ _  / __/ _  / _ \/ _  /
/_/\_\\_,_/\__/\_,_/_//_/\_,_/ v0.0.3

                projectdiscovery.io

[script] https://site.com/static/111213/js/perf/stub.js
```