### PR TITLE
Upgrade alpine to 3.18.6 for security fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . /app
 RUN go mod download
 RUN go build ./cmd/katana
 
-FROM alpine:3.18.5
+FROM alpine:3.18.6
 RUN apk -U upgrade --no-cache \
     && apk add --no-cache bind-tools ca-certificates chromium
 COPY --from=builder /app/katana /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . /app
 RUN go mod download
 RUN go build ./cmd/katana
 
-FROM alpine:3.18.2
+FROM alpine:3.18.5
 RUN apk -U upgrade --no-cache \
     && apk add --no-cache bind-tools ca-certificates chromium
 COPY --from=builder /app/katana /usr/local/bin/


### PR DESCRIPTION
The following vulnerabilities are fixed with an upgrade:
- https://security.alpinelinux.org/vuln/CVE-2023-6129
- https://security.alpinelinux.org/vuln/CVE-2023-6237
- https://security.alpinelinux.org/vuln/CVE-2024-0727