### PR TITLE
fix filter and match functionality in lib

### DIFF
--- a/pkg/engine/common/base.go
+++ b/pkg/engine/common/base.go
@@ -108,9 +108,9 @@ func (s *Shared) Output(navigationRequest *navigation.Request, navigationRespons
 		Error:     errData,
 	}
 
-	_ = s.Options.OutputWriter.Write(result)
+	outputErr := s.Options.OutputWriter.Write(result)
 
-	if s.Options.Options.OnResult != nil {
+	if s.Options.Options.OnResult != nil && outputErr == nil {
 		s.Options.Options.OnResult(*result)
 	}
 }

--- a/pkg/types/crawler_options.go
+++ b/pkg/types/crawler_options.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"context"
+	"regexp"
 	"time"
 
 	"github.com/projectdiscovery/fastdialer/fastdialer"
@@ -77,6 +78,22 @@ func NewCrawlerOptions(options *Options) (*CrawlerOptions, error) {
 		OutputMatchCondition:  options.OutputMatchCondition,
 		OutputFilterCondition: options.OutputFilterCondition,
 	}
+
+	for _, mr := range options.OutputMatchRegex {
+		cr, err := regexp.Compile(mr)
+		if err != nil {
+			return nil, errorutil.NewWithErr(err).Msgf("Invalid value for match regex option")
+		}
+		outputOptions.MatchRegex = append(outputOptions.MatchRegex, cr)
+	}
+	for _, fr := range options.OutputFilterRegex {
+		cr, err := regexp.Compile(fr)
+		if err != nil {
+			return nil, errorutil.NewWithErr(err).Msgf("Invalid value for filter regex option")
+		}
+		outputOptions.FilterRegex = append(outputOptions.FilterRegex, cr)
+	}
+
 	outputWriter, err := output.New(outputOptions)
 	if err != nil {
 		return nil, errorutil.NewWithErr(err).Msgf("could not create output writer")


### PR DESCRIPTION
Closes #716

```go
package main

import (
	"math"

	"github.com/projectdiscovery/gologger"
	"github.com/projectdiscovery/gologger/levels"
	"github.com/projectdiscovery/katana/pkg/engine/standard"
	"github.com/projectdiscovery/katana/pkg/output"
	"github.com/projectdiscovery/katana/pkg/types"
)

func main() {
	gologger.DefaultLogger.SetMaxLevel(levels.LevelSilent)

	options := &types.Options{
		MaxDepth:         3,           // Maximum depth to crawl
		FieldScope:       "rdn",       // Crawling Scope Field
		BodyReadSize:     math.MaxInt, // Maximum response size to read
		Timeout:          10,          // Timeout is the time to wait for request in seconds
		Concurrency:      10,          // Concurrency is the number of concurrent crawling goroutines
		OutputMatchRegex: []string{"policies"},
		Parallelism:      10,            // Parallelism is the number of urls processing goroutines
		Delay:            0,             // Delay is the delay between each crawl requests in seconds
		RateLimit:        150,           // Maximum requests to send per second
		Strategy:         "depth-first", // Visit strategy (depth-first, breadth-first)
		OnResult: func(result output.Result) { // Callback function to execute for result
			gologger.Info().Msg(result.Request.URL)
		},
	}
	crawlerOptions, err := types.NewCrawlerOptions(options)
	if err != nil {
		gologger.Fatal().Msg(err.Error())
	}
	defer crawlerOptions.Close()
	crawler, err := standard.New(crawlerOptions)
	if err != nil {
		gologger.Fatal().Msg(err.Error())
	}
	defer crawler.Close()
	var input = "https://www.hackerone.com"
	err = crawler.Crawl(input)
	if err != nil {
		gologger.Warning().Msgf("Could not crawl %s: %s", input, err.Error())
	}
}

```


```console
$ go run .
https://www.hackerone.com/policies
https://www.hackerone.com/policies/employee-participation
https://www.hackerone.com/policies/community-code-of-conduct
https://www.hackerone.com/policies/faq
https://www.hackerone.com/policies/live-hacking-roe
https://www.hackerone.com/policies/clear-rules-of-engagement
https://www.hackerone.com/policies/pentest-rules-of-engagement
https://www.hackerone.com/policies/code-of-conduct
```