### PR TITLE
add urlscan as a passive source

### DIFF
--- a/pkg/engine/passive/registry.go
+++ b/pkg/engine/passive/registry.go
@@ -4,6 +4,7 @@ import (
 	"github.com/projectdiscovery/katana/pkg/engine/passive/source"
 	"github.com/projectdiscovery/katana/pkg/engine/passive/source/alienvault"
 	"github.com/projectdiscovery/katana/pkg/engine/passive/source/commoncrawl"
+	"github.com/projectdiscovery/katana/pkg/engine/passive/source/urlscan"
 	"github.com/projectdiscovery/katana/pkg/engine/passive/source/waybackarchive"
 )
 
@@ -11,4 +12,5 @@ var Sources = map[string]source.Source{
 	"waybackarchive": &waybackarchive.Source{},
 	"commoncrawl":    &commoncrawl.Source{},
 	"alienvault":     &alienvault.Source{},
+	"urlscan":        &urlscan.Source{},
 }

--- a/pkg/engine/passive/source/urlscan/urlscan.go
+++ b/pkg/engine/passive/source/urlscan/urlscan.go
@@ -1,0 +1,109 @@
+package urlscan
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/projectdiscovery/katana/pkg/engine/common"
+	"github.com/projectdiscovery/katana/pkg/engine/passive/httpclient"
+	"github.com/projectdiscovery/katana/pkg/engine/passive/source"
+	urlutil "github.com/projectdiscovery/utils/url"
+)
+
+type response struct {
+	Results []Result `json:"results"`
+	HasMore bool     `json:"has_more"`
+}
+
+type Result struct {
+	Page Page          `json:"page"`
+	Sort []interface{} `json:"sort"`
+}
+
+type Page struct {
+	Url string `json:"url"`
+}
+
+type Source struct {
+	apiKeys []string
+}
+
+func (s *Source) Run(ctx context.Context, sharedCtx *common.Shared, rootUrl string) <-chan source.Result {
+	results := make(chan source.Result)
+
+	go func() {
+		defer close(results)
+
+		if parsedRootUrl, err := urlutil.Parse(rootUrl); err == nil {
+			rootUrl = parsedRootUrl.Hostname()
+		}
+		httpClient := httpclient.NewHttpClient(sharedCtx.Options.Options.Timeout)
+
+		randomApiKey := source.PickRandom(s.apiKeys, s.Name())
+		if randomApiKey == "" {
+			return
+		}
+
+		var searchAfter string
+		hasMore := true
+		headers := map[string]string{"API-Key": randomApiKey}
+		apiURL := fmt.Sprintf("https://urlscan.io/api/v1/search/?q=domain:%s&size=10000", rootUrl)
+		for hasMore {
+			if searchAfter != "" {
+				apiURL = fmt.Sprintf("%s&search_after=%s", apiURL, searchAfter)
+			}
+
+			resp, err := httpClient.Get(ctx, apiURL, "", headers)
+			if err != nil {
+				results <- source.Result{Source: s.Name(), Error: err}
+				httpClient.DiscardHTTPResponse(resp)
+				return
+			}
+
+			var data response
+			err = jsoniter.NewDecoder(resp.Body).Decode(&data)
+			if err != nil {
+				results <- source.Result{Source: s.Name(), Error: err}
+				resp.Body.Close()
+				return
+			}
+			resp.Body.Close()
+
+			if resp.StatusCode == http.StatusTooManyRequests {
+				results <- source.Result{Source: s.Name(), Error: fmt.Errorf("urlscan rate limited")}
+				return
+			}
+
+			for _, url := range data.Results {
+				results <- source.Result{Source: s.Name(), Value: url.Page.Url, Reference: apiURL}
+			}
+			if len(data.Results) > 0 {
+				lastResult := data.Results[len(data.Results)-1]
+				if len(lastResult.Sort) > 0 {
+					sort1 := strconv.Itoa(int(lastResult.Sort[0].(float64)))
+					sort2, _ := lastResult.Sort[1].(string)
+
+					searchAfter = fmt.Sprintf("%s,%s", sort1, sort2)
+				}
+			}
+			hasMore = data.HasMore
+		}
+	}()
+
+	return results
+}
+
+func (s *Source) Name() string {
+	return "urlscan"
+}
+
+func (s *Source) NeedsKey() bool {
+	return true
+}
+
+func (s *Source) AddApiKeys(keys []string) {
+	s.apiKeys = keys
+}

--- a/pkg/engine/passive/source/utils.go
+++ b/pkg/engine/passive/source/utils.go
@@ -1,0 +1,42 @@
+package source
+
+import (
+	"math/rand"
+	"strings"
+
+	"github.com/projectdiscovery/gologger"
+)
+
+const MultipleKeyPartsLength = 2
+
+func PickRandom[T any](v []T, sourceName string) T {
+	var result T
+	length := len(v)
+	if length == 0 {
+		gologger.Debug().Msgf("Cannot use the %s source because there was no API key/secret defined for it.", sourceName)
+		return result
+	}
+	return v[rand.Intn(length)]
+}
+
+func CreateApiKeys[T any](keys []string, provider func(k, v string) T) []T {
+	var result []T
+	for _, key := range keys {
+		if keyPartA, keyPartB, ok := createMultiPartKey(key); ok {
+			result = append(result, provider(keyPartA, keyPartB))
+		}
+	}
+	return result
+}
+
+func createMultiPartKey(key string) (keyPartA, keyPartB string, ok bool) {
+	parts := strings.Split(key, ":")
+	ok = len(parts) == MultipleKeyPartsLength
+
+	if ok {
+		keyPartA = parts[0]
+		keyPartB = parts[1]
+	}
+
+	return
+}

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -152,6 +152,8 @@ type Options struct {
 	TlsImpersonate bool
 	//DisableRedirects disables the following of redirects
 	DisableRedirects bool
+	// PassiveProviderConfig is the path to the passive provider configuration file
+	PassiveProviderConfig string
 }
 
 func (options *Options) ParseCustomHeaders() map[string]string {


### PR DESCRIPTION
Closes #842

```console
$ go run . -u hackerone.com -ps -pss urlscan

   __        __                
  / /_____ _/ /____ ____  ___ _
 /  '_/ _  / __/ _  / _ \/ _  /
/_/\_\\_,_/\__/\_,_/_//_/\_,_/                                                   

                projectdiscovery.io

[INF] Current katana version v1.1.0 (latest)
[INF] Loading provider config from /Users/dogancanbakir/Library/Application Support/katana/passive-providers-config.yaml
[INF] Enumerating passive endpoints for https://hackerone.com
https://docs.hackerone.com/en/articles/8404308-hacker-email-alias
https://www.hackerone.com/
https://hackerone.com/zxwo
https://hackerone.com/reports/898841
https://hackerone.com/reports/411337
...
[INF] Found 472 endpoints for https://hackerone.com in 652.030917ms (urlscan: 472)
```