### PR TITLE
fix stats

### DIFF
--- a/pkg/engine/passive/passive.go
+++ b/pkg/engine/passive/passive.go
@@ -104,6 +104,11 @@ func (c *Crawler) Crawl(rootURL string) error {
 			continue
 		}
 
+		if !c.Options.ExtensionsValidator.ValidatePath(result.Value) {
+			gologger.Debug().Msgf("`%v` not allowed extension. skipping", result.Value)
+			continue
+		}
+
 		seenURLs[result.Value] = struct{}{}
 		sourceStats[result.Source]++
 


### PR DESCRIPTION
Closes #816

``` console
$ go run . -u hackerone.com -passive -o output.txt
...
[INF] Found 172471 endpoints for https://hackerone.com in 47.809113166s (alienvault: 50, commoncrawl: 12817, waybackarchive: 159604)

$ grep -cve '^$' output.txt                       
172471
```