### PR TITLE
auto increase depth when `-kf` is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,14 +115,15 @@ Usage:
 Flags:
 INPUT:
    -u, -list string[]  target url / list to crawl
+   -resume string      resume scan using resume.cfg
 
 CONFIGURATION:
    -r, -resolvers string[]       list of custom resolver (file or comma separated)
    -d, -depth int                maximum depth to crawl (default 3)
    -jc, -js-crawl                enable endpoint parsing / crawling in javascript file
-   -jsl, -jsluice                 enable jsluice parsing in javascript file (memory intensive)
+   -jsl, -jsluice                enable jsluice parsing in javascript file (memory intensive)
    -ct, -crawl-duration value    maximum duration to crawl the target for (s, m, h, d) (default s)
-   -kf, -known-files string      enable crawling of known files (all,robotstxt,sitemapxml)
+   -kf, -known-files string      enable crawling of known files (all,robotstxt,sitemapxml), a minimum depth of 3 is required to ensure all known files are properly crawled.
    -mrs, -max-response-size int  maximum response size to read (default 9223372036854775807)
    -timeout int                  time to wait for request in seconds (default 10)
    -aff, -automatic-form-fill    enable automatic form filling (experimental)
@@ -136,6 +137,7 @@ CONFIGURATION:
    -s, -strategy string          Visit strategy (depth-first, breadth-first) (default "depth-first")
    -iqp, -ignore-query-params    Ignore crawling same path with different query-param values
    -tlsi, -tls-impersonate       enable experimental client hello (ja3) tls randomization
+   -dr, -disable-redirects       disable following redirects (default false)
 
 DEBUG:
    -health-check, -hc        run diagnostic check up
@@ -156,7 +158,7 @@ HEADLESS:
 SCOPE:
    -cs, -crawl-scope string[]       in scope url regex to be followed by crawler
    -cos, -crawl-out-scope string[]  out of scope url regex to be excluded by crawler
-   -fs, -field-scope string  pre-defined scope field (dn,rdn,fqdn) or custom regex (e.g., '(company-staging.io|company.com)') (default "rdn")
+   -fs, -field-scope string         pre-defined scope field (dn,rdn,fqdn) or custom regex (e.g., '(company-staging.io|company.com)') (default "rdn")
    -ns, -no-scope                   disables host based default scope
    -do, -display-out-scope          display external endpoint from scoped crawling
 

--- a/cmd/katana/main.go
+++ b/cmd/katana/main.go
@@ -91,7 +91,7 @@ pipelines offering both headless and non-headless crawling.`)
 		flagSet.BoolVarP(&options.ScrapeJSResponses, "js-crawl", "jc", false, "enable endpoint parsing / crawling in javascript file"),
 		flagSet.BoolVarP(&options.ScrapeJSLuiceResponses, "jsluice", "jsl", false, "enable jsluice parsing in javascript file (memory intensive)"),
 		flagSet.DurationVarP(&options.CrawlDuration, "crawl-duration", "ct", 0, "maximum duration to crawl the target for (s, m, h, d) (default s)"),
-		flagSet.StringVarP(&options.KnownFiles, "known-files", "kf", "", "enable crawling of known files (all,robotstxt,sitemapxml)"),
+		flagSet.StringVarP(&options.KnownFiles, "known-files", "kf", "", "enable crawling of known files (all,robotstxt,sitemapxml), a minimum depth of 3 is required to ensure all known files are properly crawled."),
 		flagSet.IntVarP(&options.BodyReadSize, "max-response-size", "mrs", math.MaxInt, "maximum response size to read"),
 		flagSet.IntVar(&options.Timeout, "timeout", 10, "time to wait for request in seconds"),
 		flagSet.BoolVarP(&options.AutomaticFormFill, "automatic-form-fill", "aff", false, "enable automatic form filling (experimental)"),
@@ -182,6 +182,12 @@ pipelines offering both headless and non-headless crawling.`)
 			return nil, errorutil.NewWithErr(err).Msgf("could not read config file")
 		}
 	}
+
+	if options.KnownFiles != "" && options.MaxDepth < 3 {
+		gologger.Info().Msgf("Depth automatically set to 3 to accommodate the `--known-files` option (originally set to %d).", options.MaxDepth)
+		options.MaxDepth = 3
+	}
+
 	cleanupOldResumeFiles()
 	return flagSet, nil
 }

--- a/cmd/katana/main.go
+++ b/cmd/katana/main.go
@@ -183,11 +183,6 @@ pipelines offering both headless and non-headless crawling.`)
 		}
 	}
 
-	if options.KnownFiles != "" && options.MaxDepth < 3 {
-		gologger.Info().Msgf("Depth automatically set to 3 to accommodate the `--known-files` option (originally set to %d).", options.MaxDepth)
-		options.MaxDepth = 3
-	}
-
 	cleanupOldResumeFiles()
 	return flagSet, nil
 }

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -52,6 +52,10 @@ func validateOptions(options *types.Options) error {
 		}
 		options.FilterRegex = append(options.FilterRegex, cr)
 	}
+	if options.KnownFiles != "" && options.MaxDepth < 3 {
+		gologger.Info().Msgf("Depth automatically set to 3 to accommodate the `--known-files` option (originally set to %d).", options.MaxDepth)
+		options.MaxDepth = 3
+	}
 	gologger.DefaultLogger.SetFormatter(formatter.NewCLI(options.NoColors))
 	return nil
 }


### PR DESCRIPTION
```console
$ go run . -u https://remoteadvisor-east1.apple.com/ -hl --system-chrome -xhr-extraction -kf all -depth 2 -aff -s
 breadth-first -iqp -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36" -o 
a.json
[INF] Depth automatically set to 3 to accommodate the `--known-files` option (originally set to 2).

   __        __                
  / /_____ _/ /____ ____  ___ _
 /  '_/ _  / __/ _  / _ \/ _  /
/_/\_\\_,_/\__/\_,_/_//_/\_,_/                                                   

                projectdiscovery.io

[INF] Current katana version v1.0.4 (latest)
[INF] Started headless crawling for => https://remoteadvisor-east1.apple.com/
https://remoteadvisor-east1.apple.com/api/
https://remoteadvisor-east1.apple.com/files/
https://remoteadvisor-east1.apple.com/appliance/
https://remoteadvisor-east1.apple.com/us/search?src=globalnav
https://remoteadvisor-east1.apple.com/content/access_key_input.js
https://www.apple.com/ac/globalfooter/2.0/en_US/scripts/ac-globalfooter.built.js
https://remoteadvisor-east1.apple.com/
https://remoteadvisor-east1.apple.com/api/content/core.js
https://remoteadvisor-east1.apple.com/api/start_session.js
https://remoteadvisor-east1.apple.com/content/portal.js
https://remoteadvisor-east1.apple.com/content/lib/jquery.js
https://remoteadvisor-east1.apple.com/content/common.css
https://remoteadvisor-east1.apple.com/content/public.css
^C[INF] - Ctrl+C pressed in Terminal
http://www.apple.com/ipad/
https://remoteadvisor-east1.apple.com/content/mobile.css
http://www.apple.com/iphone/
http://www.apple.com/support/
http://www.apple.com/music/
https://remoteadvisor-east1.apple.com/content/portal-customizations.css?_c=0
https://remoteadvisor-east1.apple.com/check_access_key?access_key_submit=Submit&access_key_pretty=katana
http://www.apple.com/us/shop/goto/bag
https://remoteadvisor-east1.apple.com/login/
http://www.apple.com
[INF] Creating resume file: /home/vscode/.config/katana/resume-cl57jts3j6edcmukr30g.cfg
```

Closes #641.