### PR TITLE
Add option to disable following redirects

### DIFF
--- a/cmd/katana/main.go
+++ b/cmd/katana/main.go
@@ -86,6 +86,7 @@ pipelines offering both headless and non-headless crawling.`)
 		flagSet.StringVarP(&options.Strategy, "strategy", "s", "depth-first", "Visit strategy (depth-first, breadth-first)"),
 		flagSet.BoolVarP(&options.IgnoreQueryParams, "ignore-query-params", "iqp", false, "Ignore crawling same path with different query-param values"),
 		flagSet.BoolVarP(&options.TlsImpersonate, "tls-impersonate", "tlsi", false, "enable experimental client hello (ja3) tls randomization"),
+		flagSet.BoolVarP(&options.DisableRedirects, "disable-redirects", "dr", false, "disable following redirects (default false)"),
 	)
 
 	flagSet.CreateGroup("debug", "Debug",

--- a/pkg/engine/common/http.go
+++ b/pkg/engine/common/http.go
@@ -54,6 +54,9 @@ func BuildHttpClient(dialer *fastdialer.Dialer, options *types.Options, redirect
 		Transport: transport,
 		Timeout:   time.Duration(options.Timeout) * time.Second,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if options.DisableRedirects {
+				return http.ErrUseLastResponse
+			}
 			if len(via) == 10 {
 				return errorutil.New("stopped after 10 redirects")
 			}

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -141,6 +141,8 @@ type Options struct {
 	Debug bool
 	// TlsImpersonate enables experimental tls ClientHello randomization for standard crawler
 	TlsImpersonate bool
+	//DisableRedirects disables the following of redirects
+	DisableRedirects bool
 }
 
 func (options *Options) ParseCustomHeaders() map[string]string {


### PR DESCRIPTION
Added a new flag -dr, -disable-redirects which sets the http client to not follow redirects. 
Issue: #561 

Examples:
With following redirects enabled (default):
<img width="717" alt="image" src="https://github.com/projectdiscovery/katana/assets/69286736/9a2d81b5-7837-4795-a18b-1d9a9f490d86">

With following redirects disabled:
<img width="647" alt="image" src="https://github.com/projectdiscovery/katana/assets/69286736/91e01d95-359a-4223-845d-e63542a50598">


