### PR TITLE
bump dockerfile golang version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine AS build-env
+FROM golang:1.24.2-alpine AS build-env
 RUN apk add --no-cache git gcc musl-dev
 WORKDIR /app
 COPY . /app

--- a/internal/runner/banner.go
+++ b/internal/runner/banner.go
@@ -12,7 +12,7 @@ var banner = (`
 /_/\_\\_,_/\__/\_,_/_//_/\_,_/							 
 `)
 
-var version = "v1.2.0"
+var version = "v1.2.1"
 
 // showBanner is used to show the banner to the user
 func showBanner() {


### PR DESCRIPTION
closes https://github.com/projectdiscovery/katana/issues/1338

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build environment to use a newer version of Go.
  * Updated the displayed version number to v1.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->