### PR TITLE
Add note to documentation about Go version required

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 
 ## Installation
 
-katana requires ~~Go 1.18~~ (as of March 2025, install fails with Go 1.18, but works with **Go 1.24.1**, which is the latest available version, if you are having trouble getting it to work, and there are recent updates to this repo, try installing the latest available version on Go, just in case updating this documtation has slipped through the cracks) to install successfully. To install, just run the below command or download pre-compiled binary from [release page](https://github.com/projectdiscovery/katana/releases).
+katana requires Go 1.21+ to install successfully. If you encounter any installation issues, we recommend trying with the latest available version of Go, as the minimum required version may have changed. Run the command below or download a pre-compiled binary from the [release page](https://github.com/projectdiscovery/katana/releases).
 
 ```console
 CGO_ENABLED=1 go install github.com/projectdiscovery/katana/cmd/katana@latest

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 
 ## Installation
 
-katana requires ~~Go 1.18~~ (as of March 2025, install fails with Go 1.18, but works with **Go 1.24.1**, which is the latest available version, if you are having trouble getting it to work, and there are recent updates to this repo, try installing the latest available version on Go, just in case this updating this documtation has slipped through the cracks) to install successfully. To install, just run the below command or download pre-compiled binary from [release page](https://github.com/projectdiscovery/katana/releases).
+katana requires ~~Go 1.18~~ (as of March 2025, install fails with Go 1.18, but works with **Go 1.24.1**, which is the latest available version, if you are having trouble getting it to work, and there are recent updates to this repo, try installing the latest available version on Go, just in case updating this documtation has slipped through the cracks) to install successfully. To install, just run the below command or download pre-compiled binary from [release page](https://github.com/projectdiscovery/katana/releases).
 
 ```console
 CGO_ENABLED=1 go install github.com/projectdiscovery/katana/cmd/katana@latest

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 
 ## Installation
 
-katana requires **Go 1.18** to install successfully. To install, just run the below command or download pre-compiled binary from [release page](https://github.com/projectdiscovery/katana/releases).
+katana requires ~~Go 1.18~~ (as of March 2025, install fails with Go 1.18, but works with **Go 1.24.1**, which is the latest available version, if you are having trouble getting it to work, and there are recent updates to this repo, try installing the latest available version on Go, just in case this updating this documtation has slipped through the cracks) to install successfully. To install, just run the below command or download pre-compiled binary from [release page](https://github.com/projectdiscovery/katana/releases).
 
 ```console
 CGO_ENABLED=1 go install github.com/projectdiscovery/katana/cmd/katana@latest


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated installation instructions to reflect the correct Go version requirements.
  - Noted that installations will now fail with Go 1.18 and recommended using Go 1.24.1.
  - Added additional guidance for troubleshooting potential installation issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->