### PR TITLE
Create new err when err is nil at navigateRequest()

### DIFF
--- a/pkg/engine/hybrid/crawl.go
+++ b/pkg/engine/hybrid/crawl.go
@@ -2,6 +2,7 @@ package hybrid
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httputil"
@@ -230,7 +231,8 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 	}
 
 	if response == nil || response.Resp == nil {
-		return nil, errkit.Wrap(err, "hybrid: response is nil")
+		// err is guaranteed to be nil, due to previous checks.
+		return nil, errors.New("hybrid: response is nil")
 	}
 	response.Resp.Request.URL = parsed.URL
 


### PR DESCRIPTION
When response.Resp is nil, it is still possible for err to be nil. errkit.Wrap() returns nil if the argument provided is also nil. To prevent returning (nil, nil) with no context to the caller, create a new error instead.

Related: #1406 #1407 #1408 