### PR TITLE
fix: increased timeout for headless mode to fix issue #611

### DIFF
--- a/pkg/engine/hybrid/crawl.go
+++ b/pkg/engine/hybrid/crawl.go
@@ -182,9 +182,13 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 			gologger.Warning().Msgf("%s\n", err)
 		}
 	}()
-
 	timeout := time.Duration(c.Options.Options.Timeout) * time.Second
+	if c.Options.Options.Headless && c.Options.Options.JSONL {
+		timeout = timeout * 2
+	}
 	page = page.Timeout(timeout)
+	
+	
 
 	navigatedURLs := sliceutil.NewSyncSlice[string]()
 	navigatedURLs.Append(request.URL)


### PR DESCRIPTION
This PR resolves the "context deadline exceeded" error occurring when using Katana in headless mode with JSONL output. 

I have implemented a conditional timeout that doubles the duration specifically for this configuration to ensure stable output.

Fixes #611
/claim #611



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated page timeout configuration to double the wait time when both Headless and JSONL processing options are enabled together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->