### PR TITLE
Add a parser to get endpoints from htmx attributes

### DIFF
--- a/pkg/engine/parser/parser.go
+++ b/pkg/engine/parser/parser.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"mime/multipart"
+	"net/http"
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
@@ -611,30 +612,26 @@ func bodyHtmxAttrParser(resp *navigation.Response) (navigationRequests []*naviga
 			Tag:          "htmx",
 		}
 
-		hxGet, ok := item.Attr("hx-get")
-		if ok && hxGet != "" {
-			req.Method = "GET"
+		if hxGet, ok := item.Attr("hx-get"); ok && hxGet != "" {
+			req.Method = http.MethodGet
 			req.URL = resp.AbsoluteURL(hxGet)
 			req.Attribute = "hx-get"
 			navigationRequests = append(navigationRequests, req)
 		}
-		hxPost, ok := item.Attr(("hx-post"))
-		if ok && hxPost != "" {
-			req.Method = "POST"
+		if hxPost, ok := item.Attr(("hx-post")); ok && hxPost != "" {
+			req.Method = http.MethodPost
 			req.URL = resp.AbsoluteURL(hxPost)
 			req.Attribute = "hx-post"
 			navigationRequests = append(navigationRequests, req)
 		}
-		hxPut, ok := item.Attr(("hx-put"))
-		if ok && hxPut != "" {
-			req.Method = "PUT"
+		if hxPut, ok := item.Attr(("hx-put")); ok && hxPut != "" {
+			req.Method = http.MethodPut
 			req.URL = resp.AbsoluteURL(hxPut)
 			req.Attribute = "hx-put"
 			navigationRequests = append(navigationRequests, req)
 		}
-		hxPatch, ok := item.Attr(("hx-patch"))
-		if ok && hxPatch != "" {
-			req.Method = "PATCH"
+		if hxPatch, ok := item.Attr(("hx-patch")); ok && hxPatch != "" {
+			req.Method = http.MethodPatch
 			req.URL = resp.AbsoluteURL(hxPatch)
 			req.Attribute = "hx-patch"
 			navigationRequests = append(navigationRequests, req)

--- a/pkg/engine/parser/parser_test.go
+++ b/pkg/engine/parser/parser_test.go
@@ -489,3 +489,37 @@ func TestRegexBodyParsers(t *testing.T) {
 		require.Equal(t, requireFields, navigationRequests[0].CustomFields, "could not get correct url")
 	})
 }
+
+func TestHtmxBodyParser(t *testing.T) {
+	parsed, _ := urlutil.Parse("https://htmx.org/examples/")
+
+	t.Run("hx-get", func(t *testing.T) {
+		documentReader, _ := goquery.NewDocumentFromReader(strings.NewReader(`<button hx-get="/contact/1/edit" class="btn primary">Click To Edit</button>`))
+		resp := &navigation.Response{Resp: &http.Response{Request: &http.Request{URL: parsed.URL}}, Reader: documentReader}
+		navigationRequests := bodyHtmxAttrParser(resp)
+		require.Equal(t, "https://htmx.org/contact/1/edit", navigationRequests[0].URL, "could not get correct url")
+		require.Equal(t, "GET", navigationRequests[0].Method, "could not get correct method")
+	})
+	t.Run("hx-post", func(t *testing.T) {
+		documentReader, _ := goquery.NewDocumentFromReader(strings.NewReader(`<form id="checked-contacts" hx-post="/users" hx-swap="outerHTML settle:3s" hx-target="#toast">`))
+		resp := &navigation.Response{Resp: &http.Response{Request: &http.Request{URL: parsed.URL}}, Reader: documentReader}
+		navigationRequests := bodyHtmxAttrParser(resp)
+		require.Equal(t, "https://htmx.org/users", navigationRequests[0].URL, "could not get correct url")
+		require.Equal(t, "POST", navigationRequests[0].Method, "could not get correct method")
+	})
+	t.Run("hx-put", func(t *testing.T) {
+		documentReader, _ := goquery.NewDocumentFromReader(strings.NewReader(`<button hx-put="/account" hx-target="body">`))
+		resp := &navigation.Response{Resp: &http.Response{Request: &http.Request{URL: parsed.URL}}, Reader: documentReader}
+		navigationRequests := bodyHtmxAttrParser(resp)
+		require.Equal(t, "https://htmx.org/account", navigationRequests[0].URL, "could not get correct url")
+		require.Equal(t, "PUT", navigationRequests[0].Method, "could not get correct method")
+
+	})
+	t.Run("hx-patch", func(t *testing.T) {
+		documentReader, _ := goquery.NewDocumentFromReader(strings.NewReader(`<button hx-patch="/account" hx-target="body">`))
+		resp := &navigation.Response{Resp: &http.Response{Request: &http.Request{URL: parsed.URL}}, Reader: documentReader}
+		navigationRequests := bodyHtmxAttrParser(resp)
+		require.Equal(t, "https://htmx.org/account", navigationRequests[0].URL, "could not get correct url")
+		require.Equal(t, "PATCH", navigationRequests[0].Method, "could not get correct method")
+	})
+}


### PR DESCRIPTION
close #1023

At the moment, it just extracts endpoints from `hx-*` attributes. Next, we could think about adding features like automatic parameter filling.