### PR TITLE
fix: remove redundant gologger output

### DIFF
--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -216,7 +216,6 @@ func (w *StandardWriter) Write(result *Result) error {
 	w.outputMutex.Lock()
 	defer w.outputMutex.Unlock()
 
-	gologger.Silent().Msgf("%s", string(data))
 	if w.outputFile != nil {
 		if !w.json {
 			data = decolorizerRegex.ReplaceAll(data, []byte(""))


### PR DESCRIPTION
resolve issue: https://github.com/projectdiscovery/katana/issues/1314

(AS-IS)
[INF] Started standard crawling for => https://www.target.com 
https://www.target.com
[INF] https://www.target.com
https://carts.target.com
[INF] https://carts.target.com

(TO-BE)
[INF] Started standard crawling for => https://www.target.com 
[INF] https://www.target.com
[INF] https://api.target.com