### PR TITLE
use "custom" to represent all custom fields

### DIFF
--- a/pkg/output/custom_field.go
+++ b/pkg/output/custom_field.go
@@ -110,9 +110,13 @@ func loadCustomFields(filePath string, fields string) error {
 		allCustomFields[item.Name] = item
 	}
 	// Set the passed custom field value globally
-	for _, f := range stringsutil.SplitAny(fields, ",") {
-		if val, ok := allCustomFields[f]; ok {
-			CustomFieldsMap[f] = val
+	if fieldSlice := stringsutil.SplitAny(fields, ","); sliceutil.Contains(fieldSlice, "custom") {
+		CustomFieldsMap = allCustomFields
+	} else {
+		for _, f := range fieldSlice {
+			if val, ok := allCustomFields[f]; ok {
+				CustomFieldsMap[f] = val
+			}
 		}
 	}
 	return nil

--- a/pkg/output/fields.go
+++ b/pkg/output/fields.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/projectdiscovery/gologger"
 	errorutil "github.com/projectdiscovery/utils/errors"
+	mapsutil "github.com/projectdiscovery/utils/maps"
+	sliceutil "github.com/projectdiscovery/utils/slice"
 	stringsutil "github.com/projectdiscovery/utils/strings"
 	urlutil "github.com/projectdiscovery/utils/url"
 	"golang.org/x/net/publicsuffix"
@@ -30,6 +32,7 @@ var FieldNames = []string{
 	"kv",
 	"dir",
 	"udir",
+	"custom",
 }
 
 type fieldOutput struct {
@@ -65,6 +68,10 @@ func storeFields(output *Result, storeFields []string) {
 	if err != nil {
 		gologger.Warning().Msgf("storeFields: failed to parse url %v got %v", output.Request.URL, err)
 		return
+	}
+
+	if sliceutil.Contains(storeFields, "custom") {
+		storeFields = sliceutil.Merge(storeFields, mapsutil.GetKeys(CustomFieldsMap))
 	}
 
 	hostname := parsed.Hostname()


### PR DESCRIPTION
There's no need to specify custom fields individually when there are too many.