### PR TITLE
fix: remove redundant gologger output

### DIFF
--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -216,7 +216,6 @@ func (w *StandardWriter) Write(result *Result) error {
 	w.outputMutex.Lock()
 	defer w.outputMutex.Unlock()
 
-	gologger.Silent().Msgf("%s", string(data))
 	if w.outputFile != nil {
 		if !w.json {
 			data = decolorizerRegex.ReplaceAll(data, []byte(""))


### PR DESCRIPTION
resolve Issue: https://github.com/projectdiscovery/katana/issues/1314

(AS-IS)
[INF] Started standard crawling for => https://www.target.com 
https://www.target.com
[INF] https://www.target.com
https://carts.target.com
[INF] https://carts.target.com

(TO-BE)
[INF] Started standard crawling for => https://www.target.com 
[INF] https://www.target.com
[INF] https://api.target.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed silent logging of output data, resulting in cleaner logs for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->