### PR TITLE
fix: resolve context deadline error with -jsonl -headless (fixes #611)

### DIFF
--- a/pkg/engine/hybrid/crawl.go
+++ b/pkg/engine/hybrid/crawl.go
@@ -282,16 +282,20 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 		}
 	}
 
+	// Use a fresh timeout for DOM retrieval since previous operations
+	// (navigation, waiting, onclick clicks) may have consumed the original timeout
+	pageWithTimeout := page.Timeout(timeout)
+
 	var getDocumentDepth = int(-1)
 	getDocument := &proto.DOMGetDocument{Depth: &getDocumentDepth, Pierce: true}
-	result, err := getDocument.Call(page)
+	result, err := getDocument.Call(pageWithTimeout)
 	if err != nil {
 		return nil, errkit.Wrap(err, "hybrid: could not get dom")
 	}
 	var builder strings.Builder
 	traverseDOMNode(result.Root, &builder)
 
-	body, err := page.HTML()
+	body, err := pageWithTimeout.HTML()
 	if err != nil {
 		return nil, errkit.Wrap(err, "hybrid: could not get html")
 	}


### PR DESCRIPTION
## Summary
Fixes #611 - context deadline exceeded error when using `-jsonl` with `-headless`.

## Problem
The page timeout set at the start of `navigateRequest` was shared across all operations. After navigation, waiting for page stability, and processing onclick links, the timeout was often exhausted before DOM retrieval.

## Solution
Use a fresh timeout context specifically for DOM retrieval and HTML extraction operations.

## Testing
- [x] Code compiles successfully
- [x] All existing tests pass
- [x] Fix targets the exact error location in hybrid/crawl.go

/claim #611

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page crawling reliability with independent timeout management for content extraction operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->