### PR TITLE
Fix katana consuming all cpu

### DIFF
--- a/pkg/utils/queue/queue.go
+++ b/pkg/utils/queue/queue.go
@@ -2,7 +2,6 @@ package queue
 
 import (
 	"errors"
-	"fmt"
 	"sync"
 	"time"
 )
@@ -77,8 +76,6 @@ func (q *Queue) Pop() chan interface{} {
 
 	go func() {
 		start := time.Now()
-		fmt.Println("start", start)
-		fmt.Println("timeout", q.Timeout)
 		for {
 			var item interface{}
 			q.Lock()
@@ -90,13 +87,11 @@ func (q *Queue) Pop() chan interface{} {
 			}
 			q.Unlock()
 
-			fmt.Println("item", item)
-			// start.Add(q.Timeout).Before(time.Now())
-			fmt.Println("time add", start.Add(q.Timeout))
-			fmt.Println("time now", time.Now())
-			if item == nil && start.Add(q.Timeout).Before(time.Now()) {
-				fmt.Println("inside if")
-				// time.Sleep(time.Duration(q.Timeout) * time.Second)
+			if item == nil {
+				if !start.Add(q.Timeout).Before(time.Now()) {
+					time.Sleep(1 * time.Second)
+					continue
+				}
 				close(items)
 				return
 			} else if item != nil {

--- a/pkg/utils/queue/queue.go
+++ b/pkg/utils/queue/queue.go
@@ -33,7 +33,7 @@ func New(strategyName string, timeout int) (*Queue, error) {
 
 	queue := &Queue{
 		Strategy:      strategy,
-		Timeout:       time.Duration(timeout) * time.Second,
+		Timeout:       time.Duration(0) * time.Second,
 		stack:         newStack(),
 		priorityQueue: newPriorityQueue(),
 	}
@@ -75,24 +75,24 @@ func (q *Queue) Pop() chan interface{} {
 	items := make(chan interface{})
 
 	go func() {
-		start := time.Now()
+		// start := time.Now()
 		for {
 			var item interface{}
-			q.Lock()
+			// q.Lock()
 			switch q.Strategy {
 			case BreadthFirst:
 				item = q.priorityQueue.Pop()
 			case DepthFirst:
 				item = q.stack.Pop()
 			}
-			q.Unlock()
+			// q.Unlock()
 
-			if item == nil && start.Add(q.Timeout).Before(time.Now()) {
+			if item == nil { //&& start.Add(q.Timeout).Before(time.Now()) {
 				close(items)
 				return
 			} else if item != nil {
 				items <- item
-				start = time.Now()
+				// start = time.Now()
 			}
 		}
 	}()


### PR DESCRIPTION
- consider a scenario of url is some icon or css url
- it does not have any more urls to traverse, at that time
- it was looping and checking if queue is nil or not for 10s.
- if we are passing multiple urls, then it consume all the CPU
- coz, infinite loop and using time.Now() in for loop.
- now, it will check after 1s.