### PR TITLE
added support for custom regex on field scope (-fs "[regex pattern]")

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ HEADLESS:
 SCOPE:
    -cs, -crawl-scope string[]       in scope url regex to be followed by crawler
    -cos, -crawl-out-scope string[]  out of scope url regex to be excluded by crawler
-   -fs, -field-scope string         pre-defined scope field (dn,rdn,fqdn) (default "rdn")
+   -fs, -field-scope string  pre-defined scope field (dn,rdn,fqdn) or custom regex (e.g., '(company-staging.io|company.com)') (default "rdn")
    -ns, -no-scope                   disables host based default scope
    -do, -display-out-scope          display external endpoint from scoped crawling
 

--- a/cmd/katana/main.go
+++ b/cmd/katana/main.go
@@ -109,7 +109,7 @@ pipelines offering both headless and non-headless crawling.`)
 	flagSet.CreateGroup("scope", "Scope",
 		flagSet.StringSliceVarP(&options.Scope, "crawl-scope", "cs", nil, "in scope url regex to be followed by crawler", goflags.FileCommaSeparatedStringSliceOptions),
 		flagSet.StringSliceVarP(&options.OutOfScope, "crawl-out-scope", "cos", nil, "out of scope url regex to be excluded by crawler", goflags.FileCommaSeparatedStringSliceOptions),
-		flagSet.StringVarP(&options.FieldScope, "field-scope", "fs", "rdn", "pre-defined scope field (dn,rdn,fqdn)"),
+		flagSet.StringVarP(&options.FieldScope, "field-scope", "fs", "rdn", "pre-defined scope field (dn,rdn,fqdn) or custom regex (e.g., '(company-staging.io|company.com)')"),
 		flagSet.BoolVarP(&options.NoScope, "no-scope", "ns", false, "disables host based default scope"),
 		flagSet.BoolVarP(&options.DisplayOutScope, "display-out-scope", "do", false, "display external endpoint from scoped crawling"),
 	)

--- a/pkg/utils/scope/scope.go
+++ b/pkg/utils/scope/scope.go
@@ -41,7 +41,6 @@ func NewManager(inScope, outOfScope []string, fieldScope string, noScope bool) (
 	}
 
 	if scopeValue, ok := stringToDNSScopeField[fieldScope]; !ok {
-		//return nil, fmt.Errorf("invalid dns scope field specified: %s", fieldScope)
 		manager.fieldScope = customDNSScopeField
 		if compiled, err := regexp.Compile(fieldScope); err != nil {
 			return nil, fmt.Errorf("could not compile regex %s: %s", fieldScope, err)


### PR DESCRIPTION
This feature is needed on cases where you have a initial website to recon, and you know that the company can use multiple base domains in its application.

For example, you can start crawling all sites of `*.company.com`, and then find mentions to `company-staging.io`. With this new commit, you can then add both hostnames to Katana's field scope by doing `-fs '(company-staging.io|company.com)'`.

It made a lot of sense to implement this on Katana for my automation, it may be useful to others.