### PR TITLE
Update formfill.go

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . /app
 RUN go mod download
 RUN go build ./cmd/katana
 
-FROM alpine:3.18.2
+FROM alpine:3.18.5
 RUN apk -U upgrade --no-cache \
     && apk add --no-cache bind-tools ca-certificates chromium
 COPY --from=builder /app/katana /usr/local/bin/

--- a/pkg/utils/formfill.go
+++ b/pkg/utils/formfill.go
@@ -26,7 +26,7 @@ type FormFillData struct {
 }
 
 var DefaultFormFillData = FormFillData{
-	Email:       fmt.Sprintf("%s@katanacrawler.io", xid.New().String()),
+	Email:       fmt.Sprintf("%s@example.org", xid.New().String()),
 	Color:       "#e66465",
 	Password:    "katanaP@assw0rd1",
 	PhoneNumber: "2124567890",


### PR DESCRIPTION
Fix a dangling domain, note that this issue poses no security risk or concern.

example.org is a sink-hole domain, not monitored and administered by ICANN.