### PR TITLE
chore: make jsluice (go-tree-sitter) optional via build tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,13 @@
 katana requires Go 1.24+ to install successfully. If you encounter any installation issues, we recommend trying with the latest available version of Go, as the minimum required version may have changed. Run the command below or download a pre-compiled binary from the [release page](https://github.com/projectdiscovery/katana/releases).
 
 ```console
-CGO_ENABLED=1 go install github.com/projectdiscovery/katana/cmd/katana@latest
+go install github.com/projectdiscovery/katana/cmd/katana@latest
+```
+
+To enable jsluice parsing (requires CGO and go-tree-sitter), build with:
+
+```console
+CGO_ENABLED=1 go install -tags jsluice github.com/projectdiscovery/katana/cmd/katana@latest
 ```
 
 **More options to install / run katana-**
@@ -206,6 +212,8 @@ OUTPUT:
    -debug                            display debug output
    -version                          display project version
 ```
+
+Note: `-jsl` requires building with `-tags jsluice` and `CGO_ENABLED=1`. Default builds omit jsluice and keep CGO off.
 
 ## Running Katana
 

--- a/pkg/utils/jsluice.go
+++ b/pkg/utils/jsluice.go
@@ -1,28 +1,10 @@
-//go:build !(386 || windows)
+//go:build cgo && jsluice && !(386 || windows)
 
 package utils
 
 import (
-	"regexp"
-
 	"github.com/BishopFox/jsluice"
 )
-
-var (
-	// CommonJSLibraryFileRegex is a regex to match common js library files.
-	CommonJSLibraryFileRegex = `(?i)(?:amplify|quantserve|slideshow|jquery|modernizr|polyfill|vendor|modules|gtm|underscore?|tween|retina|selectivizr|cufon|angular|swf|sha1|freestyle|bootstrap|d3|backbone|videojs|google[-_]analytics|material|redux|knockout|datepicker|datetimepicker|ember|react|ng|fusion|analytics|libs?|vendors?|node[-_]modules|lodash|moment|chart|highcharts|raphael|prototype|mootools|dojo|ext|yui|web[-_]?components|polymer|vue|svelte|next|nuxt|gatsby|express|koa|hapi|socket[-_.]?io|axios|superagent|request|bluebird|rxjs|ramda|immutable|flux|redux[-_]saga|mobx|relay|apollo|graphql|three|phaser|pixi|babylon|cannon|hammer|howler|gsap|velocity|mo[-_.]?js|popper|shepherd|prism|highlight|markdown[-_]?it|codemirror|ace[-_]?editor|tinymce|ckeditor|quill|simplemde|monaco[-_]?editor|pdf[-_.]?js|jspdf|fabric|paper|konva|p5|processing|matter[-_.]?js|box2d|planck|chart[-_.]?js|plotly|echarts|d3[-_.]?force|sigma|c3|nvd3|amcharts|vis[-_.]?js|dagre[-_.]?d3|cytoscape|leaflet|openlayers|ol3|mapbox|cesium|turf|moment[-_.]?timezone|luxon|dayjs|date[-_.]?fns|date[-_.]?io|flatpickr|pikaday|fullcalendar|draggable|interact|sortable|dragula|dropzone|filepond|uppy|fine[-_.]?uploader|plyr|mediaelement|flowplayer|jwplayer|video[-_.]?js|mediaelement[-_.]?js|dash[-_.]?js|hls[-_.]?js|videojs|wavesurfer|soundmanager|amplitude|pizzicato|tone|adroll|doubleclick|facebook-pixel|ga-audiences|googlesyndication|adsbygoogle|gpt|amazon-adsystem|criteo|taboola|outbrain|bidswitch|bidswitch.net|spotxchange|yahoo|media.net|contextweb|openx|pubmatic|rubiconproject|indexexchange|appnexus|liveintent|triplelift|verizonmedia|synacor|sonobi|yieldmo|gumgum|smartadserver|mopub|pubnative|inmobi|chartboost|tapjoy|admob|unityads|vungle|flurry|matomy|altitude|dataxu|thetradedesk|exponential|zypmedia|quantcast|mediamath|bidswitch|mgid|revcontent|powerlinks|rhythmone|airpush|smaato|adcolony|mopub|leadbolt|mobfox|nativo|revjet|smartyads|avocarrot|epom|imobile|supersonicads|loopme|applovin|pandora|mytarget|bidvertiser|chitika|popads|propellerads|buysellads|adhit|hilltopads|plugrush|popcash|popunder|revenuehits|trafficjunky|trafficfactory|zero-|smartoasis)(?:[-._][\w\d]*)*\.js$`
-	commonJSLibraryFileRegexCompiled = regexp.MustCompile(CommonJSLibraryFileRegex)
-)
-
-// IsPathCommonJSLibraryFile checks if a given path is a common js library file.
-func IsPathCommonJSLibraryFile(path string) bool {
-	return commonJSLibraryFileRegexCompiled.MatchString(path)
-}
-
-type JSLuiceEndpoint struct {
-	Endpoint string
-	Type     string
-}
 
 // ExtractJsluiceEndpoints extracts jsluice endpoints from a given string.
 //

--- a/pkg/utils/jsluice_common.go
+++ b/pkg/utils/jsluice_common.go
@@ -1,0 +1,21 @@
+//go:build !(386 || windows)
+
+package utils
+
+import "regexp"
+
+var (
+	// CommonJSLibraryFileRegex is a regex to match common js library files.
+	CommonJSLibraryFileRegex = `(?i)(?:amplify|quantserve|slideshow|jquery|modernizr|polyfill|vendor|modules|gtm|underscore?|tween|retina|selectivizr|cufon|angular|swf|sha1|freestyle|bootstrap|d3|backbone|videojs|google[-_]analytics|material|redux|knockout|datepicker|datetimepicker|ember|react|ng|fusion|analytics|libs?|vendors?|node[-_]modules|lodash|moment|chart|highcharts|raphael|prototype|mootools|dojo|ext|yui|web[-_]?components|polymer|vue|svelte|next|nuxt|gatsby|express|koa|hapi|socket[-_.]?io|axios|superagent|request|bluebird|rxjs|ramda|immutable|flux|redux[-_]saga|mobx|relay|apollo|graphql|three|phaser|pixi|babylon|cannon|hammer|howler|gsap|velocity|mo[-_.]?js|popper|shepherd|prism|highlight|markdown[-_]?it|codemirror|ace[-_]?editor|tinymce|ckeditor|quill|simplemde|monaco[-_]?editor|pdf[-_.]?js|jspdf|fabric|paper|konva|p5|processing|matter[-_.]?js|box2d|planck|chart[-_.]?js|plotly|echarts|d3[-_.]?force|sigma|c3|nvd3|amcharts|vis[-_.]?js|dagre[-_.]?d3|cytoscape|leaflet|openlayers|ol3|mapbox|cesium|turf|moment[-_.]?timezone|luxon|dayjs|date[-_.]?fns|date[-_.]?io|flatpickr|pikaday|fullcalendar|draggable|interact|sortable|dragula|dropzone|filepond|uppy|fine[-_.]?uploader|plyr|mediaelement|flowplayer|jwplayer|video[-_.]?js|mediaelement[-_.]?js|dash[-_.]?js|hls[-_.]?js|videojs|wavesurfer|soundmanager|amplitude|pizzicato|tone|adroll|doubleclick|facebook-pixel|ga-audiences|googlesyndication|adsbygoogle|gpt|amazon-adsystem|criteo|taboola|outbrain|bidswitch|bidswitch.net|spotxchange|yahoo|media.net|contextweb|openx|pubmatic|rubiconproject|indexexchange|appnexus|liveintent|triplelift|verizonmedia|synacor|sonobi|yieldmo|gumgum|smartadserver|mopub|pubnative|inmobi|chartboost|tapjoy|admob|unityads|vungle|flurry|matomy|altitude|dataxu|thetradedesk|exponential|zypmedia|quantcast|mediamath|bidswitch|mgid|revcontent|powerlinks|rhythmone|airpush|smaato|adcolony|mopub|leadbolt|mobfox|nativo|revjet|smartyads|avocarrot|epom|imobile|supersonicads|loopme|applovin|pandora|mytarget|bidvertiser|chitika|popads|propellerads|buysellads|adhit|hilltopads|plugrush|popcash|popunder|revenuehits|trafficjunky|trafficfactory|zero-|smartoasis)(?:[-._][\w\d]*)*\.js$`
+	commonJSLibraryFileRegexCompiled = regexp.MustCompile(CommonJSLibraryFileRegex)
+)
+
+// IsPathCommonJSLibraryFile checks if a given path is a common js library file.
+func IsPathCommonJSLibraryFile(path string) bool {
+	return commonJSLibraryFileRegexCompiled.MatchString(path)
+}
+
+type JSLuiceEndpoint struct {
+	Endpoint string
+	Type     string
+}

--- a/pkg/utils/jsluice_disabled.go
+++ b/pkg/utils/jsluice_disabled.go
@@ -1,0 +1,8 @@
+//go:build !(386 || windows) && (!cgo || !jsluice)
+
+package utils
+
+// ExtractJsluiceEndpoints is a no-op when jsluice is not enabled or CGO is off.
+func ExtractJsluiceEndpoints(data string) []JSLuiceEndpoint {
+	return nil
+}

--- a/proof.txt
+++ b/proof.txt
@@ -1,0 +1,68 @@
+Proof of tests (issue #1367)
+Date: 2026-02-07T22:31:30Z
+
+> go test ./...
+?   	github.com/projectdiscovery/katana/cmd/functional-test	[no test files]
+?   	github.com/projectdiscovery/katana/cmd/integration-test	[no test files]
+?   	github.com/projectdiscovery/katana/cmd/katana	[no test files]
+?   	github.com/projectdiscovery/katana/cmd/tools/crawl-maze-score	[no test files]
+?   	github.com/projectdiscovery/katana/internal/runner	[no test files]
+?   	github.com/projectdiscovery/katana/internal/testutils	[no test files]
+?   	github.com/projectdiscovery/katana/pkg/engine	[no test files]
+?   	github.com/projectdiscovery/katana/pkg/engine/common	[no test files]
+?   	github.com/projectdiscovery/katana/pkg/engine/headless	[no test files]
+?   	github.com/projectdiscovery/katana/pkg/engine/headless/browser	[no test files]
+ok  	github.com/projectdiscovery/katana/pkg/engine/headless/browser/cookie	(cached)
+?   	github.com/projectdiscovery/katana/pkg/engine/headless/browser/stealth	[no test files]
+ok  	github.com/projectdiscovery/katana/pkg/engine/headless/crawler	(cached)
+?   	github.com/projectdiscovery/katana/pkg/engine/headless/crawler/diagnostics	[no test files]
+ok  	github.com/projectdiscovery/katana/pkg/engine/headless/crawler/normalizer	(cached)
+ok  	github.com/projectdiscovery/katana/pkg/engine/headless/crawler/normalizer/simhash	(cached)
+?   	github.com/projectdiscovery/katana/pkg/engine/headless/graph	[no test files]
+?   	github.com/projectdiscovery/katana/pkg/engine/headless/js	[no test files]
+?   	github.com/projectdiscovery/katana/pkg/engine/headless/types	[no test files]
+?   	github.com/projectdiscovery/katana/pkg/engine/hybrid	[no test files]
+ok  	github.com/projectdiscovery/katana/pkg/engine/parser	(cached)
+ok  	github.com/projectdiscovery/katana/pkg/engine/parser/files	(cached)
+?   	github.com/projectdiscovery/katana/pkg/engine/standard	[no test files]
+?   	github.com/projectdiscovery/katana/pkg/navigation	[no test files]
+ok  	github.com/projectdiscovery/katana/pkg/output	(cached)
+ok  	github.com/projectdiscovery/katana/pkg/types	(cached)
+ok  	github.com/projectdiscovery/katana/pkg/utils	(cached)
+ok  	github.com/projectdiscovery/katana/pkg/utils/extensions	(cached)
+ok  	github.com/projectdiscovery/katana/pkg/utils/filters	(cached)
+ok  	github.com/projectdiscovery/katana/pkg/utils/queue	(cached)
+ok  	github.com/projectdiscovery/katana/pkg/utils/scope	(cached)
+
+> CGO_ENABLED=1 go test -tags jsluice ./...
+?   	github.com/projectdiscovery/katana/cmd/functional-test	[no test files]
+?   	github.com/projectdiscovery/katana/cmd/integration-test	[no test files]
+?   	github.com/projectdiscovery/katana/cmd/katana	[no test files]
+?   	github.com/projectdiscovery/katana/cmd/tools/crawl-maze-score	[no test files]
+?   	github.com/projectdiscovery/katana/internal/runner	[no test files]
+?   	github.com/projectdiscovery/katana/internal/testutils	[no test files]
+?   	github.com/projectdiscovery/katana/pkg/engine	[no test files]
+?   	github.com/projectdiscovery/katana/pkg/engine/common	[no test files]
+?   	github.com/projectdiscovery/katana/pkg/engine/headless	[no test files]
+?   	github.com/projectdiscovery/katana/pkg/engine/headless/browser	[no test files]
+ok  	github.com/projectdiscovery/katana/pkg/engine/headless/browser/cookie	(cached)
+?   	github.com/projectdiscovery/katana/pkg/engine/headless/browser/stealth	[no test files]
+ok  	github.com/projectdiscovery/katana/pkg/engine/headless/crawler	(cached)
+?   	github.com/projectdiscovery/katana/pkg/engine/headless/crawler/diagnostics	[no test files]
+ok  	github.com/projectdiscovery/katana/pkg/engine/headless/crawler/normalizer	(cached)
+ok  	github.com/projectdiscovery/katana/pkg/engine/headless/crawler/normalizer/simhash	(cached)
+?   	github.com/projectdiscovery/katana/pkg/engine/headless/graph	[no test files]
+?   	github.com/projectdiscovery/katana/pkg/engine/headless/js	[no test files]
+?   	github.com/projectdiscovery/katana/pkg/engine/headless/types	[no test files]
+?   	github.com/projectdiscovery/katana/pkg/engine/hybrid	[no test files]
+ok  	github.com/projectdiscovery/katana/pkg/engine/parser	(cached)
+ok  	github.com/projectdiscovery/katana/pkg/engine/parser/files	(cached)
+?   	github.com/projectdiscovery/katana/pkg/engine/standard	[no test files]
+?   	github.com/projectdiscovery/katana/pkg/navigation	[no test files]
+ok  	github.com/projectdiscovery/katana/pkg/output	(cached)
+ok  	github.com/projectdiscovery/katana/pkg/types	(cached)
+ok  	github.com/projectdiscovery/katana/pkg/utils	(cached)
+ok  	github.com/projectdiscovery/katana/pkg/utils/extensions	(cached)
+ok  	github.com/projectdiscovery/katana/pkg/utils/filters	(cached)
+ok  	github.com/projectdiscovery/katana/pkg/utils/queue	(cached)
+ok  	github.com/projectdiscovery/katana/pkg/utils/scope	(cached)


### PR DESCRIPTION
/claim #1367

### What
- Make `jsluice` parsing optional behind build tags (`-tags jsluice` + `CGO_ENABLED=1`).
- Default builds no longer require the `go-tree-sitter` (CGO) dependency.
- Update README install + usage notes to clarify how to enable `-jsl`.

### Why
Issue #1367: `go-tree-sitter` is pulled in via `jsluice`, but `jsluice` is an optional feature. This isolates the CGO dependency so standard builds succeed without CGO.

### Proof
See PR comments / attached proof in the repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions providing clearer guidance on enabling jsluice parsing with specific build flags and commands.

* **Refactor**
  * Reorganized internal implementation of jsluice functionality for improved maintainability.

* **Tests**
  * Full test suite validation completed across default builds and jsluice-enabled configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->