### PR TITLE
Patch: update crawling to not follow redirects when `-disable-redirects` is set

### DIFF
--- a/pkg/engine/common/base.go
+++ b/pkg/engine/common/base.go
@@ -239,6 +239,10 @@ func (s *Shared) Do(crawlSession *CrawlSession, doRequest DoRequestFunc) error {
 			if resp.Resp == nil || resp.Reader == nil {
 				return
 			}
+			isRedirectResponse := resp.StatusCode >= 300 && resp.StatusCode < 400
+			if s.Options.Options.DisableRedirects && isRedirectResponse {
+				return
+			}
 
 			navigationRequests := parser.ParseResponse(resp)
 			s.Enqueue(crawlSession.Queue, navigationRequests...)

--- a/pkg/engine/common/base.go
+++ b/pkg/engine/common/base.go
@@ -239,8 +239,7 @@ func (s *Shared) Do(crawlSession *CrawlSession, doRequest DoRequestFunc) error {
 			if resp.Resp == nil || resp.Reader == nil {
 				return
 			}
-			isRedirectResponse := resp.StatusCode >= 300 && resp.StatusCode < 400
-			if s.Options.Options.DisableRedirects && isRedirectResponse {
+			if s.Options.Options.DisableRedirects && resp.IsRedirect() {
 				return
 			}
 

--- a/pkg/engine/hybrid/crawl.go
+++ b/pkg/engine/hybrid/crawl.go
@@ -130,8 +130,7 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 		c.Enqueue(s.Queue, navigationRequests...)
 
 		// do not continue following the request if it's a redirect and redirects are disabled
-		isRedirectResponse := statusCode >= 300 && statusCode < 400
-		if c.Options.Options.DisableRedirects && isRedirectResponse {
+		if c.Options.Options.DisableRedirects && resp.IsRedirect() {
 			return nil
 		}
 		return FetchContinueRequest(page, e)

--- a/pkg/engine/hybrid/crawl.go
+++ b/pkg/engine/hybrid/crawl.go
@@ -128,6 +128,12 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 		// process the raw response
 		navigationRequests := parser.ParseResponse(resp)
 		c.Enqueue(s.Queue, navigationRequests...)
+
+		// do not continue following the request if it's a redirect and redirects are disabled
+		isRedirectResponse := statusCode >= 300 && statusCode < 400
+		if c.Options.Options.DisableRedirects && isRedirectResponse {
+			return nil
+		}
 		return FetchContinueRequest(page, e)
 	})() //nolint
 	defer func() {

--- a/pkg/engine/parser/parser.go
+++ b/pkg/engine/parser/parser.go
@@ -37,7 +37,6 @@ var responseParsers = []responseParser{
 	// Header based parsers
 	{headerParser, headerContentLocationParser},
 	{headerParser, headerLinkParser},
-	{headerParser, headerLocationParser},
 	{headerParser, headerRefreshParser},
 
 	// Body based parsers
@@ -83,6 +82,9 @@ func InitWithOptions(options *types.Options) {
 		responseParsers = append(responseParsers, responseParser{bodyParser, scriptContentRegexParser})
 		responseParsers = append(responseParsers, responseParser{contentParser, scriptJSFileRegexParser})
 		responseParsers = append(responseParsers, responseParser{contentParser, bodyScrapeEndpointsParser})
+	}
+	if !options.DisableRedirects {
+		responseParsers = append(responseParsers, responseParser{headerParser, headerLocationParser})
 	}
 }
 

--- a/pkg/navigation/response.go
+++ b/pkg/navigation/response.go
@@ -58,3 +58,7 @@ func (n Response) AbsoluteURL(path string) string {
 	final := absURL.String()
 	return final
 }
+
+func (n Response) IsRedirect() bool {
+	return n.StatusCode >= 300 && n.StatusCode <= 399
+}


### PR DESCRIPTION
This fixes #610, where redirects are not followed when performing a katana crawl.

"Standard" crawl:
```
# without changes introduced in this PR
> echo "http://projectdiscovery.io" | katana -silent -d 2 -disable-redirects
http://projectdiscovery.io
https://projectdiscovery.io/

# with changes introduced in this PR
> echo "http://projectdiscovery.io" | katana -silent -d 2 -disable-redirects
http://projectdiscovery.io
```

"Headless" crawl:
```
# without changes introduced in this PR
> echo "http://projectdiscovery.io" | katana -silent -d 2 -disable-redirects -headless
https://projectdiscovery.io/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js
https://projectdiscovery.io/cdn-cgi/scripts/5c5dd728/cloudflare-static/'+e.replace(/
https://projectdiscovery.io/cdn-cgi/l/email-protection
http://projectdiscovery.io
https://projectdiscovery.io/
https://projectdiscovery.io/terms
https://projectdiscovery.io/aboutus
https://projectdiscovery.io/privacy
https://chaos.projectdiscovery.io/
https://projectdiscovery.io/nuclei
https://projectdiscovery.io/community
https://blog.projectdiscovery.io/
https://blog.projectdiscovery.io/stop-pentesting-start-programming/
https://projectdiscovery.io/requestdemo
https://blog.projectdiscovery.io/announcing-nuclei-cloud/
https://blog.projectdiscovery.io/hunting-c2-servers/
https://blog.projectdiscovery.io/the-best-defense-is-a-good-offensive-security-program/
https://projectdiscovery.io/cloudplatform

# with changes introduced in this PR
> echo "http://projectdiscovery.io" | ./katana -silent -d 2 -disable-redirects -headless
http://projectdiscovery.io
```


