### PR TITLE
-jsonl parameter in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -778,11 +778,11 @@ By default, katana outputs the crawled endpoints in plain text format. The resul
 katana -u https://example.com -no-scope -output example_endpoints.txt
 ```
 
-*`-json`*
+*`-jsonl`*
 ---
 
 ```console
-katana -u https://example.com -json | jq .
+katana -u https://example.com -jsonl | jq .
 ```
 
 ```json


### PR DESCRIPTION
Minor change to the README file:
The parameter to write the output in json is "-json**l**" as referenced in the beginning.