### PR TITLE
fix(crawling): depth filtering should take place before uniqueness check

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -21,12 +21,11 @@ jobs:
         uses: projectdiscovery/actions/setup/go@v1
 
       - name: release test
-        uses: goreleaser/goreleaser-action@v4
+        uses: projectdiscovery/actions/goreleaser@v1
         with:
-          args: "release -f .goreleaser/mac.yml --clean --snapshot"
-          version: latest
+          args: --config=.goreleaser/mac.yml
           workdir: .
-        env: 
+        env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
   release-test-linux:
@@ -68,10 +67,9 @@ jobs:
           go-version: 1.24.x
 
       - name: release test
-        uses: goreleaser/goreleaser-action@v4
+        uses: projectdiscovery/actions/goreleaser@v1
         with:
-          args: "release -f .goreleaser/windows.yml --clean --snapshot"
-          version: latest
+          args: --config=.goreleaser/windows.yml
           workdir: .
-        env: 
+        env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -21,9 +21,10 @@ jobs:
         uses: projectdiscovery/actions/setup/go@v1
 
       - name: release test
-        uses: projectdiscovery/actions/goreleaser@v1
+        uses: goreleaser/goreleaser-action@v4
         with:
           args: --config=.goreleaser/mac.yml
+          version: latest
           workdir: .
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
@@ -67,9 +68,10 @@ jobs:
           go-version: 1.24.x
 
       - name: release test
-        uses: projectdiscovery/actions/goreleaser@v1
+        uses: goreleaser/goreleaser-action@v4
         with:
           args: --config=.goreleaser/windows.yml
+          version: latest
           workdir: .
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -23,10 +23,10 @@ jobs:
       - name: release test
         uses: goreleaser/goreleaser-action@v4
         with:
-          args: --config=.goreleaser/mac.yml
+          args: "release -f .goreleaser/mac.yml --clean --snapshot"
           version: latest
           workdir: .
-        env:
+        env: 
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
   release-test-linux:
@@ -70,8 +70,8 @@ jobs:
       - name: release test
         uses: goreleaser/goreleaser-action@v4
         with:
-          args: --config=.goreleaser/windows.yml
+          args: "release -f .goreleaser/windows.yml --clean --snapshot"
           version: latest
           workdir: .
-        env:
+        env: 
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/pkg/engine/common/base.go
+++ b/pkg/engine/common/base.go
@@ -69,6 +69,13 @@ func (s *Shared) Enqueue(queue *queue.Queue, navigationRequests ...*navigation.R
 			reqUrl = utils.ReplaceAllQueryParam(reqUrl, "")
 		}
 
+		// Skip adding to the crawl queue when the maximum depth is exceeded.
+		// Must be done before checking uniqueness to avoid caching item that will be skipped
+		// to handle them if faced on lower depth via another path.
+		if nr.Depth > s.Options.Options.MaxDepth {
+			continue
+		}
+
 		// Ignore blank URL items and only work on unique items
 		if !s.Options.UniqueFilter.UniqueURL(reqUrl) && len(nr.CustomFields) == 0 {
 			continue
@@ -89,10 +96,6 @@ func (s *Shared) Enqueue(queue *queue.Queue, navigationRequests ...*navigation.R
 			continue
 		}
 
-		// Skip adding to the crawl queue when the maximum depth is exceeded
-		if nr.Depth > s.Options.Options.MaxDepth {
-			continue
-		}
 		queue.Push(nr, nr.Depth)
 
 		if s.Options.Options.PathClimb {


### PR DESCRIPTION
The PR fixes the issue of marking URLs as known inside UniqueFilter that may be skipped after that because of a depth check. The problem is the same URL can exist on different depth levels and some results can be skipped because first seen on higher deep. The problem is highly important because the default strategy of URLs queuing is **depth-first** which triggers the issue.

Scenario where this breaks:

1. URL https://example.com/page discovered at depth 5 (exceeds maxDepth=3)
2. UniqueURL() marks it as "seen" → returns false
3. Later, same URL discovered at depth 2 (valid depth)
4. UniqueURL() returns false (already seen) → incorrectly skipped
5. Result: Valid URL missed because seen first at bad depth

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced URL validation with multi-stage checks for scope, uniqueness, and cycle detection
  * Improved crawl session initialization and management with concurrent processing support
  * Added scope validation to ensure crawling respects boundary limits
  * Refined result output handling with callback integration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->