### PR TITLE
update 1.23.1-alpine3.20 + GO111MODULE=on

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
-FROM golang:1.20.6-alpine AS builder
+FROM golang:1.23.1-alpine3.20 AS builder
 RUN apk add --no-cache git gcc musl-dev
 WORKDIR /app
 COPY . /app
 RUN go mod download
-RUN go build ./cmd/katana
+RUN GO111MODULE=on go build -o katana ./cmd/katana/main.go
 
 FROM alpine:3.18.5
-RUN apk -U upgrade --no-cache \
-    && apk add --no-cache bind-tools ca-certificates chromium
+RUN apk add --no-cache bind-tools ca-certificates chromium
 COPY --from=builder /app/katana /usr/local/bin/
 
 ENTRYPOINT ["katana"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.23.1-alpine3.20 AS builder
+FROM golang:1.21-alpine AS build-env
 RUN apk add --no-cache git gcc musl-dev
 WORKDIR /app
 COPY . /app
 RUN go mod download
-RUN GO111MODULE=on go build -o katana ./cmd/katana/main.go
+RUN go build ./cmd/katana
 
 FROM alpine:3.18.5
 RUN apk add --no-cache bind-tools ca-certificates chromium


### PR DESCRIPTION
Build Error --
github.com/projectdiscovery/fastdialer/fastdialer/metafiles
/go/pkg/mod/github.com/projectdiscovery/fastdialer@v0.0.64/fastdialer/metafiles/shared.go:49:21: undefined: sync.OnceFunc
/go/pkg/mod/github.com/projectdiscovery/fastdialer@v0.0.64/fastdialer/metafiles/shared.go:73:19: undefined: sync.OnceFunc
note: module requires Go 1.21

Update Docker file with latest golang and GOMODULE=on. 
Fix Build path to main.go. 

Thanks !!

