### PR TITLE
introduce path climb to discover parent paths to crawl

### DIFF
--- a/cmd/katana/main.go
+++ b/cmd/katana/main.go
@@ -134,6 +134,7 @@ pipelines offering both headless and non-headless crawling.`)
 		flagSet.BoolVarP(&options.IgnoreQueryParams, "ignore-query-params", "iqp", false, "Ignore crawling same path with different query-param values"),
 		flagSet.BoolVarP(&options.TlsImpersonate, "tls-impersonate", "tlsi", false, "enable experimental client hello (ja3) tls randomization"),
 		flagSet.BoolVarP(&options.DisableRedirects, "disable-redirects", "dr", false, "disable following redirects (default false)"),
+		flagSet.BoolVarP(&options.PathClimb, "path-climb", "pc", false, "enable path climb (auto crawl parent paths)"),
 	)
 
 	flagSet.CreateGroup("debug", "Debug",

--- a/internal/runner/executer.go
+++ b/internal/runner/executer.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 
 	"github.com/projectdiscovery/gologger"
-	"github.com/projectdiscovery/katana/pkg/utils"
 	errorutil "github.com/projectdiscovery/utils/errors"
 	urlutil "github.com/projectdiscovery/utils/url"
 	"github.com/remeh/sizedwaitgroup"
@@ -18,13 +17,6 @@ func (r *Runner) ExecuteCrawling() error {
 	inputs := r.parseInputs()
 	if len(inputs) == 0 {
 		return errorutil.New("no input provided for crawling")
-	}
-
-	if r.options.PathClimb {
-		for _, input := range inputs {
-			extractedParentURLs := utils.ExtractParentPaths(input)
-			inputs = append(inputs, extractedParentURLs...)
-		}
 	}
 
 	for _, input := range inputs {

--- a/internal/runner/executer.go
+++ b/internal/runner/executer.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/katana/pkg/utils"
 	errorutil "github.com/projectdiscovery/utils/errors"
 	urlutil "github.com/projectdiscovery/utils/url"
 	"github.com/remeh/sizedwaitgroup"
@@ -18,6 +19,14 @@ func (r *Runner) ExecuteCrawling() error {
 	if len(inputs) == 0 {
 		return errorutil.New("no input provided for crawling")
 	}
+
+	if r.options.PathClimb {
+		for _, input := range inputs {
+			extractedParentURLs := utils.ExtractParentPaths(input)
+			inputs = append(inputs, extractedParentURLs...)
+		}
+	}
+
 	for _, input := range inputs {
 		_ = r.state.InFlightUrls.Set(addSchemeIfNotExists(input), struct{}{})
 	}

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -168,6 +168,8 @@ type Options struct {
 	TlsImpersonate bool
 	// DisableRedirects disables the following of redirects
 	DisableRedirects bool
+	// PathClimb enables path expansion (auto crawl discovered paths)
+	PathClimb bool
 }
 
 func (options *Options) ParseCustomHeaders() map[string]string {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/lukasbob/srcset"
@@ -65,7 +66,7 @@ func ParseRefreshTag(value string) string {
 
 // WebUserAgent returns the chrome-web user agent
 func WebUserAgent() string {
-        return "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36"
+	return "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36"
 }
 
 func FlattenHeaders(headers map[string][]string) map[string]string {
@@ -89,4 +90,29 @@ func ReplaceAllQueryParam(reqUrl, val string) string {
 	})
 	u.RawQuery = params.Encode()
 	return u.String()
+}
+
+// ExtractParentPaths returns all path directories for a given URL
+func ExtractParentPaths(rawurl string) []string {
+	u, err := urlutil.Parse(rawurl)
+	if err != nil {
+		return nil
+	}
+	path := u.Path
+	if path == "" || path == "/" {
+		return nil
+	}
+
+	path = strings.Trim(path, "/")
+	parts := strings.Split(path, "/")
+	if len(parts) == 0 {
+		return nil
+	}
+	urls := []string{}
+	for i := len(parts) - 1; i > 0; i-- {
+		if parentPath := strings.Join(parts[:i], "/"); parentPath != "" {
+			urls = append(urls, fmt.Sprintf("%s://%s/%s", u.Scheme, u.Host, parentPath))
+		}
+	}
+	return urls
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -20,3 +20,8 @@ func TestParseRefreshTag(t *testing.T) {
 	values := ParseRefreshTag(header)
 	require.Equal(t, "/test/headers/refresh.found", values, "could not parse correct links")
 }
+
+func TestExtractParentPaths(t *testing.T) {
+	urls := ExtractParentPaths("https://example.com/test/path/to/file.html")
+	require.ElementsMatch(t, []string{"https://example.com/test/path/to", "https://example.com/test/path", "https://example.com/test"}, urls, "could not extract correct parent paths")
+}


### PR DESCRIPTION
closes https://github.com/projectdiscovery/katana/issues/867

```console
$ go run . -u https://scanme.sh/test/path/to/file.html -pc   

   __        __                
  / /_____ _/ /____ ____  ___ _
 /  '_/ _  / __/ _  / _ \/ _  /
/_/\_\\_,_/\__/\_,_/_//_/\_,_/                                                   

                projectdiscovery.io

[INF] Current katana version v1.1.3 (latest)
[INF] Started standard crawling for => https://scanme.sh/test
[INF] Started standard crawling for => https://scanme.sh/test/path/to/file.html
[INF] Started standard crawling for => https://scanme.sh/test/path
[INF] Started standard crawling for => https://scanme.sh/test/path/to
https://scanme.sh/test/path/to/file.html
https://scanme.sh/test/path
https://scanme.sh/test/path/to
https://scanme.sh/test
```