### PR TITLE
[IMPROVEMENT] Normalization of action & method attributes in form extraction feature.

### DIFF
--- a/pkg/engine/hybrid/crawl.go
+++ b/pkg/engine/hybrid/crawl.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httputil"
+	"net/url"
 
 	"strings"
 	"time"
@@ -180,6 +181,7 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 	}
 
 	response.Body = body
+	response.Reader.Url, _ = url.Parse(request.URL)
 	if c.Options.Options.FormExtraction {
 		response.Forms = append(response.Forms, utils.ParseFormFields(response.Reader)...)
 	}

--- a/pkg/engine/standard/crawl.go
+++ b/pkg/engine/standard/crawl.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httputil"
+	"net/url"
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
@@ -81,6 +82,7 @@ func (c *Crawler) makeRequest(s *common.CrawlSession, request *navigation.Reques
 	response.Body = string(data)
 	response.Resp = resp
 	response.Reader, err = goquery.NewDocumentFromReader(bytes.NewReader(data))
+	response.Reader.Url, _ = url.Parse(request.URL)
 	response.StatusCode = resp.StatusCode
 	response.Headers = utils.FlattenHeaders(resp.Header)
 	if c.Options.Options.FormExtraction {

--- a/pkg/utils/formfields.go
+++ b/pkg/utils/formfields.go
@@ -50,7 +50,7 @@ func ParseFormFields(document *goquery.Document) []navigation.Form {
 				if strings.HasPrefix(action, "/") {
 					// relative path
 					// 	<form action=/root_rel></form> => https://example.com/root_rel
-					cloned.UpdateRelPath(action, true)
+					_ = cloned.UpdateRelPath(action, true)
 					action = cloned.String()
 				} else {
 					// 	<form action=path_rel></form> => https://example.com/path/path_rel

--- a/pkg/utils/formfields.go
+++ b/pkg/utils/formfields.go
@@ -25,6 +25,10 @@ func ParseFormFields(document *goquery.Document) []navigation.Form {
 			method = "GET"
 		}
 
+		if enctype == "" && method != "GET" {
+			enctype = "application/x-www-form-urlencoded"
+		}
+
 		actionUrl, _ := url.Parse(action)
 		if !actionUrl.IsAbs() && !strings.HasPrefix(action, "//") && !strings.HasPrefix(action, "\\\\") {
 			if action == "" {

--- a/pkg/utils/formfields_test.go
+++ b/pkg/utils/formfields_test.go
@@ -24,7 +24,7 @@ var htmlFormExample = `<html>
 	<form action=//prel.example.com></form>
 	<form action=\\unc.example.com></form>
 	<form action=/root_rel></form>
-	<form action=path_rel></form>
+	<form action=rel_path></form>
 	<form></form>
 </body>
 </html>`
@@ -47,7 +47,7 @@ func TestParseFormFields(t *testing.T) {
 	require.Equal(t, "GET", forms[4].Method)
 	require.Equal(t, "https://example.com/root_rel", forms[4].Action)
 	require.Equal(t, "GET", forms[5].Method)
-	require.Equal(t, "https://example.com/path/path_rel", forms[5].Action)
+	require.Equal(t, "https://example.com/path/rel_path", forms[5].Action)
 	require.Equal(t, "GET", forms[6].Method)
 	require.Equal(t, "https://example.com/path", forms[6].Action)
 	require.Contains(t, forms[0].Parameters, "firstname")

--- a/pkg/utils/formfields_test.go
+++ b/pkg/utils/formfields_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"net/url"
 	"strings"
 	"testing"
 
@@ -19,8 +20,12 @@ var htmlFormExample = `<html>
 		<select name=select1></select> 
 		<input type=text /> 
 	</form>  
-	<form method=post></form>
-	<form action="/test2">
+	<form method=post action=https://abs.example.com></form>
+	<form action=//prel.example.com></form>
+	<form action=\\unc.example.com></form>
+	<form action=/root_rel></form>
+	<form action=path_rel></form>
+	<form></form>
 </body>
 </html>`
 
@@ -28,16 +33,26 @@ func TestParseFormFields(t *testing.T) {
 	document, err := goquery.NewDocumentFromReader(strings.NewReader(htmlFormExample))
 	require.NoError(t, err, "could not read document")
 
+	document.Url, _ = url.Parse("https://example.com/path")
 	forms := ParseFormFields(document)
 
-	require.Equal(t, "/test", forms[0].Action)
+	require.Equal(t, "https://example.com/test", forms[0].Action)
 	require.Equal(t, "POST", forms[0].Method)
 	require.Equal(t, "POST", forms[1].Method)
-	require.Equal(t, "/test2", forms[2].Action)
-	require.Equal(t, "", forms[0].Enctype)
+	require.Equal(t, "https://abs.example.com", forms[1].Action)
+	require.Equal(t, "GET", forms[2].Method)
+	require.Equal(t, "//prel.example.com", forms[2].Action)
+	require.Equal(t, "GET", forms[3].Method)
+	require.Equal(t, "\\\\unc.example.com", forms[3].Action)
+	require.Equal(t, "GET", forms[4].Method)
+	require.Equal(t, "https://example.com/root_rel", forms[4].Action)
+	require.Equal(t, "GET", forms[5].Method)
+	require.Equal(t, "https://example.com/path/path_rel", forms[5].Action)
+	require.Equal(t, "GET", forms[6].Method)
+	require.Equal(t, "https://example.com/path", forms[6].Action)
 	require.Contains(t, forms[0].Parameters, "firstname")
 	require.Contains(t, forms[0].Parameters, "textarea1")
 	require.Contains(t, forms[0].Parameters, "select1")
 	require.Equal(t, 3, len(forms[0].Parameters), "found more or less parameters than where present")
-	require.Equal(t, 3, len(forms), "found more or less forms than where present")
+	require.Equal(t, 7, len(forms), "found more or less forms than where present")
 }


### PR DESCRIPTION
Hi, i made some improvement to the form extraction feature.

CHANGES:
- action attributes get normalized to absolute urls
- missing method attributes get normalized to GET
- missing enctype attributes get normalized to application/x-www-form-urlencoded

i used the following page for testing
```html
<!DOCTYPE html>
<html>
<body>
<form action=https://abs.example.com></form>
<form action=//prel.example.com></form>
<form action=\\unc.example.com></form>
<form action=/root_rel></form>
<form action=path_rel></form>
<form></form>
</body>
</html>
```

result
![Screenshot from 2023-07-08 14-03-10](https://github.com/projectdiscovery/katana/assets/11355060/ed2326e3-3a9b-4c01-a80f-2e64f245fae3)
