### PR TITLE
Patch: Fix Nil Pointer Dereference When Displaying Out of Scope Endpoints in JSON

### DIFF
--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -143,9 +143,11 @@ func (w *StandardWriter) Write(result *Result) error {
 
 		if w.omitRaw {
 			result.Request.Raw = ""
-			result.Response.Raw = ""
+			if result.HasResponse() {
+				result.Response.Raw = ""
+			}
 		}
-		if w.omitBody {
+		if w.omitBody && result.HasResponse() {
 			result.Response.Body = ""
 		}
 


### PR DESCRIPTION
Fixes #528:

Example nil pointer dereference:

```
> echo "https://www.google.com" | katana -jsonl -ob -or -do

   __        __
  / /_____ _/ /____ ____  ___ _
 /  '_/ _  / __/ _  / _ \/ _  /
/_/\_\\_,_/\__/\_,_/_//_/\_,_/

		projectdiscovery.io

[INF] Current katana version v1.0.2 (latest)
[INF] Started standard crawling for => https://www.google.com
{"timestamp":"2023-07-21T14:07:17.961479-07:00","request":{"method":"GET","endpoint":"https://www.google.com"},"response":{"status_code":200,"headers":{"content_security_policy_report_only":"object-src 'none';base-uri 'self';script-src 'nonce-aqaSyLa0kgrVnAH7-tAt-w' 'strict-dynamic' 'report-sample' 'unsafe-eval' 'unsafe-inline' https: http:;report-uri https://csp.withgoogle.com/csp/gws/other-hp","date":"Fri, 21 Jul 2023 21:07:17 GMT","expires":"-1","x_xss_protection":"0","cache_control":"private, max-age=0","permissions_policy":"unload=()","strict_transport_security":"max-age=31536000","p3p":"CP=\"This is not a P3P policy! See g.co/p3phelp for more info.\"","cross_origin_opener_policy":"same-origin-allow-popups; report-to=\"gws\"","server":"gws","set_cookie":"1P_JAR=2023-07-21-21; expires=Sun, 20-Aug-2023 21:07:17 GMT; path=/; domain=.google.com; Secure; SameSite=none;AEC=Ad49MVHDWX3d2HhodaE1Jz3FGjWSuEUAYLSNKIVeLGanaAGnaBJDfSY3l7U; expires=Wed, 17-Jan-2024 21:07:17 GMT; path=/; domain=.google.com; Secure; HttpOnly; SameSite=lax;NID=511=eGrkIPQtiehlTgk4XbPXc3Xa8rGNztaTE87l5ckA2kIvgyyfo1SHtaybdngOP4na52ktT21aojJwu-iR_cEy0NVJLBTn7S83xxle-VlLI4rfkOL_xzK-tkd1VTwjHwz5o21J4V_k07XoALuJQ4_yTERF76SvHxXj280eGOsygCw; expires=Sat, 20-Jan-2024 21:07:17 GMT; path=/; domain=.google.com; Secure; HttpOnly; SameSite=none","x_frame_options":"SAMEORIGIN","report_to":"{\"group\":\"gws\",\"max_age\":2592000,\"endpoints\":[{\"url\":\"https://csp.withgoogle.com/csp/report-to/gws/other\"}]}","origin_trial":"Ap+qNlnLzJDKSmEHjzM5ilaa908GuehlLqGb6ezME5lkhelj20qVzfv06zPmQ3LodoeujZuphAolrnhnPA8w4AIAAABfeyJvcmlnaW4iOiJodHRwczovL3d3dy5nb29nbGUuY29tOjQ0MyIsImZlYXR1cmUiOiJQZXJtaXNzaW9uc1BvbGljeVVubG9hZCIsImV4cGlyeSI6MTY4NTY2Mzk5OX0=;AvudrjMZqL7335p1KLV2lHo1kxdMeIN0dUI15d0CPz9dovVLCcXk8OAqjho1DX4s6NbHbA/AGobuGvcZv0drGgQAAAB9eyJvcmlnaW4iOiJodHRwczovL3d3dy5nb29nbGUuY29tOjQ0MyIsImZlYXR1cmUiOiJCYWNrRm9yd2FyZENhY2hlTm90UmVzdG9yZWRSZWFzb25zIiwiZXhwaXJ5IjoxNjkxNTM5MTk5LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=","alt_svc":"h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000","content_type":"text/html; charset=UTF-8"},"technologies":["Google Web Server","HTTP/3","HSTS"]}}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x68 pc=0x100b18ec1]

goroutine 70 [running]:
github.com/projectdiscovery/katana/pkg/output.(*StandardWriter).Write(0xc0001d2790, 0xc002431100)
	/my-go-path/go/pkg/mod/github.com/projectdiscovery/katana@v1.0.2/pkg/output/output.go:146 +0x101
github.com/projectdiscovery/katana/pkg/engine/common.(*Shared).Output(0xc0024701c8, 0xc001adefa0, 0x0, {0x101691140?, 0xc000359c70?})
	/my-go-path/go/pkg/mod/github.com/projectdiscovery/katana@v1.0.2/pkg/engine/common/base.go:111 +0x14e
github.com/projectdiscovery/katana/pkg/engine/common.(*Shared).Enqueue(0xc0024701c8, 0xc001acfd60?, {0xc0000b1860, 0x1e, 0x0?})
	/my-go-path/go/pkg/mod/github.com/projectdiscovery/katana@v1.0.2/pkg/engine/common/base.go:75 +0x232
github.com/projectdiscovery/katana/pkg/engine/common.(*Shared).Do.func1()
	/my-go-path/go/pkg/mod/github.com/projectdiscovery/katana@v1.0.2/pkg/engine/common/base.go:246 +0x155
created by github.com/projectdiscovery/katana/pkg/engine/common.(*Shared).Do
	/my-go-path/go/pkg/mod/github.com/projectdiscovery/katana@v1.0.2/pkg/engine/common/base.go:216 +0x2b0
```