### PR TITLE
feat(output): Add `-eof` and `-lof` flags for JSON output filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ OUTPUT:
    -sfd, -store-field-dir string     store per-host field to custom directory
    -or, -omit-raw                    omit raw requests/responses from jsonl output
    -ob, -omit-body                   omit response body from jsonl output
+   -lof, -list-output-fields         list available fields for jsonl output format
+   -eof, -exclude-output-fields      exclude fields from jsonl output
    -j, -jsonl                        write output in jsonl format
    -nc, -no-color                    disable output content coloring (ANSI escape codes)
    -silent                           display output only
@@ -944,6 +946,24 @@ katana_response/www.iana.org/bfc096e6dd93b993ca8918bf4c08fdc707a70723.txt http:/
 
 *`-store-response` option is not supported in `-headless` mode.*
 
+*`-list-output-fields`*
+----
+
+The `-list-output-fields` or `-lof` flag displays all available fields that can be used in JSONL output format. This is useful for understanding what data is available when using custom output templates or when excluding specific fields.
+
+```console
+katana -lof
+```
+
+*`-exclude-output-fields`*
+----
+
+The `-exclude-output-fields` or `-eof` flag allows you to exclude specific fields from the JSONL output. This is useful for reducing output size or focusing on specific data by removing unwanted fields.
+
+```console
+katana -u https://example.com -jsonl -eof raw,body
+```
+
 Here are additional CLI options related to output -
 
 ```console
@@ -953,6 +973,8 @@ OUTPUT:
    -o, -output string                file to write output to
    -sr, -store-response              store http requests/responses
    -srd, -store-response-dir string  store http requests/responses to custom directory
+   -lof, -list-output-fields         list available fields for jsonl output format
+   -eof, -exclude-output-fields      exclude fields from jsonl output
    -j, -json                         write output in JSONL(ines) format
    -nc, -no-color                    disable output content coloring (ANSI escape codes)
    -silent                           display output only

--- a/pkg/output/format_json.go
+++ b/pkg/output/format_json.go
@@ -2,14 +2,39 @@ package output
 
 import (
 	jsoniter "github.com/json-iterator/go"
+	"github.com/projectdiscovery/utils/structs"
 )
 
 // formatJSON formats the output for json based formatting
 func (w *StandardWriter) formatJSON(output *Result) ([]byte, error) {
-	// // NOTE(dwisiswant0): No special treatment for custom fields.
-	// // Ref: https://github.com/projectdiscovery/katana/issues/1182
-	// if len(output.Request.CustomFields) > 0 {
-	// 	return nil, nil
-	// }
-	return jsoniter.Marshal(output)
+	finalMap, err := structs.FilterStructToMap(*output, nil, w.excludeOutputFields)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, ok := finalMap["request"]; ok && output.Request != nil {
+		reqMap, err := structs.FilterStructToMap(*output.Request, nil, w.excludeOutputFields)
+		if err != nil {
+			return nil, err
+		}
+		if len(reqMap) > 0 {
+			finalMap["request"] = reqMap
+		} else {
+			delete(finalMap, "request")
+		}
+	}
+
+	if _, ok := finalMap["response"]; ok && output.Response != nil {
+		respMap, err := structs.FilterStructToMap(*output.Response, nil, w.excludeOutputFields)
+		if err != nil {
+			return nil, err
+		}
+		if len(respMap) > 0 {
+			finalMap["response"] = respMap
+		} else {
+			delete(finalMap, "response")
+		}
+	}
+
+	return jsoniter.Marshal(finalMap)
 }

--- a/pkg/output/options.go
+++ b/pkg/output/options.go
@@ -28,4 +28,5 @@ type Options struct {
 	OutputTemplate        string
 	OutputMatchCondition  string
 	OutputFilterCondition string
+	ExcludeOutputFields   []string
 }

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -63,6 +63,7 @@ type StandardWriter struct {
 	outputTemplate        *fasttemplate.Template
 	outputMatchCondition  string
 	outputFilterCondition string
+	excludeOutputFields   []string
 }
 
 // New returns a new output writer instance
@@ -83,6 +84,7 @@ func New(options Options) (Writer, error) {
 		extensionValidator:    options.ExtensionValidator,
 		outputMatchCondition:  options.OutputMatchCondition,
 		outputFilterCondition: options.OutputFilterCondition,
+		excludeOutputFields:   options.ExcludeOutputFields,
 	}
 
 	if options.StoreFieldDir != "" {

--- a/pkg/types/crawler_options.go
+++ b/pkg/types/crawler_options.go
@@ -94,6 +94,7 @@ func NewCrawlerOptions(options *Options) (*CrawlerOptions, error) {
 		OutputTemplate:        options.OutputTemplate,
 		OutputMatchCondition:  options.OutputMatchCondition,
 		OutputFilterCondition: options.OutputFilterCondition,
+		ExcludeOutputFields:   options.ExcludeOutputFields,
 	}
 
 	for _, mr := range options.OutputMatchRegex {

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -86,6 +86,10 @@ type Options struct {
 	NoColors bool
 	// JSON enables writing output in JSON format
 	JSON bool
+	// ExcludeOutputFields is the list of fields to exclude from the output
+	ExcludeOutputFields goflags.StringSlice
+	// ListOutputFields is the list of fields
+	ListOutputFields bool
 	// Silent shows only output
 	Silent bool
 	// Verbose specifies showing verbose output


### PR DESCRIPTION
Resolves #1352

### Summary

This PR introduces JSON output filtering capabilities to `katana` with the `-eof` and `-lof` flags, inspired by the implementation in `naabu` ([PR #1387](https://github.com/projectdiscovery/naabu/pull/1387)). This allows users to customize the JSON output by excluding specific fields.

### Build Status

This PR currently does not build successfully on its own.  
It depends on the new `FilterStructToMap` function from the latest `projectdiscovery/utils` library ([PR #674](https://github.com/projectdiscovery/utils/pull/674)).

For local testing, I temporarily copied the `FilterStructToMap` function into `katana`, and confirmed that the feature works as expected.

As discussed with @dogancanbakir in the issue, I’m submitting this PR to share the completed feature logic. The next step is to resolve the dependency conflicts in `katana` that arise from updating `utils` (e.g., `errorutil`, `httputil.CookieJar`).

### Solution Implemented

1. **New Flags:**
   - `-eof`, `--exclude-output-fields`: Excludes specified fields from the JSONL output.
   - `-lof`, `--list-output-fields`: Lists all available fields that can be used with `-eof`.

2. **Filtering Logic (`format_json.go`):**
   - The `formatJSON` function has been refactored to use the new `utils.FilterStructToMap` function.
   - To handle katana's nested output structure, `FilterStructToMap` directly converts the `Result` struct into a map. This map is then cleaned by recursively processing nested fields (like `Request` and `Response`) before being marshaled to JSON. This approach ensures that filtering works reliably and correctly.

### `-lof` Flag Implementation Details

The `-lof` flag is implemented to provide users with a clear list of filterable fields.

Currently, it lists all field names from the `Result`, `Request`, and `Response` structs in a single, flattened, and sorted list.

*For future consideration, the user experience could be enhanced by grouping these fields (e.g., under `[request]`, `[response]`). For this initial implementation, we opted for a simple, flat list to stay consistent with `naabu`.*
