### PR TITLE
feat(hybrid): implement stderr logging for browser downloads and DOM …

### DIFF
--- a/pkg/engine/headless/browser/browser.go
+++ b/pkg/engine/headless/browser/browser.go
@@ -59,6 +59,20 @@ type LauncherOptions struct {
 
 type ScopeValidator func(string) bool
 
+// stderrLogger redirects rod download progress to stderr instead of stdout
+type stderrLogger struct{}
+
+func (l stderrLogger) Println(vs ...interface{}) {
+	fmt.Fprintln(os.Stderr, vs...)
+}
+
+// ensureBrowser downloads browser if needed, with output to stderr instead of stdout
+func ensureBrowser() {
+	browser := launcher.NewBrowser()
+	browser.Logger = stderrLogger{}
+	_ = browser.Download()
+}
+
 // NewLauncher returns a new launcher instance
 func NewLauncher(opts LauncherOptions) (*Launcher, error) {
 	l := &Launcher{
@@ -74,8 +88,13 @@ func (l *Launcher) ScopeValidator() ScopeValidator {
 }
 
 func (l *Launcher) launchBrowserWithDataDir(userDataDir string) (*rod.Browser, error) {
+	// ensure browser is downloaded (with stderr logging instead of stdout)
+	if l.opts.ChromiumPath == "" {
+		ensureBrowser()
+	}
 	chromeLauncher := launcher.New().
 		Leakless(true).
+		Logger(os.Stderr). // redirect browser output to stderr to avoid mixing with JSON output
 		Set("disable-gpu", "true").
 		Set("ignore-certificate-errors", "true").
 		Set("disable-crash-reporter", "true").

--- a/pkg/engine/hybrid/crawl.go
+++ b/pkg/engine/hybrid/crawl.go
@@ -282,18 +282,26 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 		}
 	}
 
+	var builder strings.Builder
+	var body string
+
+	// Try to get DOM - don't fail the request if this times out since we already have response data
 	var getDocumentDepth = int(-1)
 	getDocument := &proto.DOMGetDocument{Depth: &getDocumentDepth, Pierce: true}
 	result, err := getDocument.Call(page)
 	if err != nil {
-		return nil, errkit.Wrap(err, "hybrid: could not get dom")
+		gologger.Warning().Msgf("could not get dom for %s: %s (response data still captured)", request.URL, err)
+	} else {
+		traverseDOMNode(result.Root, &builder)
 	}
-	var builder strings.Builder
-	traverseDOMNode(result.Root, &builder)
 
-	body, err := page.HTML()
+	// Try to get HTML - don't fail if this times out
+	body, err = page.HTML()
 	if err != nil {
-		return nil, errkit.Wrap(err, "hybrid: could not get html")
+		gologger.Warning().Msgf("could not get html for %s: %s", request.URL, err)
+		if response != nil {
+			body = response.Body // fallback to body captured by page router
+		}
 	}
 
 	parsed, err := urlutil.Parse(request.URL)
@@ -327,7 +335,7 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 
 	response.Reader, err = goquery.NewDocumentFromReader(strings.NewReader(response.Body))
 	if err != nil {
-		return nil, errkit.Wrap(err, "hybrid: could not parse html")
+		gologger.Warning().Msgf("could not parse html for %s: %s", request.URL, err)
 	}
 
 	response.XhrRequests = xhrRequests

--- a/pkg/engine/hybrid/hybrid.go
+++ b/pkg/engine/hybrid/hybrid.go
@@ -18,6 +18,20 @@ import (
 	urlutil "github.com/projectdiscovery/utils/url"
 )
 
+// stderrLogger redirects rod download progress to stderr instead of stdout
+type stderrLogger struct{}
+
+func (l stderrLogger) Println(vs ...interface{}) {
+	fmt.Fprintln(os.Stderr, vs...)
+}
+
+// ensureBrowser downloads browser if needed, with output to stderr instead of stdout
+func ensureBrowser() {
+	browser := launcher.NewBrowser()
+	browser.Logger = stderrLogger{}
+	_ = browser.Download()
+}
+
 // Crawler is a standard crawler instance
 type Crawler struct {
 	*common.Shared
@@ -53,6 +67,10 @@ func New(options *types.CrawlerOptions) (*Crawler, error) {
 	if options.Options.ChromeWSUrl != "" {
 		launcherURL = options.Options.ChromeWSUrl
 	} else {
+		// ensure browser is downloaded (with stderr logging instead of stdout)
+		if !options.Options.UseInstalledChrome && options.Options.SystemChromePath == "" {
+			ensureBrowser()
+		}
 		// create new chrome launcher instance
 		chromeLauncher, err = buildChromeLauncher(options, dataStore)
 		if err != nil {
@@ -205,6 +223,7 @@ func (c *Crawler) Do(crawlSession *common.CrawlSession, doRequest common.DoReque
 func buildChromeLauncher(options *types.CrawlerOptions, dataStore string) (*launcher.Launcher, error) {
 	chromeLauncher := launcher.New().
 		Leakless(true).
+		Logger(os.Stderr). // redirect browser output to stderr to avoid mixing with JSON output
 		Set("disable-gpu", "true").
 		Set("ignore-certificate-errors", "true").
 		Set("ignore-certificate-errors", "1").


### PR DESCRIPTION
## Summary

Fixes the `-jsonl` option with `-headless` resulting in `"error": "context deadline exceeded <- could not get dom"`.

Fixes #611

## What changed?

- Don't fail the entire request when DOM/HTML retrieval times out - log warning and return captured response
- Redirect browser download progress to stderr instead of stdout (was breaking JSON parsing)

## Before

```json
{
  "error": "[hybrid:RUNTIME] context deadline exceeded <- could not get dom"
}
```

## After

```json
{
  "request": {"method": "GET", "endpoint": "https://example.com", ...},
  "response": {"status_code": 200, ...}
}
```


<img width="1134" height="119" alt="Screenshot From 2026-02-04 10-36-36" src="https://github.com/user-attachments/assets/77fab437-68da-49f0-9a02-d52251e9d2f9" />



## Testing

```bash
echo "https://example.com" | ./katana -silent -d 1 -jsonl -headless 2>/dev/null | jq
```
https://github.com/user-attachments/assets/509f9721-d5ea-40d3-b335-02e9b5eb6474

- [x] No error in JSON output
- [x] Response data captured even if DOM times out
- [x] Download progress goes to stderr (not mixed with JSON)

/claim #611 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic browser download when installation path is not specified.

* **Bug Fixes**
  * DOM and HTML retrieval failures no longer halt processing; warnings are logged instead.
  * Browser output now directed to stderr, preventing interference with JSON results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->