### PR TITLE
fix extension filter

### DIFF
--- a/pkg/engine/common/base.go
+++ b/pkg/engine/common/base.go
@@ -206,10 +206,6 @@ func (s *Shared) Do(crawlSession *CrawlSession, doRequest DoRequestFunc) error {
 			gologger.Debug().Msgf("`%v` not in scope. skipping", req.URL)
 			continue
 		}
-		if !s.Options.ValidatePath(req.URL) {
-			gologger.Debug().Msgf("skipping url with blacklisted extension %v", req.URL)
-			continue
-		}
 
 		wg.Add()
 		// gologger.Debug().Msgf("Visting: %v", req.URL) // not sure if this is needed

--- a/pkg/output/options.go
+++ b/pkg/output/options.go
@@ -1,21 +1,26 @@
 package output
 
-import "regexp"
+import (
+	"regexp"
+
+	"github.com/projectdiscovery/katana/pkg/utils/extensions"
+)
 
 // Options contains the configuration options for output writer
 type Options struct {
-	Colors           bool
-	JSON             bool
-	Verbose          bool
-	StoreResponse    bool
-	OmitRaw          bool
-	OmitBody         bool
-	OutputFile       string
-	Fields           string
-	StoreFields      string
-	StoreResponseDir string
-	FieldConfig      string
-	ErrorLogFile     string
-	MatchRegex       []*regexp.Regexp
-	FilterRegex      []*regexp.Regexp
+	Colors             bool
+	JSON               bool
+	Verbose            bool
+	StoreResponse      bool
+	OmitRaw            bool
+	OmitBody           bool
+	OutputFile         string
+	Fields             string
+	StoreFields        string
+	StoreResponseDir   string
+	FieldConfig        string
+	ErrorLogFile       string
+	MatchRegex         []*regexp.Regexp
+	FilterRegex        []*regexp.Regexp
+	ExtensionValidator *extensions.Validator
 }

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -11,6 +11,7 @@ import (
 	jsoniter "github.com/json-iterator/go"
 	"github.com/logrusorgru/aurora"
 	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/katana/pkg/utils/extensions"
 	errorutil "github.com/projectdiscovery/utils/errors"
 )
 
@@ -35,36 +36,38 @@ type Writer interface {
 
 // StandardWriter is an standard output writer structure
 type StandardWriter struct {
-	storeFields      []string
-	fields           string
-	json             bool
-	verbose          bool
-	aurora           aurora.Aurora
-	outputFile       *fileWriter
-	outputMutex      *sync.Mutex
-	storeResponse    bool
-	storeResponseDir string
-	omitRaw          bool
-	omitBody         bool
-	errorFile        *fileWriter
-	matchRegex       []*regexp.Regexp
-	filterRegex      []*regexp.Regexp
+	storeFields        []string
+	fields             string
+	json               bool
+	verbose            bool
+	aurora             aurora.Aurora
+	outputFile         *fileWriter
+	outputMutex        *sync.Mutex
+	storeResponse      bool
+	storeResponseDir   string
+	omitRaw            bool
+	omitBody           bool
+	errorFile          *fileWriter
+	matchRegex         []*regexp.Regexp
+	filterRegex        []*regexp.Regexp
+	extensionValidator *extensions.Validator
 }
 
 // New returns a new output writer instance
 func New(options Options) (Writer, error) {
 	writer := &StandardWriter{
-		fields:           options.Fields,
-		json:             options.JSON,
-		verbose:          options.Verbose,
-		aurora:           aurora.NewAurora(options.Colors),
-		outputMutex:      &sync.Mutex{},
-		storeResponse:    options.StoreResponse,
-		storeResponseDir: options.StoreResponseDir,
-		omitRaw:          options.OmitRaw,
-		omitBody:         options.OmitBody,
-		matchRegex:       options.MatchRegex,
-		filterRegex:      options.FilterRegex,
+		fields:             options.Fields,
+		json:               options.JSON,
+		verbose:            options.Verbose,
+		aurora:             aurora.NewAurora(options.Colors),
+		outputMutex:        &sync.Mutex{},
+		storeResponse:      options.StoreResponse,
+		storeResponseDir:   options.StoreResponseDir,
+		omitRaw:            options.OmitRaw,
+		omitBody:           options.OmitBody,
+		matchRegex:         options.MatchRegex,
+		filterRegex:        options.FilterRegex,
+		extensionValidator: options.ExtensionValidator,
 	}
 	// if fieldConfig empty get the default file
 	if options.FieldConfig == "" {
@@ -132,6 +135,11 @@ func (w *StandardWriter) Write(result *Result) error {
 		if len(w.storeFields) > 0 {
 			storeFields(result, w.storeFields)
 		}
+
+		if !w.extensionValidator.ValidatePath(result.Request.URL) {
+			return nil
+		}
+
 		if !w.matchOutput(result) {
 			return nil
 		}

--- a/pkg/types/crawler_options.go
+++ b/pkg/types/crawler_options.go
@@ -58,20 +58,21 @@ func NewCrawlerOptions(options *Options) (*CrawlerOptions, error) {
 	}
 
 	outputOptions := output.Options{
-		Colors:           !options.NoColors,
-		JSON:             options.JSON,
-		Verbose:          options.Verbose,
-		StoreResponse:    options.StoreResponse,
-		OutputFile:       options.OutputFile,
-		Fields:           options.Fields,
-		StoreFields:      options.StoreFields,
-		StoreResponseDir: options.StoreResponseDir,
-		OmitRaw:          options.OmitRaw,
-		OmitBody:         options.OmitBody,
-		FieldConfig:      options.FieldConfig,
-		ErrorLogFile:     options.ErrorLogFile,
-		MatchRegex:       options.MatchRegex,
-		FilterRegex:      options.FilterRegex,
+		Colors:             !options.NoColors,
+		JSON:               options.JSON,
+		Verbose:            options.Verbose,
+		StoreResponse:      options.StoreResponse,
+		OutputFile:         options.OutputFile,
+		Fields:             options.Fields,
+		StoreFields:        options.StoreFields,
+		StoreResponseDir:   options.StoreResponseDir,
+		OmitRaw:            options.OmitRaw,
+		OmitBody:           options.OmitBody,
+		FieldConfig:        options.FieldConfig,
+		ErrorLogFile:       options.ErrorLogFile,
+		MatchRegex:         options.MatchRegex,
+		FilterRegex:        options.FilterRegex,
+		ExtensionValidator: extensionsValidator,
 	}
 	outputWriter, err := output.New(outputOptions)
 	if err != nil {


### PR DESCRIPTION
This PR fixes a bug in the output filter with extensions. Closes #480.

```
$ go run . -u https://blog.it-securityguard.com -jc -f ufile -em js

   __        __                
  / /_____ _/ /____ ____  ___ _
 /  '_/ _  / __/ _  / _ \/ _  /
/_/\_\\_,_/\__/\_,_/_//_/\_,_/                                                   

                projectdiscovery.io

[INF] Current katana version v1.0.3-dev (development)
[INF] Started standard crawling for => https://blog.it-securityguard.com
https://blog.it-securityguard.com/wp-content/plugins/pdf-embedder/assets/js/min/all-pdfemb-min.js?ver=b82890d99bf14594a05514ba8096cd4d
https://blog.it-securityguard.com/\/blog.it-securityguard.com\/wp-content\/plugins\/pdf-embedder\/js\/pdfjs\/pdf.worker.min.js
https://blog.it-securityguard.com/wp-content/plugins/pdf-embedder/assets/js/pdfjs/pdf.min.js?ver=4.6.4
https://blog.it-securityguard.com/wp-includes/js/wp-embed.min.js?ver=b82890d99bf14594a05514ba8096cd4d
https://blog.it-securityguard.com/wp-includes/js/mediaelement/wp-mediaelement.min.js?ver=b82890d99bf14594a05514ba8096cd4d
https://blog.it-securityguard.com/wp-includes/js/mediaelement/renderers/vimeo.min.js?ver=4.2.17
https://blog.it-securityguard.com/\/blog.it-securityguard.com\/wp-includes\/js\/wp-emoji-release.min.js
https://blog.it-securityguard.com/wp-includes/js/mediaelement/mediaelement-migrate.min.js?ver=b82890d99bf14594a05514ba8096cd4d
https://blog.it-securityguard.com/wp-content/themes/casper/js/main.js?ver=1.0.0
https://blog.it-securityguard.com/wp-content/plugins/wp-statistics/assets/js/tracker.js?ver=b82890d99bf14594a05514ba8096cd4d
https://blog.it-securityguard.com/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.0
https://blog.it-securityguard.com/wp-includes/js/mediaelement/renderers/MediaElement.js
https://blog.it-securityguard.com/wp-includes/js/jquery/jquery.min.js?ver=3.6.4
https://blog.it-securityguard.com/wp-includes/js/mediaelement/mediaelement-and-player.min.js?ver=4.2.17
https://blog.it-securityguard.com/wp-includes/js/mediaelement/MediaElement.js
```


```
$ go run . -u https://blog.it-securityguard.com -jc -f ufile -ef js

   __        __                
  / /_____ _/ /____ ____  ___ _
 /  '_/ _  / __/ _  / _ \/ _  /
/_/\_\\_,_/\__/\_,_/_//_/\_,_/                                                   

                projectdiscovery.io

[INF] Current katana version v1.0.3-dev (development)
[INF] Started standard crawling for => https://blog.it-securityguard.com
https://blog.it-securityguard.com/phpinfo.php
https://blog.it-securityguard.com/wp-login.php?action=postpass
https://blog.it-securityguard.com/2014/06/monitor.it-securityguard.com/test2.html
https://blog.it-securityguard.com/wp-content/plugins/pdf-embedder/assets/css/pdfemb-embed-pdf.css?ver=4.6.4
https://blog.it-securityguard.com/pbbt.xmind
https://blog.it-securityguard.com/wp-content/themes/casper/js/video.html
https://blog.it-securityguard.com/wp-includes/js/mediaelement/'+t.src+'
https://blog.it-securityguard.com/wp-includes/js/mediaelement/wp-mediaelement.min.css?ver=b82890d99bf14594a05514ba8096cd4d
https://blog.it-securityguard.com/wp-includes/js/mediaelement/mediaelementplayer-legacy.min.css?ver=4.2.17
https://blog.it-securityguard.com/wp-includes/wlwmanifest.xml
https://blog.it-securityguard.com/wp-content/plugins/recent-posts-widget-with-thumbnails/public.css?ver=7.1.1
https://blog.it-securityguard.com/wp-content/themes/casper/style.css?ver=b82890d99bf14594a05514ba8096cd4d
https://blog.it-securityguard.com/wp-includes/css/classic-themes.min.css?ver=b82890d99bf14594a05514ba8096cd4d
https://blog.it-securityguard.com/xmlrpc.php?rsd
https://blog.it-securityguard.com/wp-includes/css/dist/block-library/style.min.css?ver=b82890d99bf14594a05514ba8096cd4d
https://blog.it-securityguard.com/xmlrpc.php
https://blog.it-securityguard.com/wp-admin/edit-comments.php
https://blog.it-securityguard.com/wp-admin/post.php
```