### PR TITLE
Patch: save correct headers for XHR requests

### DIFF
--- a/pkg/engine/hybrid/crawl.go
+++ b/pkg/engine/hybrid/crawl.go
@@ -108,10 +108,14 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 		}
 
 		if e.ResourceType == "XHR" && c.Options.Options.XhrExtraction {
+			xhr_headers := make(map[string][]string)
+			for k, v := range e.Request.Headers {
+				xhr_headers[k] = []string{v.Str()}
+			}
 			xhr := navigation.Request{
 				URL:     httpreq.URL.String(),
 				Method:  httpreq.Method,
-				Headers: utils.FlattenHeaders(httpreq.Header),
+				Headers: utils.FlattenHeaders(xhr_headers),
 				Body:    e.Request.PostData,
 			}
 			xhrRequests = append(xhrRequests, xhr)

--- a/pkg/engine/hybrid/crawl.go
+++ b/pkg/engine/hybrid/crawl.go
@@ -107,16 +107,22 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 			Raw:          string(rawBytesResponse),
 		}
 
+		requestHeaders := make(map[string][]string)
+		for name, value := range e.Request.Headers {
+			requestHeaders[name] = []string{value.Str()}
+		}
+
 		if e.ResourceType == "XHR" && c.Options.Options.XhrExtraction {
-			xhr_headers := make(map[string][]string)
-			for k, v := range e.Request.Headers {
-				xhr_headers[k] = []string{v.Str()}
-			}
 			xhr := navigation.Request{
-				URL:     httpreq.URL.String(),
-				Method:  httpreq.Method,
-				Headers: utils.FlattenHeaders(xhr_headers),
-				Body:    e.Request.PostData,
+				URL:    httpreq.URL.String(),
+				Method: httpreq.Method,
+
+				Body: e.Request.PostData,
+			}
+			if len(httpreq.Header) > 0 {
+				xhr.Headers = utils.FlattenHeaders(httpreq.Header)
+			} else {
+				xhr.Headers = utils.FlattenHeaders(requestHeaders)
 			}
 			xhrRequests = append(xhrRequests, xhr)
 		}

--- a/pkg/engine/hybrid/crawl.go
+++ b/pkg/engine/hybrid/crawl.go
@@ -116,8 +116,7 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 			xhr := navigation.Request{
 				URL:    httpreq.URL.String(),
 				Method: httpreq.Method,
-
-				Body: e.Request.PostData,
+				Body:   e.Request.PostData,
 			}
 			if len(httpreq.Header) > 0 {
 				xhr.Headers = utils.FlattenHeaders(httpreq.Header)


### PR DESCRIPTION
None of the headers of XHR requests are outputted when performing headless crawls with the `-xhr` flag set:
```
> echo "https://projectdiscovery.io" | katana -silent -d 2 -jsonl -headless -xhr -cs "https://projectdiscovery.io" -ob -or -timeout 30 | jq ".response.xhr_requests"
...
[
  {
    "method": "OPTIONS",
    "endpoint": "https://events.framer.com/anonymous"
  },
  {
    "method": "POST",
    "endpoint": "https://events.framer.com/anonymous",
    "body": "[{\"source\":\"framer.site\",\"timestamp\":1697650690430,\"data\":{\"type\":\"track\",\"uuid\":\"a7dd37e7-62ca-459e-fb2a-0df5891948de\",\"event\":\"published_site_pageview\",\"referrer\":null,\"url\":\"https://projectdiscovery.io/requestdemo\",\"hostname\":\"projectdiscovery.io\",\"pathname\":\"/requestdemo\",\"hash\":null,\"search\":null,\"framerSiteId\":\"70c3acc11c8a46451735095dca225b4de6121e4fabcd9bc18c7f46602f2e8e93\",\"context\":{\"framerSiteId\":\"70c3acc11c8a46451735095dca225b4de6121e4fabcd9bc18c7f46602f2e8e93\",\"origin\":\"https://projectdiscovery.io\",\"pathname\":\"/requestdemo\",\"search\":\"\"}}}]"
  }
]
...
```
The headers will always be `null` because `httpreq.Header` is used (see [here](https://github.com/projectdiscovery/katana/blob/main/pkg/engine/hybrid/crawl.go#L114)), which uses the crawler's headers. Instead, the headers from the fetch request should be used.

Here is the output from running the same command above, but with the changes incorporated in this pull request:
```
> echo "https://projectdiscovery.io" | ./katana -silent -d 2 -jsonl -headless -xhr -cs "https://projectdiscovery.io" -ob -or -timeout 30 | jq ".response.xhr_requests" 
...
[
  {
    "method": "OPTIONS",
    "endpoint": "https://events.framer.com/anonymous",
    "headers": {
      "Access-Control-Request-Method": "POST",
      "Origin": "https://projectdiscovery.io",
      "Referer": "https://projectdiscovery.io/",
      "Sec-Fetch-Mode": "cors",
      "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_0_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36",
      "Accept": "*/*",
      "Access-Control-Request-Headers": "content-type"
    }
  },
  {
    "method": "POST",
    "endpoint": "https://events.framer.com/anonymous",
    "body": "[{\"source\":\"framer.site\",\"timestamp\":1697651222844,\"data\":{\"type\":\"track\",\"uuid\":\"a12c91e3-5b8a-6143-84a2-33352d507261\",\"event\":\"published_site_pageview\",\"referrer\":null,\"url\":\"https://projectdiscovery.io/requestdemo\",\"hostname\":\"projectdiscovery.io\",\"pathname\":\"/requestdemo\",\"hash\":null,\"search\":null,\"framerSiteId\":\"70c3acc11c8a46451735095dca225b4de6121e4fabcd9bc18c7f46602f2e8e93\",\"context\":{\"framerSiteId\":\"70c3acc11c8a46451735095dca225b4de6121e4fabcd9bc18c7f46602f2e8e93\",\"origin\":\"https://projectdiscovery.io\",\"pathname\":\"/requestdemo\",\"search\":\"\"}}}]",
    "headers": {
      "Referer": "https://projectdiscovery.io/",
      "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_0_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36",
      "Accept": "*/*",
      "Accept-Language": "en",
      "Content-Type": "application/json",
      "Origin": "https://projectdiscovery.io"
    }
  }
]
...
```

