### PR TITLE
fix `-match-regex` err

### DIFF
--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -255,13 +255,20 @@ func (w *StandardWriter) matchOutput(event *Result) bool {
 	if w.matchRegex == nil && w.outputMatchCondition == "" {
 		return true
 	}
-	for _, regex := range w.matchRegex {
-		if regex.MatchString(event.Request.URL) {
-			return true
+
+	if w.matchRegex != nil {
+		for _, regex := range w.matchRegex {
+			if regex.MatchString(event.Request.URL) {
+				return true
+			}
 		}
 	}
 
-	return evalDslExpr(event, w.outputMatchCondition)
+	if w.outputMatchCondition != "" {
+		return evalDslExpr(event, w.outputMatchCondition)
+	}
+
+	return false
 }
 
 // filterOutput returns true if the event should be filtered out
@@ -269,13 +276,20 @@ func (w *StandardWriter) filterOutput(event *Result) bool {
 	if w.filterRegex == nil && w.outputFilterCondition == "" {
 		return false
 	}
-	for _, regex := range w.filterRegex {
-		if regex.MatchString(event.Request.URL) {
-			return true
+
+	if w.filterRegex != nil {
+		for _, regex := range w.filterRegex {
+			if regex.MatchString(event.Request.URL) {
+				return true
+			}
 		}
 	}
 
-	return evalDslExpr(event, w.outputFilterCondition)
+	if w.outputFilterCondition != "" {
+		return evalDslExpr(event, w.outputFilterCondition)
+	}
+
+	return false
 }
 
 func evalDslExpr(result *Result, dslExpr string) bool {


### PR DESCRIPTION
Closes #563.

Before:
```console
$ go run main.go -u https://google.com -match-regex "^https://google.com$"

   __        __                
  / /_____ _/ /____ ____  ___ _
 /  '_/ _  / __/ _  / _ \/ _  /
/_/\_\\_,_/\__/\_,_/_//_/\_,_/                                                   

                projectdiscovery.io

[INF] Current katana version v1.0.3 (latest)
[INF] Started standard crawling for => https://google.com
https://google.com
[ERR] Could not evaluate DSL expression: Unexpected end of expression
[ERR] Could not evaluate DSL expression: Unexpected end of expression
[ERR] Could not evaluate DSL expression: Unexpected end of expression
[ERR] Could not evaluate DSL expression: Unexpected end of expression
[ERR] Could not evaluate DSL expression: Unexpected end of expression
[ERR] Could not evaluate DSL expression: Unexpected end of expression
[ERR] Could not evaluate DSL expression: Unexpected end of expression
[ERR] Could not evaluate DSL expression: Unexpected end of expression
[ERR] Could not evaluate DSL expression: Unexpected end of expression
[ERR] Could not evaluate DSL expression: Unexpected end of expression
[ERR] Could not evaluate DSL expression: Unexpected end of expression
[ERR] Could not evaluate DSL expression: Unexpected end of expression
[ERR] Could not evaluate DSL expression: Unexpected end of expression
[ERR] Could not evaluate DSL expression: Unexpected end of expression
[ERR] Could not evaluate DSL expression: Unexpected end of expression
^C[INF] - Ctrl+C pressed in Terminal
```

After:
```console
$ go run main.go -u https://google.com -match-regex "^https://google.com$"

   __        __                
  / /_____ _/ /____ ____  ___ _
 /  '_/ _  / __/ _  / _ \/ _  /
/_/\_\\_,_/\__/\_,_/_//_/\_,_/                                                   

                projectdiscovery.io

[INF] Current katana version v1.0.3 (latest)
[INF] Started standard crawling for => https://google.com
https://google.com
^C[INF] - Ctrl+C pressed in Terminal
```
