### PR TITLE
no need for browser.close()

### DIFF
--- a/pkg/engine/hybrid/hybrid.go
+++ b/pkg/engine/hybrid/hybrid.go
@@ -96,11 +96,6 @@ func New(options *types.CrawlerOptions) (*Crawler, error) {
 
 // Close closes the crawler process
 func (c *Crawler) Close() error {
-	if c.Options.Options.ChromeWSUrl == "" {
-		if err := c.browser.Close(); err != nil {
-			return err
-		}
-	}
 	if c.Options.Options.ChromeDataDir == "" {
 		if err := os.RemoveAll(c.tempDir); err != nil {
 			return err


### PR DESCRIPTION
When the katana process exits, rod will automatically kill the browser process. (https://github.com/go-rod/rod/issues/550#issuecomment-1064650720)

Moreover, when using non-headless mode (`-sb`), even if `Ctrl-c` is pressed, the katana will hang on `browser.close()` until the scraping is complete, preventing the process from terminating.

Close #978