### PR TITLE
Add random tls impersonate

### DIFF
--- a/cmd/katana/main.go
+++ b/cmd/katana/main.go
@@ -84,6 +84,7 @@ pipelines offering both headless and non-headless crawling.`)
 		flagSet.StringVarP(&options.FieldConfig, "field-config", "flc", "", "path to custom field configuration file"),
 		flagSet.StringVarP(&options.Strategy, "strategy", "s", "depth-first", "Visit strategy (depth-first, breadth-first)"),
 		flagSet.BoolVarP(&options.IgnoreQueryParams, "ignore-query-params", "iqp", false, "Ignore crawling same path with different query-param values"),
+		flagSet.BoolVarP(&options.TlsImpersonate, "tls-impersonate", "tlsi", false, "enable experimental client hello (ja3) tls randomization"),
 	)
 
 	flagSet.CreateGroup("debug", "Debug",

--- a/pkg/engine/common/base.go
+++ b/pkg/engine/common/base.go
@@ -134,13 +134,14 @@ func (s *Shared) NewCrawlSessionWithURL(URL string) (*CrawlSession, error) {
 
 	parsed, err := urlutil.Parse(URL)
 	if err != nil {
-		//nolint
+		cancel()
 		return nil, errorutil.New("could not parse root URL").Wrap(err)
 	}
 	hostname := parsed.Hostname()
 
 	queue, err := queue.New(s.Options.Options.Strategy, s.Options.Options.Timeout)
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 	queue.Push(&navigation.Request{Method: http.MethodGet, URL: URL, Depth: 0}, 0)
@@ -170,6 +171,7 @@ func (s *Shared) NewCrawlSessionWithURL(URL string) (*CrawlSession, error) {
 		s.Enqueue(queue, navigationRequests...)
 	})
 	if err != nil {
+		cancel()
 		return nil, errorutil.New("could not create http client").Wrap(err)
 	}
 	crawlSession := &CrawlSession{

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -130,6 +130,8 @@ type Options struct {
 	IgnoreQueryParams bool
 	// Debug
 	Debug bool
+	// TlsImpersonate enables experimental tls ClientHello randomization for standard crawler
+	TlsImpersonate bool
 }
 
 func (options *Options) ParseCustomHeaders() map[string]string {


### PR DESCRIPTION
## Description
This PR implements random TLS impersonate for standard http crawler. Hybrid crawling already support natively tls extension randomization.

Closes #136 