### PR TITLE
Fix: JSONL output with headless mode (#611)

### DIFF
--- a/pkg/output/format_json.go
+++ b/pkg/output/format_json.go
@@ -1,6 +1,8 @@
 package output
 
 import (
+	"fmt"
+
 	jsoniter "github.com/json-iterator/go"
 	"github.com/projectdiscovery/utils/structs"
 )
@@ -9,13 +11,13 @@ import (
 func (w *StandardWriter) formatJSON(output *Result) ([]byte, error) {
 	finalOrdMap, err := structs.FilterStructToMap(*output, nil, w.excludeOutputFields)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to filter struct: %w", err)
 	}
 
 	if _, ok := finalOrdMap.Get("request"); ok && output.Request != nil {
 		reqOrdMap, err := structs.FilterStructToMap(*output.Request, nil, w.excludeOutputFields)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to filter request: %w", err)
 		}
 		if reqOrdMap.Len() > 0 {
 			finalOrdMap.Set("request", reqOrdMap)
@@ -27,7 +29,7 @@ func (w *StandardWriter) formatJSON(output *Result) ([]byte, error) {
 	if _, ok := finalOrdMap.Get("response"); ok && output.Response != nil {
 		respOrdMap, err := structs.FilterStructToMap(*output.Response, nil, w.excludeOutputFields)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to filter response: %w", err)
 		}
 		if respOrdMap.Len() > 0 {
 			finalOrdMap.Set("response", respOrdMap)
@@ -36,5 +38,45 @@ func (w *StandardWriter) formatJSON(output *Result) ([]byte, error) {
 		}
 	}
 
-	return jsoniter.Marshal(finalOrdMap)
+	// FIX: Sanitize the map to ensure all values are JSON serializable
+	// This fixes issues when using -jsonl with -headless mode
+	sanitized := sanitizeForJSON(finalOrdMap)
+
+	return jsoniter.Marshal(sanitized)
+}
+
+// sanitizeForJSON recursively sanitizes a map to ensure all values are JSON serializable
+// This prevents errors when headless mode produces non-serializable data
+func sanitizeForJSON(v interface{}) interface{} {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		result := make(map[string]interface{})
+		for k, v := range val {
+			result[k] = sanitizeForJSON(v)
+		}
+		return result
+	case []interface{}:
+		result := make([]interface{}, len(val))
+		for i, v := range val {
+			result[i] = sanitizeForJSON(v)
+		}
+		return result
+	case string, int, int64, float64, bool, nil:
+		return val
+	case []string:
+		result := make([]interface{}, len(val))
+		for i, v := range val {
+			result[i] = v
+		}
+		return result
+	case map[string]string:
+		result := make(map[string]interface{})
+		for k, v := range val {
+			result[k] = v
+		}
+		return result
+	default:
+		// For any other types (functions, channels, complex structs), convert to string
+		return fmt.Sprintf("%v", val)
+	}
 }


### PR DESCRIPTION
## Problem
Using `-jsonl` flag together with `-headless` caused errors due to non-serializable fields in headless results.

## Root Cause
When headless mode is enabled, some internal data structures may contain non-JSON-serializable values (functions, channels, complex objects) that cause `json.Marshal` to fail.

## Solution
- Added `sanitizeForJSON()` function to recursively sanitize data before JSON marshaling
- Improved error handling in `formatJSON()` function with descriptive error messages
- Handles edge cases like nil values, slices, maps, and unknown types gracefully

## Changes
- `pkg/output/format_json.go`: Added sanitization logic and better error handling

## Testing
```bash
# Build and test
go build ./cmd/katana
./katana -u https://example.com -jsonl -headless
```

The output should now be valid JSONL format without errors.

## Checklist
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code follows project style guidelines
- [x] Self-review completed

Fixes #611

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON output handling with better support for non-standard data types, now properly converted to JSON-compatible formats.
  * Removed empty request/response sections from JSON output after filtering operations.
  * Enhanced error reporting in JSON formatting operations with improved error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->