### PR TITLE
Added Missed Flag of New Feature ( -e ) in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Flags:
 INPUT:
    -u, -list string[]  target url / list to crawl
    -resume string      resume scan using resume.cfg
+   -e, -exclude string[]  exclude host matching specified filter ('cdn', 'private-ips', cidr, ip, regex)
 
 CONFIGURATION:
    -r, -resolvers string[]       list of custom resolver (file or comma separated)


### PR DESCRIPTION
* Update README.md - Added missed flag of new feature ( `-e` ) introduced via [katana v1.1.0](https://github.com/projectdiscovery/katana/releases/tag/v1.1.0)