### PR TITLE
[ FIX ] -jsonl option with -headless option results in error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,10 @@ GOFLAGS := -v
 # This should be disabled if the binary uses pprof
 LDFLAGS := -s -w
 
-ifeq ($(STATIC),1)
 ifneq ($(shell go env GOOS),darwin)
-LDFLAGS += -extldflags "-static"
+LDFLAGS := -extldflags "-static"
 endif
-endif
+
 all: build
 build:
 	$(GOBUILD) $(GOFLAGS) -ldflags '$(LDFLAGS)' -o "katana" cmd/katana/main.go

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,11 @@ GOFLAGS := -v
 # This should be disabled if the binary uses pprof
 LDFLAGS := -s -w
 
+ifeq ($(STATIC),1)
 ifneq ($(shell go env GOOS),darwin)
-LDFLAGS := -extldflags "-static"
+LDFLAGS += -extldflags "-static"
 endif
-
+endif
 all: build
 build:
 	$(GOBUILD) $(GOFLAGS) -ldflags '$(LDFLAGS)' -o "katana" cmd/katana/main.go

--- a/pkg/engine/hybrid/crawl.go
+++ b/pkg/engine/hybrid/crawl.go
@@ -158,16 +158,19 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 		gologger.Warning().Msgf("\"%s\" on wait idle: %s\n", request.URL, err)
 	}
 
+    // Create a fresh timeout context for DOM extraction operations
+    domPage := page.Timeout(timeout)
+
 	var getDocumentDepth = int(-1)
 	getDocument := &proto.DOMGetDocument{Depth: &getDocumentDepth, Pierce: true}
-	result, err := getDocument.Call(page)
+	result, err := getDocument.Call(domPage)
 	if err != nil {
 		return nil, errorutil.NewWithTag("hybrid", "could not get dom").Wrap(err)
 	}
 	var builder strings.Builder
 	traverseDOMNode(result.Root, &builder)
 
-	body, err := page.HTML()
+	body, err := domPage.HTML()
 	if err != nil {
 		return nil, errorutil.NewWithTag("hybrid", "could not get html").Wrap(err)
 	}


### PR DESCRIPTION
## Description

Fixes #611 - Resolves context deadline exceeded error when using `-jsonl` and `-headless` options together.
/claim #611
## Problem

When crawling certain websites (e.g., https://projectdiscovery.io, https://www.discover.com) with both `-jsonl` and `-headless` flags enabled, katana fails with the error:

This error occurs because the timeout context set earlier in the navigation flow gets consumed by navigation, page loading, and idle waiting operations. By the time DOM extraction begins, the timeout has already expired or insufficient time remains.

## Solution

The fix creates a fresh timeout context specifically for DOM extraction operations by calling `page.Timeout(timeout)` right before the `DOMGetDocument` and `HTML()` calls. This ensures DOM extraction operations have the full timeout duration available, independent of time consumed by earlier navigation steps.

## Changes

- Added fresh timeout context for DOM extraction in `pkg/engine/hybrid/crawl.go`
- Renamed the page variable to `domPage` for clarity in the DOM extraction section

## Testing

Tested with the command from the issue:
```bash
echo "https://projectdiscovery.io" | katana -silent -d 1 -jsonl -headless


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Separated timeout handling for DOM extraction operations from navigation, allowing each process to manage timing independently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->