### PR TITLE
introduce exclude flag

### DIFF
--- a/cmd/katana/main.go
+++ b/cmd/katana/main.go
@@ -83,6 +83,7 @@ pipelines offering both headless and non-headless crawling.`)
 	flagSet.CreateGroup("input", "Input",
 		flagSet.StringSliceVarP(&options.URLs, "list", "u", nil, "target url / list to crawl", goflags.FileCommaSeparatedStringSliceOptions),
 		flagSet.StringVar(&options.Resume, "resume", "", "resume scan using resume.cfg"),
+		flagSet.StringSliceVarP(&options.Exclude, "exclude", "e", nil, "exclude host matching specified filter ('cdn', 'private-ips', cidr, ip, regex)", goflags.CommaSeparatedStringSliceOptions),
 	)
 
 	flagSet.CreateGroup("config", "Configuration",

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/projectdiscovery/goflags v0.1.33
 	github.com/projectdiscovery/gologger v1.1.12
 	github.com/projectdiscovery/hmap v0.0.34
+	github.com/projectdiscovery/mapcidr v1.1.16
 	github.com/projectdiscovery/ratelimit v0.0.24
 	github.com/projectdiscovery/retryablehttp-go v1.0.42
 	github.com/projectdiscovery/utils v0.0.73
@@ -63,9 +64,9 @@ require (
 	github.com/muesli/termenv v0.15.1 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/pierrec/lz4/v4 v4.1.2 // indirect
+	github.com/projectdiscovery/asnmap v1.0.6 // indirect
 	github.com/projectdiscovery/blackrock v0.0.1 // indirect
 	github.com/projectdiscovery/gostruct v0.0.2 // indirect
-	github.com/projectdiscovery/mapcidr v1.1.16 // indirect
 	github.com/quic-go/quic-go v0.37.7 // indirect
 	github.com/refraction-networking/utls v1.5.4 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
@@ -111,7 +112,7 @@ require (
 	github.com/nwaples/rardecode v1.1.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
-	github.com/projectdiscovery/networkpolicy v0.0.7 // indirect
+	github.com/projectdiscovery/networkpolicy v0.0.7
 	github.com/projectdiscovery/retryabledns v1.0.51 // indirect
 	github.com/saintfish/chardet v0.0.0-20230101081208-5e3ef4b5456d // indirect
 	github.com/syndtr/goleveldb v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -194,6 +194,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/projectdiscovery/asnmap v1.0.6 h1:NZj1hybBf4KF/hMCgJ6E2GXCe60tg5fIRkexEIU+0og=
+github.com/projectdiscovery/asnmap v1.0.6/go.mod h1:cXQjWMgxkl+8A4861Nms9u+ASxQLTb47imJD+AyX+dU=
 github.com/projectdiscovery/blackrock v0.0.1 h1:lHQqhaaEFjgf5WkuItbpeCZv2DUIE45k0VbGJyft6LQ=
 github.com/projectdiscovery/blackrock v0.0.1/go.mod h1:ANUtjDfaVrqB453bzToU+YB4cUbvBRpLvEwoWIwlTss=
 github.com/projectdiscovery/dsl v0.0.36 h1:mOcJcwenwEKfUTI0avJKSHMjGc+xlS5Xs9079AAWGcw=

--- a/internal/runner/executer.go
+++ b/internal/runner/executer.go
@@ -23,6 +23,10 @@ func (r *Runner) ExecuteCrawling() error {
 
 	wg := sizedwaitgroup.New(r.options.Parallelism)
 	for _, input := range inputs {
+		if !r.networkpolicy.Validate(input) {
+			gologger.Info().Msgf("Skipping %s due to network policy", input)
+			continue
+		}
 		wg.Add()
 		input = addSchemeIfNotExists(input)
 		go func(input string) {

--- a/internal/runner/executer.go
+++ b/internal/runner/executer.go
@@ -24,7 +24,7 @@ func (r *Runner) ExecuteCrawling() error {
 	wg := sizedwaitgroup.New(r.options.Parallelism)
 	for _, input := range inputs {
 		if !r.networkpolicy.Validate(input) {
-			gologger.Info().Msgf("Skipping %s due to network policy", input)
+			gologger.Info().Msgf("Skipping excluded host %s", input)
 			continue
 		}
 		wg.Add()

--- a/pkg/types/crawler_options.go
+++ b/pkg/types/crawler_options.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"context"
-	"strconv"
 	"time"
 
 	"github.com/projectdiscovery/fastdialer/fastdialer"
@@ -10,12 +9,8 @@ import (
 	"github.com/projectdiscovery/katana/pkg/utils/extensions"
 	"github.com/projectdiscovery/katana/pkg/utils/filters"
 	"github.com/projectdiscovery/katana/pkg/utils/scope"
-	"github.com/projectdiscovery/mapcidr"
-	"github.com/projectdiscovery/mapcidr/asn"
-	"github.com/projectdiscovery/networkpolicy"
 	"github.com/projectdiscovery/ratelimit"
 	errorutil "github.com/projectdiscovery/utils/errors"
-	iputil "github.com/projectdiscovery/utils/ip"
 	urlutil "github.com/projectdiscovery/utils/url"
 	wappalyzer "github.com/projectdiscovery/wappalyzergo"
 )
@@ -48,29 +43,6 @@ func NewCrawlerOptions(options *Options) (*CrawlerOptions, error) {
 	dialerOpts := fastdialer.DefaultOptions
 	if len(options.Resolvers) > 0 {
 		dialerOpts.BaseResolvers = options.Resolvers
-	}
-	for _, exclude := range options.Exclude {
-		switch {
-		case exclude == "cdn":
-			//implement cdn check in netoworkpolicy pkg??
-			continue
-		case exclude == "private-ips":
-			dialerOpts.Deny = append(dialerOpts.Deny, networkpolicy.DefaultIPv4Denylist...)
-			dialerOpts.Deny = append(dialerOpts.Deny, networkpolicy.DefaultIPv4DenylistRanges...)
-			dialerOpts.Deny = append(dialerOpts.Deny, networkpolicy.DefaultIPv6Denylist...)
-			dialerOpts.Deny = append(dialerOpts.Deny, networkpolicy.DefaultIPv6DenylistRanges...)
-		case iputil.IsCIDR(exclude):
-			dialerOpts.Deny = append(dialerOpts.Deny, exclude)
-		case asn.IsASN(exclude):
-			// update this to use networkpolicy pkg once https://github.com/projectdiscovery/networkpolicy/pull/55 is merged
-			ips := expandASNInputValue(exclude)
-			dialerOpts.Deny = append(dialerOpts.Deny, ips...)
-		case iputil.IsPort(exclude):
-			port, _ := strconv.Atoi(exclude)
-			dialerOpts.DenyPortList = append(dialerOpts.DenyPortList, port)
-		default:
-			dialerOpts.Deny = append(dialerOpts.Deny, exclude)
-		}
 	}
 
 	fastdialerInstance, err := fastdialer.NewDialer(dialerOpts)
@@ -132,24 +104,6 @@ func NewCrawlerOptions(options *Options) (*CrawlerOptions, error) {
 	crawlerOptions.Wappalyzer = wappalyze
 
 	return crawlerOptions, nil
-}
-
-func expandCIDRInputValue(value string) []string {
-	var ips []string
-	ipsCh, _ := mapcidr.IPAddressesAsStream(value)
-	for ip := range ipsCh {
-		ips = append(ips, ip)
-	}
-	return ips
-}
-
-func expandASNInputValue(value string) []string {
-	var ips []string
-	cidrs, _ := asn.GetCIDRsForASNNum(value)
-	for _, cidr := range cidrs {
-		ips = append(ips, expandCIDRInputValue(cidr.String())...)
-	}
-	return ips
 }
 
 // Close closes the crawler options resources

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -18,6 +18,8 @@ type Options struct {
 	URLs goflags.StringSlice
 	// Resume the scan from the state stored in the resume config file
 	Resume string
+	// Exclude host matching specified filter ('cdn', 'private-ips', cidr, ip, regex)
+	Exclude goflags.StringSlice
 	// Scope contains a list of regexes for in-scope URLS
 	Scope goflags.StringSlice
 	// OutOfScope contains a list of regexes for out-scope URLS


### PR DESCRIPTION
Closes #719

```console

$ go run . -exclude 'cdn,private-ips,http://*scanme.sh,443,1.0.0.0/24,https://www.hackerone.com' -u 'http://scanme.sh,127.0.0.1,scanme.sh:443,projectdiscovery.io,example.com,https://www.hackerone.com'

   __        __                
  / /_____ _/ /____ ____  ___ _
 /  '_/ _  / __/ _  / _ \/ _  /
/_/\_\\_,_/\__/\_,_/_//_/\_,_/                                                   

                projectdiscovery.io

[INF] Current katana version v1.0.5 (latest)
[INF] Skipping excluded host http://scanme.sh
[INF] Skipping excluded host 127.0.0.1
[INF] Skipping excluded host scanme.sh:443
[INF] Skipping excluded host https://www.hackerone.com
[INF] Started standard crawling for => https://projectdiscovery.io
[INF] Started standard crawling for => https://example.com
https://projectdiscovery.io
https://example.com
https://projectdiscovery.io/
```

Note: CDN is not excluded. I would like to discuss whether we should add a check for CDN in the network policy package or not.