### PR TITLE
ci(compat-checks): disable release test

### DIFF
--- a/.github/workflows/compat-checks.yaml
+++ b/.github/workflows/compat-checks.yaml
@@ -15,5 +15,3 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: projectdiscovery/actions/setup/go/compat-checks@v1
-        with:
-          release-test: true


### PR DESCRIPTION
Closes #1327 

Skip release test since we use custom GoReleaser configuration (== not located in `$WORKSPACE/.goreleaser.yaml`).