### PR TITLE
fix(crawl): onclick event javascript check url

### DIFF
--- a/pkg/engine/hybrid/crawl.go
+++ b/pkg/engine/hybrid/crawl.go
@@ -328,7 +328,7 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 			if err == nil {
 				navReq := &navigation.Request{
 					URL:          parsed.String(),
-					Depth:        request.Depth,
+					Depth:        depth,
 					RootHostname: s.Hostname,
 				}
 				c.Enqueue(s.Queue, navReq)

--- a/pkg/engine/hybrid/crawl.go
+++ b/pkg/engine/hybrid/crawl.go
@@ -260,7 +260,7 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 				continue
 			}
 
-			gologger.Debug().Msgf("Clicked onclick link %d", idx)
+			gologger.Debug().Msgf("Clicked onclick link [%d] at URL: %s", idx, beforeURLStr)
 
 			time.Sleep(1 * time.Second)
 

--- a/pkg/types/crawler_options.go
+++ b/pkg/types/crawler_options.go
@@ -141,6 +141,10 @@ func NewCrawlerOptions(options *Options) (*CrawlerOptions, error) {
 		crawlerOptions.Wappalyzer = wappalyze
 	}
 
+	if options.MaxOnclickLinks <= 0 {
+		options.MaxOnclickLinks = 10
+	}
+
 	return crawlerOptions, nil
 }
 

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -178,6 +178,8 @@ type Options struct {
 	PathClimb bool
 	// DisableUniqueFilter disables duplicate content filtering
 	DisableUniqueFilter bool
+	// MaxOnclickLinks is the maximum number of onclick links to process per page (default: 10)
+	MaxOnclickLinks int
 }
 
 func (options *Options) ParseCustomHeaders() map[string]string {


### PR DESCRIPTION
By Detect JS-triggered navigation via proto.PageFrameNavigated event with Onclick Link Click Simulation
Related Issue: https://github.com/projectdiscovery/katana/issues/1358

<img width="716" height="522" alt="Screenshot 2025-10-05 at 8 32 06 PM" src="https://github.com/user-attachments/assets/8f07ea3e-e7ce-4a1c-b289-9376599836c2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Detects and follows JavaScript-driven navigations and top-level frame changes.
  - Discovers and enqueues links triggered by onclick handlers (configurable per page; default: 10).
  - Preserves crawl depth and host context for newly discovered URLs.

- **Bug Fixes**
  - Reduces missed pages on sites using client-side routing or JS redirects.
  - Improves crawl coverage and reliability when tracking discovered navigations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->