### PR TITLE
fix(scope): fixed -no-scope behaviour to match help message

### DIFF
--- a/pkg/utils/scope/scope.go
+++ b/pkg/utils/scope/scope.go
@@ -67,7 +67,8 @@ func NewManager(inScope, outOfScope []string, fieldScope string, noScope bool) (
 	return manager, nil
 }
 
-// Validate returns true if the URL matches scope rules
+// Validate returns true if the URL matches scope rules.
+// When noScope is true, DNS validation is skipped but URL-based scope rules still apply.
 func (m *Manager) Validate(URL *url.URL, rootHostname string) (bool, error) {
 	if !m.noScope {
 		// Only validate DNS if scope is enabled

--- a/pkg/utils/scope/scope.go
+++ b/pkg/utils/scope/scope.go
@@ -89,6 +89,10 @@ func (m *Manager) Validate(URL *url.URL, rootHostname string) (bool, error) {
 	return true, nil
 }
 
+// validateURL checks whether the given URL matches the configured inScope and outOfScope patterns.
+// It returns true if the URL is allowed (matches inScope and doesn't match outOfScope),
+// false if rejected, and an error if pattern matching fails.
+// When both inScope and outOfScope are empty, it returns true with no error.
 func (m *Manager) validateURL(URL string) (bool, error) {
 	for _, item := range m.outOfScope {
 		if item.MatchString(URL) {
@@ -109,6 +113,10 @@ func (m *Manager) validateURL(URL string) (bool, error) {
 	return inScopeMatched, nil
 }
 
+// validateDNS performs DNS-based scope validation by checking if the URL's hostname
+// matches the configured host-based scope rules. It returns true if the hostname
+// is within scope, false if out of scope, and an error if DNS resolution or
+// validation fails.
 func (m *Manager) validateDNS(hostname, rootHostname string) (bool, error) {
 	parsed := net.ParseIP(hostname)
 	if m.fieldScope == customDNSScopeField {
@@ -135,6 +143,9 @@ func (m *Manager) validateDNS(hostname, rootHostname string) (bool, error) {
 	return false, nil
 }
 
+// getDomainRDNandRDN extracts and returns the root domain name (RDN) and the
+// effective top-level domain plus one label (eTLD+1) from the given hostname.
+// It returns empty strings and an error if the hostname cannot be parsed.
 func getDomainRDNandRDN(domain string) (string, string, error) {
 	if strings.HasPrefix(domain, ".") || strings.HasSuffix(domain, ".") || strings.Contains(domain, "..") {
 		return "", "", fmt.Errorf("publicsuffix: empty label in domain %q", domain)

--- a/pkg/utils/scope/scope_test.go
+++ b/pkg/utils/scope/scope_test.go
@@ -78,3 +78,68 @@ func TestGetDomainRDNandDN(t *testing.T) {
 	require.Equal(t, "projectdiscovery.io", rdn, "could not get correct rdn")
 	require.Equal(t, "projectdiscovery", dn, "could not get correct dn")
 }
+
+func TestNoScopeWithOutOfScope(t *testing.T) {
+	t.Run("noScope with outOfScope rules", func(t *testing.T) {
+		// Create manager with noScope=true and outOfScope patterns
+		outOfScopePatterns := []string{
+			`logout\.php`,
+			`/admin/`,
+			`\.js$`,
+			`^https?://[^/]+/\?lang=[a-z]{2}`,
+		}
+		manager, err := NewManager(nil, outOfScopePatterns, "rdn", true)
+		require.NoError(t, err, "could not create scope manager with noScope and outOfScope")
+
+		// Test 1: URL from different domain should be allowed (noScope ignores DNS)
+		parsed, _ := urlutil.Parse("https://completely-different.com/index.php")
+		validated, err := manager.Validate(parsed.URL, "original.com")
+		require.NoError(t, err, "could not validate cross-domain URL with noScope")
+		require.True(t, validated, "cross-domain URL should be allowed with noScope")
+
+		// Test 2: URL matching outOfScope pattern should be rejected
+		parsed, _ = urlutil.Parse("https://completely-different.com/logout.php")
+		validated, err = manager.Validate(parsed.URL, "original.com")
+		require.NoError(t, err, "could not validate outOfScope URL")
+		require.False(t, validated, "outOfScope pattern should still be applied with noScope")
+
+		// Test 3: Normal URLs should be allowed
+		parsed, _ = urlutil.Parse("https://any-site.com/products/item123")
+		validated, err = manager.Validate(parsed.URL, "original.com")
+		require.NoError(t, err, "could not validate normal URL")
+		require.True(t, validated, "normal URLs should be allowed")
+	})
+
+	t.Run("noScope with both inScope and outOfScope", func(t *testing.T) {
+		// Test combining noScope with both inScope and outOfScope
+		inScopePatterns := []string{`/api/`, `/products/`}
+		outOfScopePatterns := []string{`/api/internal/`, `\.css$`}
+
+		manager, err := NewManager(inScopePatterns, outOfScopePatterns, "fqdn", true)
+		require.NoError(t, err, "could not create manager with both scope types")
+
+		// Should be allowed: matches inScope, doesn't match outOfScope
+		parsed, _ := urlutil.Parse("https://external.com/api/users")
+		validated, err := manager.Validate(parsed.URL, "original.com")
+		require.NoError(t, err, "could not validate API endpoint")
+		require.True(t, validated, "API endpoint should be allowed")
+
+		// Should be rejected: matches both inScope and outOfScope (outOfScope wins)
+		parsed, _ = urlutil.Parse("https://external.com/api/internal/secrets")
+		validated, err = manager.Validate(parsed.URL, "original.com")
+		require.NoError(t, err, "could not validate internal API")
+		require.False(t, validated, "internal API should be excluded by outOfScope")
+
+		// Should be rejected: doesn't match inScope
+		parsed, _ = urlutil.Parse("https://external.com/about/company")
+		validated, err = manager.Validate(parsed.URL, "original.com")
+		require.NoError(t, err, "could not validate about page")
+		require.False(t, validated, "about page should be rejected (not in inScope)")
+
+		// Should be rejected: matches outOfScope
+		parsed, _ = urlutil.Parse("https://external.com/styles/main.css")
+		validated, err = manager.Validate(parsed.URL, "original.com")
+		require.NoError(t, err, "could not validate CSS file")
+		require.False(t, validated, "CSS files should be excluded")
+	})
+}

--- a/pkg/utils/scope/scope_test.go
+++ b/pkg/utils/scope/scope_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestManagerValidate verifies the Manager's Validate method with various scope configurations,
+// including URL pattern matching and host-based DNS validation for different scope types (dn, rdn, fqdn).
 func TestManagerValidate(t *testing.T) {
 	t.Run("url", func(t *testing.T) {
 		manager, err := NewManager([]string{`example`}, []string{`logout\.php`}, "dn", false)
@@ -72,6 +74,8 @@ func TestManagerValidate(t *testing.T) {
 	})
 }
 
+// TestGetDomainRDNandDN verifies the extraction of root domain name (RDN) and
+// effective top-level domain plus one label (eTLD+1) from a hostname.
 func TestGetDomainRDNandDN(t *testing.T) {
 	rdn, dn, err := getDomainRDNandRDN("test.projectdiscovery.io")
 	require.Nil(t, err, "could not get domain rdn and dn")

--- a/pkg/utils/scope/scope_test.go
+++ b/pkg/utils/scope/scope_test.go
@@ -79,6 +79,10 @@ func TestGetDomainRDNandDN(t *testing.T) {
 	require.Equal(t, "projectdiscovery", dn, "could not get correct dn")
 }
 
+// TestNoScopeWithOutOfScope verifies that when noScope is enabled, host-based
+// DNS validation is bypassed while URL pattern matching (inScope/outOfScope rules)
+// continues to function correctly. It tests scenarios with only outOfScope patterns
+// and with both inScope and outOfScope patterns to ensure proper filtering behavior.
 func TestNoScopeWithOutOfScope(t *testing.T) {
 	t.Run("noScope with outOfScope rules", func(t *testing.T) {
 		// Create manager with noScope=true and outOfScope patterns


### PR DESCRIPTION
Behaviour of -ns if a bit confusing: according to help it's "disables host based default scope" but in fact it entirely disables any scope filtering. 

With this fix behaviour will match the help text and we'll be able to disable DNS filtering in the same time we use othe scope filtering caps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * DNS checks now run only when scope restrictions are enabled and are attempted before URL rule checks when rules exist.
  * URL pattern rules are enforced independently; out-of-scope patterns take precedence.
  * Validation succeeds by default when no scope rules are configured.

* **Tests**
  * Added tests covering scoped vs. no-scope behavior, cross-domain cases, and domain extraction for DNS-based checks.

* **Documentation**
  * Updated docs/comments to clarify scope validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->