### PR TITLE
Fix SIGSEGV in headless mode

### DIFF
--- a/pkg/engine/common/base.go
+++ b/pkg/engine/common/base.go
@@ -298,7 +298,7 @@ func (s *Shared) Do(crawlSession *CrawlSession, doRequest DoRequestFunc) error {
 				_ = s.Options.OutputWriter.WriteErr(outputError)
 				return
 			}
-			if resp.Resp == nil || resp.Reader == nil {
+			if resp == nil || resp.Resp == nil || resp.Reader == nil {
 				return
 			}
 			if s.Options.Options.DisableRedirects && resp.IsRedirect() {

--- a/pkg/engine/hybrid/crawl.go
+++ b/pkg/engine/hybrid/crawl.go
@@ -2,6 +2,7 @@ package hybrid
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httputil"
@@ -230,7 +231,8 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 	}
 
 	if response.Resp == nil {
-		return nil, errkit.Wrap(err, "hybrid: response is nil")
+		// err is guaranteed to be nil, due to previous checks.
+		return nil, errors.New("hybrid: response is nil")
 	}
 	response.Resp.Request.URL = parsed.URL
 


### PR DESCRIPTION
SIGSEGV can occur when page navigation does not cause and error but the response is not returned in crawl.go%navigateRequest().

- When response.Resp is nil, instead of calling errkit.Wrap() on a nil error, create a new error.
- In base.go%.Do(), add an additional condition to nil check to resp before using its members.

Resolves #1406 