### PR TITLE
Add -no-default-ext-filter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,15 +166,16 @@ SCOPE:
    -do, -display-out-scope          display external endpoint from scoped crawling
 
 FILTER:
-   -mr, -match-regex string[]       regex or list of regex to match on output url (cli, file)
-   -fr, -filter-regex string[]      regex or list of regex to filter on output url (cli, file)
-   -f, -field string                field to display in output (url,path,fqdn,rdn,rurl,qurl,qpath,file,ufile,key,value,kv,dir,udir) (Deprecated: use -output-template instead)
-   -sf, -store-field string         field to store in per-host output (url,path,fqdn,rdn,rurl,qurl,qpath,file,ufile,key,value,kv,dir,udir)
-   -em, -extension-match string[]   match output for given extension (eg, -em php,html,js)
-   -ef, -extension-filter string[]  filter output for given extension (eg, -ef png,css)
-   -mdc, -match-condition string    match response with dsl based condition
-   -fdc, -filter-condition string   filter response with dsl based condition
-   -duf, -disable-unique-filter     disable duplicate content filtering
+   -mr, -match-regex string[]             regex or list of regex to match on output url (cli, file)
+   -fr, -filter-regex string[]            regex or list of regex to filter on output url (cli, file)
+   -f, -field string                      field to display in output (url,path,fqdn,rdn,rurl,qurl,qpath,file,ufile,key,value,kv,dir,udir) (Deprecated: use -output-template instead)
+   -sf, -store-field string               field to store in per-host output (url,path,fqdn,rdn,rurl,qurl,qpath,file,ufile,key,value,kv,dir,udir)
+   -em, -extension-match string[]         match output for given extension (eg, -em php,html,js)
+   -ef, -extension-filter string[]        filter output for given extension (eg, -ef png,css)
+   -ndef, -no-default-ext-filter bool     remove default extensions from the filter list
+   -mdc, -match-condition string          match response with dsl based condition
+   -fdc, -filter-condition string         filter response with dsl based condition
+   -duf, -disable-unique-filter           disable duplicate content filtering
 
 RATE-LIMIT:
    -c, -concurrency int          number of concurrent fetchers to use (default 10)
@@ -731,6 +732,15 @@ Crawl output can be easily filtered for specific extension using `-ef` option wh
 
 ```
 katana -u https://tesla.com -silent -ef css,txt,md
+
+```
+*`-no-default-ext-filter`*
+---
+
+Katana filters several extensions by default. This can be disabled with the `-ndef` option.
+
+```
+katana -u https://tesla.com -silent -ndef
 ```
 
 *`-match-regex`*
@@ -777,15 +787,16 @@ katana -h filter
 
 Flags:
 FILTER:
-   -mr, -match-regex string[]       regex or list of regex to match on output url (cli, file)
-   -fr, -filter-regex string[]      regex or list of regex to filter on output url (cli, file)
-   -f, -field string                field to display in output (url,path,fqdn,rdn,rurl,qurl,qpath,file,ufile,key,value,kv,dir,udir)
-   -sf, -store-field string         field to store in per-host output (url,path,fqdn,rdn,rurl,qurl,qpath,file,ufile,key,value,kv,dir,udir)
-   -em, -extension-match string[]   match output for given extension (eg, -em php,html,js)
-   -ef, -extension-filter string[]  filter output for given extension (eg, -ef png,css)
-   -mdc, -match-condition string    match response with dsl based condition
-   -fdc, -filter-condition string   filter response with dsl based condition
-   -duf, -disable-unique-filter     disable duplicate content filtering
+   -mr, -match-regex string[]             regex or list of regex to match on output url (cli, file)
+   -fr, -filter-regex string[]            regex or list of regex to filter on output url (cli, file)
+   -f, -field string                      field to display in output (url,path,fqdn,rdn,rurl,qurl,qpath,file,ufile,key,value,kv,dir,udir)
+   -sf, -store-field string               field to store in per-host output (url,path,fqdn,rdn,rurl,qurl,qpath,file,ufile,key,value,kv,dir,udir)
+   -em, -extension-match string[]         match output for given extension (eg, -em php,html,js)
+   -ef, -extension-filter string[]        filter output for given extension (eg, -ef png,css)
+   -ndef, -no-default-ext-filter bool     remove default extensions from the filter list
+   -mdc, -match-condition string          match response with dsl based condition
+   -fdc, -filter-condition string         filter response with dsl based condition
+   -duf, -disable-unique-filter           disable duplicate content filtering
 ```
 
 

--- a/cmd/katana/main.go
+++ b/cmd/katana/main.go
@@ -172,6 +172,7 @@ pipelines offering both headless and non-headless crawling.`)
 		flagSet.StringVarP(&options.StoreFields, "store-field", "sf", "", fmt.Sprintf("field to store in per-host output (%s)", availableFields)),
 		flagSet.StringSliceVarP(&options.ExtensionsMatch, "extension-match", "em", nil, "match output for given extension (eg, -em php,html,js)", goflags.CommaSeparatedStringSliceOptions),
 		flagSet.StringSliceVarP(&options.ExtensionFilter, "extension-filter", "ef", nil, "filter output for given extension (eg, -ef png,css)", goflags.CommaSeparatedStringSliceOptions),
+		flagSet.BoolVarP(&options.NoDefaultExtFilter, "no-default-ext-filter", "ndef", false, "remove default extensions from the filter list"),
 		flagSet.StringVarP(&options.OutputMatchCondition, "match-condition", "mdc", "", "match response with dsl based condition"),
 		flagSet.StringVarP(&options.OutputFilterCondition, "filter-condition", "fdc", "", "filter response with dsl based condition"),
 		flagSet.BoolVarP(&options.DisableUniqueFilter, "disable-unique-filter", "duf", false, "disable duplicate content filtering"),

--- a/pkg/types/crawler_options.go
+++ b/pkg/types/crawler_options.go
@@ -43,7 +43,7 @@ type CrawlerOptions struct {
 // from user specified options.
 func NewCrawlerOptions(options *Options) (*CrawlerOptions, error) {
 	options.ConfigureOutput()
-	extensionsValidator := extensions.NewValidator(options.ExtensionsMatch, options.ExtensionFilter)
+	extensionsValidator := extensions.NewValidator(options.ExtensionsMatch, options.ExtensionFilter, options.NoDefaultExtFilter)
 
 	parserOptions := &parser.Options{
 		AutomaticFormFill:      options.AutomaticFormFill,

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -38,6 +38,8 @@ type Options struct {
 	ExtensionsMatch goflags.StringSlice
 	// ExtensionFilter contains additional items for filter list
 	ExtensionFilter goflags.StringSlice
+	// NoDefaultExtFilter removes the default extensions from the filter list
+	NoDefaultExtFilter bool
 	// OutputMatchCondition is the condition to match output
 	OutputMatchCondition string
 	// OutputFilterCondition is the condition to filter output

--- a/pkg/utils/extensions/extensions.go
+++ b/pkg/utils/extensions/extensions.go
@@ -9,7 +9,7 @@ import (
 )
 
 // defaultDenylist is the default list of extensions to be denied
-var defaultDenylist = []string{".3g2", ".3gp", ".7z", ".apk", ".arj", ".avi", ".axd", ".bmp", ".csv", ".deb", ".dll", ".doc", ".drv", ".eot", ".exe", ".flv", ".gif", ".gifv", ".gz", ".h264", ".ico", ".iso", ".jar", ".jpeg", ".jpg", ".lock", ".m4a", ".m4v", ".map", ".mkv", ".mov", ".mp3", ".mp4", ".mpeg", ".mpg", ".msi", ".ogg", ".ogm", ".ogv", ".otf", ".pdf", ".pkg", ".png", ".ppt", ".psd", ".rar", ".rm", ".rpm", ".svg", ".swf", ".sys", ".tar.gz", ".tar", ".tif", ".tiff", ".ttf", ".txt", ".vob", ".wav", ".webm", ".webp", ".wmv", ".woff", ".woff2", ".xcf", ".xls", ".xlsx", ".zip"}
+var defaultExtFilter = []string{".3g2", ".3gp", ".7z", ".apk", ".arj", ".avi", ".axd", ".bmp", ".csv", ".deb", ".dll", ".doc", ".drv", ".eot", ".exe", ".flv", ".gif", ".gifv", ".gz", ".h264", ".ico", ".iso", ".jar", ".jpeg", ".jpg", ".lock", ".m4a", ".m4v", ".map", ".mkv", ".mov", ".mp3", ".mp4", ".mpeg", ".mpg", ".msi", ".ogg", ".ogm", ".ogv", ".otf", ".pdf", ".pkg", ".png", ".ppt", ".psd", ".rar", ".rm", ".rpm", ".svg", ".swf", ".sys", ".tar.gz", ".tar", ".tif", ".tiff", ".ttf", ".txt", ".vob", ".wav", ".webm", ".webp", ".wmv", ".woff", ".woff2", ".xcf", ".xls", ".xlsx", ".zip"}
 
 // Validator is a validator for file extension
 type Validator struct {
@@ -18,7 +18,7 @@ type Validator struct {
 }
 
 // NewValidator creates a new extension validator instance
-func NewValidator(extensionsMatch, extensionsFilter []string) *Validator {
+func NewValidator(extensionsMatch, extensionsFilter []string, noDefaultExtFilter bool) *Validator {
 	validator := &Validator{
 		extensionsMatch:  make(map[string]struct{}),
 		extensionsFilter: make(map[string]struct{}),
@@ -27,8 +27,10 @@ func NewValidator(extensionsMatch, extensionsFilter []string) *Validator {
 	for _, extension := range extensionsMatch {
 		validator.extensionsMatch[normalizeExtension(extension)] = struct{}{}
 	}
-	for _, item := range defaultDenylist {
-		validator.extensionsFilter[normalizeExtension(item)] = struct{}{}
+	if !noDefaultExtFilter {
+		for _, item := range defaultExtFilter {
+			validator.extensionsFilter[normalizeExtension(item)] = struct{}{}
+		}
 	}
 	for _, extension := range extensionsFilter {
 		validator.extensionsFilter[normalizeExtension(extension)] = struct{}{}

--- a/pkg/utils/extensions/extensions_test.go
+++ b/pkg/utils/extensions/extensions_test.go
@@ -7,14 +7,20 @@ import (
 )
 
 func TestValidatorValidate(t *testing.T) {
-	validator := NewValidator([]string{".go"}, nil)
+	validator := NewValidator([]string{".go"}, nil, false)
 	require.True(t, validator.ValidatePath("main.go"), "could not validate correct data with extensions")
 	require.False(t, validator.ValidatePath("main.php"), "could not validate correct data with wrong extension")
 
-	validator = NewValidator(nil, []string{".php"})
+	validator = NewValidator(nil, []string{".php"}, false)
 	require.False(t, validator.ValidatePath("main.php"), "could not validate correct data with deny list extension")
 	require.True(t, validator.ValidatePath("main.go"), "could not validate correct data with no custom extensions")
 
-	validator = NewValidator([]string{"png"}, nil)
+	validator = NewValidator([]string{"png"}, nil, false)
 	require.True(t, validator.ValidatePath("main.png"), "could not validate correct data with default denylist bypass")
+
+	validator = NewValidator(nil, nil, true)
+	require.True(t, validator.ValidatePath("main.png"), "could not validate correct data with no default extension filter")
+
+	validator = NewValidator(nil, []string{"png"}, true)
+	require.False(t, validator.ValidatePath("main.png"), "could not validate correct data with no default extension filter and custom filter")
 }


### PR DESCRIPTION
Katana has a default set of extensions which are filtered.

This can cause problems in some cases:
- User does not know about the denylist so they get a result which is different from what they expected
- User has to manually add a long list of extensions in the `-extension-match` option

To better support those cases, add a new option `-disable-default-denylist`.

Resolves #1360 