### PR TITLE
New way to add headers for hybrid request output

### DIFF
--- a/pkg/engine/hybrid/crawl.go
+++ b/pkg/engine/hybrid/crawl.go
@@ -74,9 +74,11 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 		}
 		// Note: headers are originally sent using `c.addHeadersToPage` below changes are done so that
 		// headers are reflected in request dump
+		// Headers, CustomHeaders, and Cookies are present in e.Request.Headers. We need to consider all of them and not only CustomHeaders
+		// Otherwise, we will miss headers and output will be inconsistent
 		if httpreq != nil {
-			for k, v := range c.Headers {
-				httpreq.Header.Set(k, v)
+			for k, v := range e.Request.Headers {
+				httpreq.Header.Set(k, v.String())
 			}
 		}
 


### PR DESCRIPTION
Based on #930

We crawl an endpoint
The request sent by the hybrid engine is according to the proxy : 
<img width="617" alt="Capture d’écran 2024-06-18 à 12 00 11" src="https://github.com/projectdiscovery/katana/assets/159776828/b8d78e8d-354e-47b0-87c8-cbb82f1182dc">

Current output: 
<img width="1024" alt="Capture d’écran 2024-06-18 à 11 59 40" src="https://github.com/projectdiscovery/katana/assets/159776828/f8771a17-4834-4a4f-9278-1cd2bfe849c4">

Based on Custom Headers and GO httpreq only

With my PR:
<img width="1200" alt="Capture d’écran 2024-06-18 à 12 06 47" src="https://github.com/projectdiscovery/katana/assets/159776828/c45bf52e-a142-487a-bfb6-0ab54253aedb">

Based on the hijacked request detected by the hybrid engine
