### PR TITLE
Update jsluice.go

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . /app
 RUN go mod download
 RUN go build ./cmd/katana
 
-FROM alpine:3.18.2
+FROM alpine:3.18.5
 RUN apk -U upgrade --no-cache \
     && apk add --no-cache bind-tools ca-certificates chromium
 COPY --from=builder /app/katana /usr/local/bin/

--- a/pkg/utils/jsluice.go
+++ b/pkg/utils/jsluice.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// CommonJSLibraryFileRegex is a regex to match common js library files.
-	CommonJSLibraryFileRegex         = `(?:amplify|quantserve|slideshow|jquery|modernizr|polyfill|vendor|modules|gtm|underscor|tween|retina|selectivizr|cufon|underscore|angular|swf|sha1|freestyle|jquery|bootstrap|modernizr|d3|backbone|videojs|google_analytics|material|redux|knockout|datepicker|datetimepicker|ember|react|ng|angular|fusion|analytics|lib|libs|vendor|vendors|node_modules)([-._][\w\d]*)*\.js$`
+	CommonJSLibraryFileRegex         = `(?i)(?:amplify|quantserve|slideshow|jquery|modernizr|polyfill|vendor|modules|gtm|underscore?|tween|retina|selectivizr|cufon|angular|swf|sha1|freestyle|bootstrap|d3|backbone|videojs|google[-_]analytics|material|redux|knockout|datepicker|datetimepicker|ember|react|ng|fusion|analytics|libs?|vendors?|node[-_]modules|lodash|moment|chart|highcharts|raphael|prototype|mootools|dojo|ext|yui|web[-_]?components|polymer|vue|svelte|next|nuxt|gatsby|express|koa|hapi|socket[-_.]?io|axios|superagent|request|bluebird|rxjs|ramda|immutable|flux|redux[-_]saga|mobx|relay|apollo|graphql|three|phaser|pixi|babylon|cannon|hammer|howler|gsap|velocity|mo[-_.]?js|popper|shepherd|prism|highlight|markdown[-_]?it|codemirror|ace[-_]?editor|tinymce|ckeditor|quill|simplemde|monaco[-_]?editor|pdf[-_.]?js|jspdf|fabric|paper|konva|p5|processing|matter[-_.]?js|box2d|planck)(?:[-._][\w\d]*)*\.js$`
 	commonJSLibraryFileRegexCompiled = regexp.MustCompile(CommonJSLibraryFileRegex)
 )
 


### PR DESCRIPTION
The following libraries have been added to the regular expression:

- Lodash
- Moment.js
- Chart.js
- Highcharts
- Raphael
- Prototype
- MooTools
- Dojo Toolkit
- Ext JS
- YUI (Yahoo User Interface)
- Web Components
- Polymer
- Vue.js
- Svelte
- Next.js
- Nuxt.js
- Gatsby
- Express
- Koa
- Hapi
- Socket.io
- Axios
- SuperAgent
- Request
- Bluebird
- RxJS
- Ramda
- Immutable.js
- Flux
- Redux Saga
- MobX
- Relay
- Apollo
- GraphQL
- Three.js
- Phaser
- PixiJS
- Babylon.js
- Cannon.js
- Hammer.js
- Howler.js
- GSAP (GreenSock Animation Platform)
- Velocity.js
- Mo.js
- Popper.js
- Shepherd
- Prism
- Highlight.js
- Markdown-it
- CodeMirror
- Ace Editor
- TinyMCE
- CKEditor
- Quill
- SimpleMDE
- Monaco Editor
- PDF.js
- jsPDF
- Fabric.js
- Paper.js
- Konva
- p5.js
- Processing.js
- Matter.js
- Box2D
- Planck.js