### PR TITLE
feat: add query parameter count and path depth filtering

### DIFF
--- a/cmd/katana/main.go
+++ b/cmd/katana/main.go
@@ -213,6 +213,8 @@ pipelines offering both headless and non-headless crawling.`)
 		flagSet.StringVarP(&options.OutputMatchCondition, "match-condition", "mdc", "", "match response with dsl based condition"),
 		flagSet.StringVarP(&options.OutputFilterCondition, "filter-condition", "fdc", "", "filter response with dsl based condition"),
 		flagSet.BoolVarP(&options.DisableUniqueFilter, "disable-unique-filter", "duf", false, "disable duplicate content filtering"),
+		flagSet.StringSliceVarP(&options.QueryParamCount, "query-param-count", "cqp", nil, "filter URLs based on query parameter count (e.g., >=3, ==5, <2)", goflags.CommaSeparatedStringSliceOptions),
+		flagSet.StringSliceVarP(&options.PathDepth, "path-depth", "cpd", nil, "filter URLs based on path depth (e.g., >=4, ==3, <=2)", goflags.CommaSeparatedStringSliceOptions),
 	)
 
 	flagSet.CreateGroup("ratelimit", "Rate-Limit",

--- a/pkg/output/options.go
+++ b/pkg/output/options.go
@@ -29,4 +29,6 @@ type Options struct {
 	OutputMatchCondition  string
 	OutputFilterCondition string
 	ExcludeOutputFields   []string
+	QueryParamCount       []string
+	PathDepth             []string
 }

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -16,6 +16,7 @@ import (
 	"github.com/projectdiscovery/dsl"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/katana/pkg/navigation"
+	"github.com/projectdiscovery/katana/pkg/utils"
 	"github.com/projectdiscovery/katana/pkg/utils/extensions"
 	"github.com/projectdiscovery/utils/errkit"
 	fileutil "github.com/projectdiscovery/utils/file"
@@ -64,6 +65,8 @@ type StandardWriter struct {
 	outputMatchCondition  string
 	outputFilterCondition string
 	excludeOutputFields   []string
+	queryParamCount       []string
+	pathDepth             []string
 }
 
 // New returns a new output writer instance
@@ -85,6 +88,8 @@ func New(options Options) (Writer, error) {
 		outputMatchCondition:  options.OutputMatchCondition,
 		outputFilterCondition: options.OutputFilterCondition,
 		excludeOutputFields:   options.ExcludeOutputFields,
+		queryParamCount:       options.QueryParamCount,
+		pathDepth:             options.PathDepth,
 	}
 
 	if options.StoreFieldDir != "" {
@@ -180,6 +185,28 @@ func (w *StandardWriter) Write(result *Result) error {
 	}
 	if w.filterOutput(result) {
 		return errors.New("result is filtered out")
+	}
+
+	// Filter by query parameter count
+	if len(w.queryParamCount) > 0 {
+		matches, err := utils.MatchesQueryParamCount(result.Request.URL, w.queryParamCount)
+		if err != nil {
+			return errkit.Wrap(err, "error checking query param count")
+		}
+		if !matches {
+			return errors.New("result does not match query param count filter")
+		}
+	}
+
+	// Filter by path depth
+	if len(w.pathDepth) > 0 {
+		matches, err := utils.MatchesPathDepth(result.Request.URL, w.pathDepth)
+		if err != nil {
+			return errkit.Wrap(err, "error checking path depth")
+		}
+		if !matches {
+			return errors.New("result does not match path depth filter")
+		}
 	}
 	var data []byte
 	var err error

--- a/pkg/types/crawler_options.go
+++ b/pkg/types/crawler_options.go
@@ -102,6 +102,8 @@ func NewCrawlerOptions(options *Options) (*CrawlerOptions, error) {
 		OutputMatchCondition:  options.OutputMatchCondition,
 		OutputFilterCondition: options.OutputFilterCondition,
 		ExcludeOutputFields:   options.ExcludeOutputFields,
+		QueryParamCount:       options.QueryParamCount,
+		PathDepth:             options.PathDepth,
 	}
 
 	for _, mr := range options.OutputMatchRegex {

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -186,6 +186,10 @@ type Options struct {
 	DisableUniqueFilter bool
 	// MaxOnclickLinks is the maximum number of onclick links to process per page (default: 10)
 	MaxOnclickLinks int
+	// QueryParamCount is a list of conditions to filter URLs based on query parameter count
+	QueryParamCount goflags.StringSlice
+	// PathDepth is a list of conditions to filter URLs based on path depth
+	PathDepth goflags.StringSlice
 }
 
 func (options *Options) ParseCustomHeaders() map[string]string {

--- a/pkg/utils/url_filter.go
+++ b/pkg/utils/url_filter.go
@@ -7,13 +7,15 @@ import (
 	"strings"
 )
 
-// Condition represents a comparison condition
+// Condition represents a comparison condition.
 type Condition struct {
+	// Operator is the comparison operator (>=, <=, ==, >, <).
 	Operator string
-	Value    int
+	// Value is the numeric value to compare against.
+	Value int
 }
 
-// ParseCondition parses a condition string like ">=3", "==5", "<2"
+// ParseCondition parses a condition string like ">=3", "==5", "<2".
 func ParseCondition(condStr string) (*Condition, error) {
 	condStr = strings.TrimSpace(condStr)
 
@@ -35,7 +37,7 @@ func ParseCondition(condStr string) (*Condition, error) {
 	return nil, fmt.Errorf("invalid condition format: %s (expected format: >=3, ==5, <2, etc.)", condStr)
 }
 
-// Evaluate checks if the actual value satisfies the condition
+// Evaluate checks if the actual value satisfies the condition.
 func (c *Condition) Evaluate(actual int) bool {
 	switch c.Operator {
 	case ">=":
@@ -53,7 +55,7 @@ func (c *Condition) Evaluate(actual int) bool {
 	}
 }
 
-// CountQueryParams counts the number of query parameters in a URL
+// CountQueryParams counts the number of query parameters in a URL.
 func CountQueryParams(rawURL string) (int, error) {
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil {
@@ -64,8 +66,8 @@ func CountQueryParams(rawURL string) (int, error) {
 	return len(values), nil
 }
 
-// CountPathDepth counts the depth of the path in a URL
-// For example: /a/b/c has depth 3, / has depth 0
+// CountPathDepth counts the depth of the path in a URL.
+// For example: /a/b/c has depth 3, / has depth 0.
 func CountPathDepth(rawURL string) (int, error) {
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil {
@@ -81,7 +83,7 @@ func CountPathDepth(rawURL string) (int, error) {
 	return len(segments), nil
 }
 
-// CheckConditions checks if a value satisfies all conditions
+// CheckConditions checks if a value satisfies all conditions.
 func CheckConditions(value int, conditionStrs []string) (bool, error) {
 	if len(conditionStrs) == 0 {
 		return true, nil
@@ -101,7 +103,7 @@ func CheckConditions(value int, conditionStrs []string) (bool, error) {
 	return true, nil
 }
 
-// MatchesQueryParamCount checks if URL matches query parameter count conditions
+// MatchesQueryParamCount checks if URL matches query parameter count conditions.
 func MatchesQueryParamCount(rawURL string, conditions []string) (bool, error) {
 	if len(conditions) == 0 {
 		return true, nil
@@ -115,7 +117,7 @@ func MatchesQueryParamCount(rawURL string, conditions []string) (bool, error) {
 	return CheckConditions(count, conditions)
 }
 
-// MatchesPathDepth checks if URL matches path depth conditions
+// MatchesPathDepth checks if URL matches path depth conditions.
 func MatchesPathDepth(rawURL string, conditions []string) (bool, error) {
 	if len(conditions) == 0 {
 		return true, nil

--- a/pkg/utils/url_filter.go
+++ b/pkg/utils/url_filter.go
@@ -1,0 +1,130 @@
+package utils
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// Condition represents a comparison condition
+type Condition struct {
+	Operator string
+	Value    int
+}
+
+// ParseCondition parses a condition string like ">=3", "==5", "<2"
+func ParseCondition(condStr string) (*Condition, error) {
+	condStr = strings.TrimSpace(condStr)
+
+	operators := []string{">=", "<=", "==", ">", "<"}
+	for _, op := range operators {
+		if strings.HasPrefix(condStr, op) {
+			valueStr := strings.TrimSpace(condStr[len(op):])
+			value, err := strconv.Atoi(valueStr)
+			if err != nil {
+				return nil, fmt.Errorf("invalid value in condition %s: %v", condStr, err)
+			}
+			return &Condition{
+				Operator: op,
+				Value:    value,
+			}, nil
+		}
+	}
+
+	return nil, fmt.Errorf("invalid condition format: %s (expected format: >=3, ==5, <2, etc.)", condStr)
+}
+
+// Evaluate checks if the actual value satisfies the condition
+func (c *Condition) Evaluate(actual int) bool {
+	switch c.Operator {
+	case ">=":
+		return actual >= c.Value
+	case "<=":
+		return actual <= c.Value
+	case "==":
+		return actual == c.Value
+	case ">":
+		return actual > c.Value
+	case "<":
+		return actual < c.Value
+	default:
+		return false
+	}
+}
+
+// CountQueryParams counts the number of query parameters in a URL
+func CountQueryParams(rawURL string) (int, error) {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return 0, err
+	}
+
+	values := parsedURL.Query()
+	return len(values), nil
+}
+
+// CountPathDepth counts the depth of the path in a URL
+// For example: /a/b/c has depth 3, / has depth 0
+func CountPathDepth(rawURL string) (int, error) {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return 0, err
+	}
+
+	path := strings.Trim(parsedURL.Path, "/")
+	if path == "" {
+		return 0, nil
+	}
+
+	segments := strings.Split(path, "/")
+	return len(segments), nil
+}
+
+// CheckConditions checks if a value satisfies all conditions
+func CheckConditions(value int, conditionStrs []string) (bool, error) {
+	if len(conditionStrs) == 0 {
+		return true, nil
+	}
+
+	for _, condStr := range conditionStrs {
+		cond, err := ParseCondition(condStr)
+		if err != nil {
+			return false, err
+		}
+
+		if !cond.Evaluate(value) {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// MatchesQueryParamCount checks if URL matches query parameter count conditions
+func MatchesQueryParamCount(rawURL string, conditions []string) (bool, error) {
+	if len(conditions) == 0 {
+		return true, nil
+	}
+
+	count, err := CountQueryParams(rawURL)
+	if err != nil {
+		return false, err
+	}
+
+	return CheckConditions(count, conditions)
+}
+
+// MatchesPathDepth checks if URL matches path depth conditions
+func MatchesPathDepth(rawURL string, conditions []string) (bool, error) {
+	if len(conditions) == 0 {
+		return true, nil
+	}
+
+	depth, err := CountPathDepth(rawURL)
+	if err != nil {
+		return false, err
+	}
+
+	return CheckConditions(depth, conditions)
+}

--- a/pkg/utils/url_filter_test.go
+++ b/pkg/utils/url_filter_test.go
@@ -1,0 +1,378 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestParseCondition(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantOp    string
+		wantValue int
+		wantErr   bool
+	}{
+		{
+			name:      "greater than or equal",
+			input:     ">=3",
+			wantOp:    ">=",
+			wantValue: 3,
+			wantErr:   false,
+		},
+		{
+			name:      "less than or equal",
+			input:     "<=5",
+			wantOp:    "<=",
+			wantValue: 5,
+			wantErr:   false,
+		},
+		{
+			name:      "equal",
+			input:     "==2",
+			wantOp:    "==",
+			wantValue: 2,
+			wantErr:   false,
+		},
+		{
+			name:      "greater than",
+			input:     ">10",
+			wantOp:    ">",
+			wantValue: 10,
+			wantErr:   false,
+		},
+		{
+			name:      "less than",
+			input:     "<1",
+			wantOp:    "<",
+			wantValue: 1,
+			wantErr:   false,
+		},
+		{
+			name:    "invalid format",
+			input:   "invalid",
+			wantErr: true,
+		},
+		{
+			name:    "invalid value",
+			input:   ">=abc",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cond, err := ParseCondition(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ParseCondition() expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("ParseCondition() unexpected error: %v", err)
+				return
+			}
+			if cond.Operator != tt.wantOp {
+				t.Errorf("ParseCondition() operator = %v, want %v", cond.Operator, tt.wantOp)
+			}
+			if cond.Value != tt.wantValue {
+				t.Errorf("ParseCondition() value = %v, want %v", cond.Value, tt.wantValue)
+			}
+		})
+	}
+}
+
+func TestConditionEvaluate(t *testing.T) {
+	tests := []struct {
+		name     string
+		operator string
+		value    int
+		actual   int
+		want     bool
+	}{
+		{
+			name:     "greater than or equal - true",
+			operator: ">=",
+			value:    3,
+			actual:   5,
+			want:     true,
+		},
+		{
+			name:     "greater than or equal - equal",
+			operator: ">=",
+			value:    3,
+			actual:   3,
+			want:     true,
+		},
+		{
+			name:     "greater than or equal - false",
+			operator: ">=",
+			value:    3,
+			actual:   2,
+			want:     false,
+		},
+		{
+			name:     "less than or equal - true",
+			operator: "<=",
+			value:    5,
+			actual:   3,
+			want:     true,
+		},
+		{
+			name:     "equal - true",
+			operator: "==",
+			value:    3,
+			actual:   3,
+			want:     true,
+		},
+		{
+			name:     "equal - false",
+			operator: "==",
+			value:    3,
+			actual:   4,
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cond := &Condition{
+				Operator: tt.operator,
+				Value:    tt.value,
+			}
+			if got := cond.Evaluate(tt.actual); got != tt.want {
+				t.Errorf("Condition.Evaluate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCountQueryParams(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		want    int
+		wantErr bool
+	}{
+		{
+			name:    "no query params",
+			url:     "https://example.com/path",
+			want:    0,
+			wantErr: false,
+		},
+		{
+			name:    "one query param",
+			url:     "https://example.com/path?key=value",
+			want:    1,
+			wantErr: false,
+		},
+		{
+			name:    "three query params",
+			url:     "https://example.com/path?a=1&b=2&c=3",
+			want:    3,
+			wantErr: false,
+		},
+		{
+			name:    "multiple values for same key",
+			url:     "https://example.com/path?key=value1&key=value2",
+			want:    1,
+			wantErr: false,
+		},
+		{
+			name:    "five query params",
+			url:     "https://example.com/path?a=1&b=2&c=3&d=4&e=5",
+			want:    5,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CountQueryParams(tt.url)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CountQueryParams() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("CountQueryParams() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCountPathDepth(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		want    int
+		wantErr bool
+	}{
+		{
+			name:    "root path",
+			url:     "https://example.com/",
+			want:    0,
+			wantErr: false,
+		},
+		{
+			name:    "single segment",
+			url:     "https://example.com/path",
+			want:    1,
+			wantErr: false,
+		},
+		{
+			name:    "three segments",
+			url:     "https://example.com/a/b/c",
+			want:    3,
+			wantErr: false,
+		},
+		{
+			name:    "four segments",
+			url:     "https://example.com/a/b/c/d",
+			want:    4,
+			wantErr: false,
+		},
+		{
+			name:    "trailing slash",
+			url:     "https://example.com/a/b/c/",
+			want:    3,
+			wantErr: false,
+		},
+		{
+			name:    "no path",
+			url:     "https://example.com",
+			want:    0,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CountPathDepth(tt.url)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CountPathDepth() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("CountPathDepth() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchesQueryParamCount(t *testing.T) {
+	tests := []struct {
+		name       string
+		url        string
+		conditions []string
+		want       bool
+		wantErr    bool
+	}{
+		{
+			name:       "no conditions",
+			url:        "https://example.com/path?a=1",
+			conditions: []string{},
+			want:       true,
+			wantErr:    false,
+		},
+		{
+			name:       "matches >= condition",
+			url:        "https://example.com/path?a=1&b=2&c=3",
+			conditions: []string{">=3"},
+			want:       true,
+			wantErr:    false,
+		},
+		{
+			name:       "does not match >= condition",
+			url:        "https://example.com/path?a=1&b=2",
+			conditions: []string{">=3"},
+			want:       false,
+			wantErr:    false,
+		},
+		{
+			name:       "matches multiple conditions",
+			url:        "https://example.com/path?a=1&b=2&c=3",
+			conditions: []string{">=2", "<=5"},
+			want:       true,
+			wantErr:    false,
+		},
+		{
+			name:       "does not match one condition",
+			url:        "https://example.com/path?a=1&b=2&c=3&d=4&e=5&f=6",
+			conditions: []string{">=2", "<=5"},
+			want:       false,
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := MatchesQueryParamCount(tt.url, tt.conditions)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MatchesQueryParamCount() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("MatchesQueryParamCount() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchesPathDepth(t *testing.T) {
+	tests := []struct {
+		name       string
+		url        string
+		conditions []string
+		want       bool
+		wantErr    bool
+	}{
+		{
+			name:       "no conditions",
+			url:        "https://example.com/a/b/c",
+			conditions: []string{},
+			want:       true,
+			wantErr:    false,
+		},
+		{
+			name:       "matches >= condition",
+			url:        "https://example.com/a/b/c/d",
+			conditions: []string{">=4"},
+			want:       true,
+			wantErr:    false,
+		},
+		{
+			name:       "does not match >= condition",
+			url:        "https://example.com/a/b",
+			conditions: []string{">=4"},
+			want:       false,
+			wantErr:    false,
+		},
+		{
+			name:       "matches == condition",
+			url:        "https://example.com/a/b/c/d",
+			conditions: []string{"==4"},
+			want:       true,
+			wantErr:    false,
+		},
+		{
+			name:       "matches multiple conditions",
+			url:        "https://example.com/a/b/c",
+			conditions: []string{">=2", "<=5"},
+			want:       true,
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := MatchesPathDepth(tt.url, tt.conditions)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MatchesPathDepth() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("MatchesPathDepth() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Implements support for filtering URLs based on query parameter count and path depth, addressing #1353.

### New CLI Flags
- **`-cqp, --query-param-count`**: Filter URLs by query parameter count
- **`-cpd, --path-depth`**: Filter URLs by path depth

Both flags support comparison operators: `>=`, `<=`, `==`, `>`, `<`

### Examples

**Filter URLs with 3+ query parameters:**
```bash
katana -u https://target.com -cqp ">=3"
```

**Filter URLs with path depth exactly 4:**
```bash
katana -u https://target.com -cpd "==4"
```

**Filter URLs with path depth 2-5:**
```bash
katana -u https://target.com -cpd ">=2" -cpd "<=5"
```

**Combine both filters (query params <= 2 AND path depth >= 3):**
```bash
katana -u https://target.com -cqp "<=2" -cpd ">=3"
```

### Implementation Details
- Created new `url_filter.go` utility with condition parsing and evaluation
- Integrated filtering logic into the output writer pipeline
- Added comprehensive test coverage for all filtering functions
- All existing tests continue to pass

### Test Coverage
- Condition parsing (all operators)
- Query parameter counting
- Path depth calculation
- Filter evaluation with single and multiple conditions

/claim #1353


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --query-param-count (-cqp) and --path-depth (-cpd) CLI flags to filter URLs by query parameter count and path depth
  * Filters are condition-based and support operators: >=, <=, ==, >, <; filter evaluation is applied to output selection

* **Tests**
  * Added comprehensive tests covering condition parsing, query-param counting, path-depth calculation, and matching logic
<!-- end of auto-generated comment: release notes by coderabbit.ai -->