### PR TITLE
introduce incremental crawling

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ CONFIGURATION:
    -iqp, -ignore-query-params    Ignore crawling same path with different query-param values
    -tlsi, -tls-impersonate       enable experimental client hello (ja3) tls randomization
    -dr, -disable-redirects       disable following redirects (default false)
+   -ic, -incremental crawling    enable incremental crawling (default false)
 
 DEBUG:
    -health-check, -hc        run diagnostic check up

--- a/cmd/katana/main.go
+++ b/cmd/katana/main.go
@@ -54,10 +54,18 @@ func main() {
 			gologger.DefaultLogger.Info().Msg("- Ctrl+C pressed in Terminal")
 			katanaRunner.Close()
 
-			gologger.Info().Msgf("Creating resume file: %s\n", resumeFilename)
-			err := katanaRunner.SaveState(resumeFilename)
-			if err != nil {
-				gologger.Error().Msgf("Couldn't create resume file: %s\n", err)
+			if options.IncrementalCrawling {
+				gologger.Info().Msgf("Creating incremental crawling state file: %s\n", runner.IncrementalCrawlingStateFilename())
+				err := katanaRunner.SaveState(runner.IncrementalCrawlingStateFilename())
+				if err != nil {
+					gologger.Error().Msgf("Couldn't create incremental crawling state file: %s\n", err)
+				}
+			} else {
+				gologger.Info().Msgf("Creating resume file: %s\n", resumeFilename)
+				err := katanaRunner.SaveState(resumeFilename)
+				if err != nil {
+					gologger.Error().Msgf("Couldn't create resume file: %s\n", err)
+				}
 			}
 
 			os.Exit(0)
@@ -107,6 +115,7 @@ pipelines offering both headless and non-headless crawling.`)
 		flagSet.BoolVarP(&options.IgnoreQueryParams, "ignore-query-params", "iqp", false, "Ignore crawling same path with different query-param values"),
 		flagSet.BoolVarP(&options.TlsImpersonate, "tls-impersonate", "tlsi", false, "enable experimental client hello (ja3) tls randomization"),
 		flagSet.BoolVarP(&options.DisableRedirects, "disable-redirects", "dr", false, "disable following redirects (default false)"),
+		flagSet.BoolVarP(&options.IncrementalCrawling, "incremental crawling", "ic", false, "enable incremental crawling (default false)"),
 	)
 
 	flagSet.CreateGroup("debug", "Debug",

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -25,6 +25,10 @@ func validateOptions(options *types.Options) error {
 		return errorutil.New("no inputs specified for crawler")
 	}
 
+	if options.IncrementalCrawling && options.Resume != "" {
+		return errorutil.New("incremental crawling and resume cannot be used together")
+	}
+
 	if options.Headless && options.Passive {
 		return errorutil.New("headless mode (-headless) and passive mode (-passive) cannot be used together")
 	}
@@ -99,6 +103,10 @@ func (r *Runner) parseInputs() []string {
 	}
 	final := make([]string, 0, len(values))
 	for k := range values {
+		if r.state.CrawledURLs.Has(utils.AddSchemeIfNotExists(k)) {
+			gologger.Debug().Msgf("Skipping already crawled URL %s", k)
+			continue
+		}
 		final = append(final, k)
 	}
 	return final

--- a/pkg/output/options.go
+++ b/pkg/output/options.go
@@ -25,4 +25,5 @@ type Options struct {
 	ExtensionValidator    *extensions.Validator
 	OutputMatchCondition  string
 	OutputFilterCondition string
+	IncrementalCrawling   bool
 }

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -117,12 +117,14 @@ func New(options Options) (Writer, error) {
 		if options.StoreResponseDir != DefaultResponseDir && options.StoreResponseDir != "" {
 			writer.storeResponseDir = options.StoreResponseDir
 		}
-		_ = os.RemoveAll(writer.storeResponseDir)
-		_ = os.MkdirAll(writer.storeResponseDir, os.ModePerm)
-		// todo: the index file seems never used?
-		_, err := newFileOutputWriter(filepath.Join(writer.storeResponseDir, indexFile))
-		if err != nil {
-			return nil, errorutil.NewWithTag("output", "could not create index file").Wrap(err)
+		if !options.IncrementalCrawling {
+			_ = os.RemoveAll(writer.storeResponseDir)
+			_ = os.MkdirAll(writer.storeResponseDir, os.ModePerm)
+			// todo: the index file seems never used?
+			_, err := newFileOutputWriter(filepath.Join(writer.storeResponseDir, indexFile))
+			if err != nil {
+				return nil, errorutil.NewWithTag("output", "could not create index file").Wrap(err)
+			}
 		}
 	}
 	if options.ErrorLogFile != "" {

--- a/pkg/types/crawler_options.go
+++ b/pkg/types/crawler_options.go
@@ -81,6 +81,7 @@ func NewCrawlerOptions(options *Options) (*CrawlerOptions, error) {
 		ExtensionValidator:    extensionsValidator,
 		OutputMatchCondition:  options.OutputMatchCondition,
 		OutputFilterCondition: options.OutputFilterCondition,
+		IncrementalCrawling:   options.IncrementalCrawling,
 	}
 
 	for _, mr := range options.OutputMatchRegex {

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -152,6 +152,8 @@ type Options struct {
 	TlsImpersonate bool
 	//DisableRedirects disables the following of redirects
 	DisableRedirects bool
+	// IncrementalCrawling enables incremental crawling
+	IncrementalCrawling bool
 }
 
 func (options *Options) ParseCustomHeaders() map[string]string {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -90,3 +90,21 @@ func ReplaceAllQueryParam(reqUrl, val string) string {
 	u.RawQuery = params.Encode()
 	return u.String()
 }
+
+// scheme less urls are skipped and are required for headless mode and other purposes
+// this method adds scheme if given input does not have any
+func AddSchemeIfNotExists(inputURL string) string {
+	if strings.HasPrefix(inputURL, urlutil.HTTP) || strings.HasPrefix(inputURL, urlutil.HTTPS) {
+		return inputURL
+	}
+	parsed, err := urlutil.Parse(inputURL)
+	if err != nil {
+		gologger.Warning().Msgf("input %v is not a valid url got %v", inputURL, err)
+		return inputURL
+	}
+	if parsed.Port() != "" && (parsed.Port() == "80" || parsed.Port() == "8080") {
+		return urlutil.HTTP + urlutil.SchemeSeparator + inputURL
+	} else {
+		return urlutil.HTTPS + urlutil.SchemeSeparator + inputURL
+	}
+}


### PR DESCRIPTION
Closes  #749

```console
$ cat url.list 
hackerone.com
scanme.sh
projectdiscovery.io

$ go run . -u url.list -ic -sr -debug
[INF] Resuming incremental crawling from save checkpoint

   __        __                
  / /_____ _/ /____ ____  ___ _
 /  '_/ _  / __/ _  / _ \/ _  /
/_/\_\\_,_/\__/\_,_/_//_/\_,_/                                                   

                projectdiscovery.io

[INF] Current katana version v1.1.0 (latest)
[INF] Incremental crawling enabled
[DBG] Skipping already crawled URL scanme.sh
[INF] Started standard crawling for => https://hackerone.com
[INF] Started standard crawling for => https://projectdiscovery.io
https://www.hackerone.com/
https://hackerone.com
^C[INF] - Ctrl+C pressed in Terminal
[INF] Creating incremental crawling state file: /Users/dogancanbakir/.config/katana/incremental_crawling_state
```