### PR TITLE
fix header marshalling

### DIFF
--- a/pkg/navigation/response.go
+++ b/pkg/navigation/response.go
@@ -20,7 +20,7 @@ type Form struct {
 func (h *Headers) MarshalJSON() ([]byte, error) {
 	hCopy := make(Headers)
 	for k, v := range *h {
-		k := strings.ReplaceAll(strings.ToLower(k), "-", "_")
+		k := strings.ToLower(k)
 		hCopy[k] = v
 	}
 	return jsoniter.Marshal(hCopy)


### PR DESCRIPTION
Closes #922

```console
$ go run . -u scanme.sh -j | jq

   __        __                
  / /_____ _/ /____ ____  ___ _
 /  '_/ _  / __/ _  / _ \/ _  /
/_/\_\\_,_/\__/\_,_/_//_/\_,_/                                                   

                projectdiscovery.io

[INF] Current katana version v1.1.0 (latest)
[INF] Started standard crawling for => https://scanme.sh
{
  "timestamp": "2024-06-07T13:49:57.458764+03:00",
  "request": {
    "method": "GET",
    "endpoint": "https://scanme.sh",
    "raw": "GET / HTTP/1.1\r\nHost: scanme.sh\r\nUser-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36\r\nAccept-Encoding: gzip\r\n\r\n"
  },
  "response": {
    "status_code": 200,
    "headers": {
      "content-type": "text/plain; charset=utf-8",
      "date": "Fri, 07 Jun 2024 10:49:57 GMT",
      "content-length": "2"
    },
    "body": "ok",
    "raw": "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Fri, 07 Jun 2024 10:49:57 GMT\r\n\r\nok"
  }
}
```