### PR TITLE
Handle incorrect use of -kf early

### DIFF
--- a/cmd/katana/main.go
+++ b/cmd/katana/main.go
@@ -117,7 +117,12 @@ pipelines offering both headless and non-headless crawling.`)
 		flagSet.BoolVarP(&options.ScrapeJSResponses, "js-crawl", "jc", false, "enable endpoint parsing / crawling in javascript file"),
 		flagSet.BoolVarP(&options.ScrapeJSLuiceResponses, "jsluice", "jsl", false, "enable jsluice parsing in javascript file (memory intensive)"),
 		flagSet.DurationVarP(&options.CrawlDuration, "crawl-duration", "ct", 0, "maximum duration to crawl the target for (s, m, h, d) (default s)"),
-		flagSet.StringVarP(&options.KnownFiles, "known-files", "kf", "", "enable crawling of known files (all,robotstxt,sitemapxml), a minimum depth of 3 is required to ensure all known files are properly crawled."),
+		flagSet.EnumVarP(&options.KnownFiles, "known-files", "kf", goflags.EnumVariable(0), "enable crawling of known files (all,robotstxt,sitemapxml), a minimum depth of 3 is required to ensure all known files are properly crawled.", goflags.AllowdTypes{
+			"":           goflags.EnumVariable(0),
+			"all":        goflags.EnumVariable(1),
+			"robotstxt":  goflags.EnumVariable(2),
+			"sitemapxml": goflags.EnumVariable(3),
+		}),
 		flagSet.IntVarP(&options.BodyReadSize, "max-response-size", "mrs", defaultBodyReadSize, "maximum response size to read"),
 		flagSet.IntVar(&options.Timeout, "timeout", 10, "time to wait for request in seconds"),
 		flagSet.IntVar(&options.TimeStable, "time-stable", 1, "time to wait until the page is stable in seconds"),


### PR DESCRIPTION
The `-kf` flag accepts a string value as parameter which specifies which known files to crawl. When no parameter is given and there are more flags after `-kf`, katana assumes that the next flag is the parameter value for the `-kf` flag.

Since `-kf` has a pre-determined set of values that it can accept, perform that check at `validateOptions()`.

Solving this problem in `goflags` seems impractical, because of the nature of the flag that accepts a string value.

@dogancanbakir please take a look.

Related: https://github.com/projectdiscovery/katana/issues/1265 , https://github.com/projectdiscovery/goflags/issues/238

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for the KnownFiles option, ensuring only supported values are accepted and providing clearer error messages for invalid inputs.
  * Enhanced handling of MaxDepth adjustment when KnownFiles is set, maintaining consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->