### PR TITLE
feat: add -filter-similar flag for URL path pattern deduplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ CONFIGURATION:
    -s, -strategy string          Visit strategy (depth-first, breadth-first) (default "depth-first")
    -iqp, -ignore-query-params    Ignore crawling same path with different query-param values
    -fsu, -filter-similar         filter crawling of similar looking URLs (e.g., /users/123 and /users/456)
+   -fst, -filter-similar-threshold int  number of distinct values before a path position is treated as parameter (default 10)
    -tlsi, -tls-impersonate       enable experimental client hello (ja3) tls randomization
    -dr, -disable-redirects       disable following redirects (default false)
 
@@ -510,6 +511,21 @@ Automatic form filling is experimental feature.
 katana -u https://tesla.com -aff
 ```
 
+*`-filter-similar`*
+----
+
+Option to filter crawling of similar looking URLs by normalizing variable path segments. This detects IDs, UUIDs, hashes, dates, and other dynamic values, and also learns repeating patterns at runtime. For example, `/users/123` and `/users/456` are treated as the same endpoint.
+
+```
+katana -u https://tesla.com -fsu
+```
+
+The promotion threshold (how many distinct values at a path position before it's treated as a parameter) can be tuned with `-fst`. Lower values are more aggressive (fewer URLs crawled), higher values are more permissive. Default is `10`.
+
+```
+katana -u https://tesla.com -fsu -fst 5
+```
+
 ## Authenticated Crawling
 
 Authenticated crawling involves including custom headers or cookies in HTTP requests to access protected resources. These headers provide authentication or authorization information, allowing you to crawl authenticated content / endpoint. You can specify headers directly in the command line or provide them as a file with katana to perform authenticated crawling.
@@ -565,6 +581,9 @@ CONFIGURATION:
    -fc, -form-config string      path to custom form configuration file
    -flc, -field-config string    path to custom field configuration file
    -s, -strategy string          Visit strategy (depth-first, breadth-first) (default "depth-first")
+   -iqp, -ignore-query-params    Ignore crawling same path with different query-param values
+   -fsu, -filter-similar         filter crawling of similar looking URLs (e.g., /users/123 and /users/456)
+   -fst, -filter-similar-threshold int  number of distinct values before a path position is treated as parameter (default 10)
 ```
 
 ### Connecting to Active Browser Session

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ CONFIGURATION:
    -flc, -field-config string    path to custom field configuration file
    -s, -strategy string          Visit strategy (depth-first, breadth-first) (default "depth-first")
    -iqp, -ignore-query-params    Ignore crawling same path with different query-param values
+   -fsu, -filter-similar         filter crawling of similar looking URLs (e.g., /users/123 and /users/456)
    -tlsi, -tls-impersonate       enable experimental client hello (ja3) tls randomization
    -dr, -disable-redirects       disable following redirects (default false)
 

--- a/cmd/katana/main.go
+++ b/cmd/katana/main.go
@@ -167,6 +167,7 @@ pipelines offering both headless and non-headless crawling.`)
 		flagSet.StringVarP(&options.Strategy, "strategy", "s", "depth-first", "Visit strategy (depth-first, breadth-first)"),
 		flagSet.BoolVarP(&options.IgnoreQueryParams, "ignore-query-params", "iqp", false, "Ignore crawling same path with different query-param values"),
 		flagSet.BoolVarP(&options.FilterSimilar, "filter-similar", "fsu", false, "filter crawling of similar looking URLs (e.g., /users/123 and /users/456)"),
+		flagSet.IntVarP(&options.FilterSimilarThreshold, "filter-similar-threshold", "fst", 10, "number of distinct values before a path position is treated as parameter (default 10)"),
 		flagSet.BoolVarP(&options.TlsImpersonate, "tls-impersonate", "tlsi", false, "enable experimental client hello (ja3) tls randomization"),
 		flagSet.BoolVarP(&options.DisableRedirects, "disable-redirects", "dr", false, "disable following redirects (default false)"),
 		flagSet.BoolVarP(&options.PathClimb, "path-climb", "pc", false, "enable path climb (auto crawl parent paths)"),

--- a/cmd/katana/main.go
+++ b/cmd/katana/main.go
@@ -166,6 +166,7 @@ pipelines offering both headless and non-headless crawling.`)
 		flagSet.StringVarP(&options.FieldConfig, "field-config", "flc", "", "path to custom field configuration file"),
 		flagSet.StringVarP(&options.Strategy, "strategy", "s", "depth-first", "Visit strategy (depth-first, breadth-first)"),
 		flagSet.BoolVarP(&options.IgnoreQueryParams, "ignore-query-params", "iqp", false, "Ignore crawling same path with different query-param values"),
+		flagSet.BoolVarP(&options.FilterSimilar, "filter-similar", "fsu", false, "filter crawling of similar looking URLs (e.g., /users/123 and /users/456)"),
 		flagSet.BoolVarP(&options.TlsImpersonate, "tls-impersonate", "tlsi", false, "enable experimental client hello (ja3) tls randomization"),
 		flagSet.BoolVarP(&options.DisableRedirects, "disable-redirects", "dr", false, "disable following redirects (default false)"),
 		flagSet.BoolVarP(&options.PathClimb, "path-climb", "pc", false, "enable path climb (auto crawl parent paths)"),

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/adrianbrad/queue v1.3.0
 	github.com/dominikbraun/graph v0.23.0
 	github.com/go-rod/rod v0.116.2
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/json-iterator/go v1.1.12
 	github.com/lmittmann/tint v1.0.6
 	github.com/logrusorgru/aurora v2.0.3+incompatible
@@ -71,7 +72,6 @@ require (
 	github.com/gosimple/slug v1.15.0 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
-	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/hdm/jarm-go v0.0.7 // indirect
 	github.com/iangcarroll/cookiemonster v1.6.0 // indirect
 	github.com/kataras/jwt v0.1.8 // indirect

--- a/pkg/engine/common/base.go
+++ b/pkg/engine/common/base.go
@@ -33,6 +33,7 @@ type Shared struct {
 	KnownFiles *files.KnownFiles
 	Options    *types.CrawlerOptions
 	Jar        *httputil.CookieJar
+	PathTrie   *utils.PathTrie
 }
 
 // NewShared creates a new Shared instance with the provided crawler options.
@@ -57,6 +58,10 @@ func NewShared(options *types.CrawlerOptions) (*Shared, error) {
 		return nil, errkit.Wrap(err, "could not create cookie jar")
 	}
 	shared.Jar = jar
+
+	if options.Options.FilterSimilar {
+		shared.PathTrie = utils.NewPathTrie()
+	}
 
 	return shared, nil
 }
@@ -87,6 +92,9 @@ func (s *Shared) Enqueue(queue *queue.Queue, navigationRequests ...*navigation.R
 		reqUrl := nr.RequestURL()
 		if s.Options.Options.IgnoreQueryParams {
 			reqUrl = utils.ReplaceAllQueryParam(reqUrl, "")
+		}
+		if s.Options.Options.FilterSimilar {
+			reqUrl = utils.FingerprintURL(reqUrl, s.PathTrie)
 		}
 
 		// Skip adding to the crawl queue when the maximum depth is exceeded.
@@ -125,7 +133,11 @@ func (s *Shared) Enqueue(queue *queue.Queue, navigationRequests ...*navigation.R
 					continue
 				}
 
-				if !s.Options.UniqueFilter.UniqueURL(extractedParentURL) {
+				checkURL := extractedParentURL
+				if s.Options.Options.FilterSimilar {
+					checkURL = utils.FingerprintURL(checkURL, s.PathTrie)
+				}
+				if !s.Options.UniqueFilter.UniqueURL(checkURL) {
 					continue
 				}
 				if !s.ValidateScope(extractedParentURL, nr.RootHostname) {

--- a/pkg/engine/common/base.go
+++ b/pkg/engine/common/base.go
@@ -60,7 +60,7 @@ func NewShared(options *types.CrawlerOptions) (*Shared, error) {
 	shared.Jar = jar
 
 	if options.Options.FilterSimilar {
-		shared.PathTrie = utils.NewPathTrie()
+		shared.PathTrie = utils.NewPathTrie(options.Options.FilterSimilarThreshold)
 	}
 
 	return shared, nil

--- a/pkg/engine/headless/headless.go
+++ b/pkg/engine/headless/headless.go
@@ -37,7 +37,7 @@ func New(options *types.CrawlerOptions) (*Headless, error) {
 		deduplicator: mapsutil.NewSyncLockMap[string, struct{}](),
 	}
 	if options.Options.FilterSimilar {
-		headless.pathTrie = utils.NewPathTrie()
+		headless.pathTrie = utils.NewPathTrie(options.Options.FilterSimilarThreshold)
 	}
 
 	// Show crawl debugger if verbose is enabled

--- a/pkg/engine/headless/headless.go
+++ b/pkg/engine/headless/headless.go
@@ -12,6 +12,7 @@ import (
 	"github.com/projectdiscovery/katana/pkg/engine/parser"
 	"github.com/projectdiscovery/katana/pkg/output"
 	"github.com/projectdiscovery/katana/pkg/types"
+	"github.com/projectdiscovery/katana/pkg/utils"
 	mapsutil "github.com/projectdiscovery/utils/maps"
 )
 
@@ -20,6 +21,7 @@ type Headless struct {
 	options *types.CrawlerOptions
 
 	deduplicator *mapsutil.SyncLockMap[string, struct{}]
+	pathTrie     *utils.PathTrie
 
 	debugger *CrawlDebugger
 }
@@ -33,6 +35,9 @@ func New(options *types.CrawlerOptions) (*Headless, error) {
 		options: options,
 
 		deduplicator: mapsutil.NewSyncLockMap[string, struct{}](),
+	}
+	if options.Options.FilterSimilar {
+		headless.pathTrie = utils.NewPathTrie()
 	}
 
 	// Show crawl debugger if verbose is enabled
@@ -177,10 +182,14 @@ func (h *Headless) performAdditionalAnalysis(rr *output.Result) []*output.Result
 
 	navigationRequests := make([]*output.Result, 0)
 	for _, resp := range newNavigations {
-		if _, ok := h.deduplicator.Get(resp.URL); ok {
+		dedupKey := resp.URL
+		if h.options.Options.FilterSimilar {
+			dedupKey = utils.FingerprintURL(dedupKey, h.pathTrie)
+		}
+		if _, ok := h.deduplicator.Get(dedupKey); ok {
 			continue
 		}
-		if err := h.deduplicator.Set(resp.URL, struct{}{}); err != nil {
+		if err := h.deduplicator.Set(dedupKey, struct{}{}); err != nil {
 			h.logger.Debug("deduplicator set failed",
 				slog.String("url", resp.URL),
 				slog.String("error", err.Error()),

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -177,6 +177,9 @@ type Options struct {
 	// FilterSimilar filters crawling of similar looking URLs
 	// by normalizing variable path segments (IDs, UUIDs, hashes, dates)
 	FilterSimilar bool
+	// FilterSimilarThreshold is the number of distinct values at a path position
+	// before it is treated as a parameter (default 10, lower = more aggressive)
+	FilterSimilarThreshold int
 	// Debug
 	Debug bool
 	// TlsImpersonate enables experimental tls ClientHello randomization for standard crawler

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -174,6 +174,9 @@ type Options struct {
 	DisableUpdateCheck bool
 	//IgnoreQueryParams ignore crawling same path with different query-param values
 	IgnoreQueryParams bool
+	// FilterSimilar filters crawling of similar looking URLs
+	// by normalizing variable path segments (IDs, UUIDs, hashes, dates)
+	FilterSimilar bool
 	// Debug
 	Debug bool
 	// TlsImpersonate enables experimental tls ClientHello randomization for standard crawler

--- a/pkg/utils/pathtrie.go
+++ b/pkg/utils/pathtrie.go
@@ -1,0 +1,73 @@
+package utils
+
+// DefaultPromotionThreshold is the number of distinct children a trie node
+// must accumulate before being promoted to a parameter node.
+const DefaultPromotionThreshold = 10
+
+// PathTrie is a per-host adaptive trie that tracks unique path segments
+// at each position. When a node accumulates more distinct children than
+// the promotion threshold, it is promoted to a parameter node and all
+// future values at that position are collapsed.
+type PathTrie struct {
+	roots     map[string]*trieNode
+	threshold int
+}
+
+type trieNode struct {
+	children   map[string]*trieNode
+	paramChild *trieNode
+	promoted   bool
+}
+
+// NewPathTrie creates a new PathTrie with the default promotion threshold.
+func NewPathTrie() *PathTrie {
+	return &PathTrie{
+		roots:     make(map[string]*trieNode),
+		threshold: DefaultPromotionThreshold,
+	}
+}
+
+// Fingerprint walks the trie for the given host and segments, returning
+// a new slice where promoted positions are replaced with "{param}".
+// Non-promoted segments are registered in the trie for future cardinality tracking.
+func (t *PathTrie) Fingerprint(host string, segments []string) []string {
+	root, ok := t.roots[host]
+	if !ok {
+		root = &trieNode{children: make(map[string]*trieNode)}
+		t.roots[host] = root
+	}
+
+	result := make([]string, len(segments))
+	current := root
+
+	for i, seg := range segments {
+		if current.promoted {
+			result[i] = "{param}"
+			if current.paramChild == nil {
+				current.paramChild = &trieNode{children: make(map[string]*trieNode)}
+			}
+			current = current.paramChild
+			continue
+		}
+
+		child, exists := current.children[seg]
+		if !exists {
+			child = &trieNode{children: make(map[string]*trieNode)}
+			current.children[seg] = child
+
+			if len(current.children) > t.threshold {
+				current.promoted = true
+				current.paramChild = &trieNode{children: make(map[string]*trieNode)}
+				current.children = nil
+				result[i] = "{param}"
+				current = current.paramChild
+				continue
+			}
+		}
+
+		result[i] = seg
+		current = child
+	}
+
+	return result
+}

--- a/pkg/utils/pathtrie.go
+++ b/pkg/utils/pathtrie.go
@@ -1,18 +1,29 @@
 package utils
 
-import "sync"
+import (
+	"sync"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+)
 
 // DefaultPromotionThreshold is the number of distinct children a trie node
 // must accumulate before being promoted to a parameter node.
 const DefaultPromotionThreshold = 10
 
+// DefaultMaxHosts is the maximum number of hosts tracked by the LRU cache.
+// When exceeded, the least recently used host's trie is evicted.
+const DefaultMaxHosts = 10000
+
 // PathTrie is a per-host adaptive trie that tracks unique path segments
 // at each position. When a node accumulates more distinct children than
 // the promotion threshold, it is promoted to a parameter node and all
 // future values at that position are collapsed.
+//
+// Host tracking is bounded by an LRU cache to prevent unbounded memory
+// growth during large crawls.
 type PathTrie struct {
 	mu        sync.Mutex
-	roots     map[string]*trieNode
+	roots     *lru.Cache[string, *trieNode]
 	threshold int
 }
 
@@ -22,11 +33,16 @@ type trieNode struct {
 	promoted   bool
 }
 
-// NewPathTrie creates a new PathTrie with the default promotion threshold.
-func NewPathTrie() *PathTrie {
+// NewPathTrie creates a new PathTrie with the given promotion threshold.
+// If threshold is <= 0, DefaultPromotionThreshold is used.
+func NewPathTrie(threshold int) *PathTrie {
+	if threshold <= 0 {
+		threshold = DefaultPromotionThreshold
+	}
+	cache, _ := lru.New[string, *trieNode](DefaultMaxHosts)
 	return &PathTrie{
-		roots:     make(map[string]*trieNode),
-		threshold: DefaultPromotionThreshold,
+		roots:     cache,
+		threshold: threshold,
 	}
 }
 
@@ -37,10 +53,10 @@ func (t *PathTrie) Fingerprint(host string, segments []string) []string {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	root, ok := t.roots[host]
+	root, ok := t.roots.Get(host)
 	if !ok {
 		root = &trieNode{children: make(map[string]*trieNode)}
-		t.roots[host] = root
+		t.roots.Add(host, root)
 	}
 
 	result := make([]string, len(segments))

--- a/pkg/utils/pathtrie.go
+++ b/pkg/utils/pathtrie.go
@@ -1,5 +1,7 @@
 package utils
 
+import "sync"
+
 // DefaultPromotionThreshold is the number of distinct children a trie node
 // must accumulate before being promoted to a parameter node.
 const DefaultPromotionThreshold = 10
@@ -9,6 +11,7 @@ const DefaultPromotionThreshold = 10
 // the promotion threshold, it is promoted to a parameter node and all
 // future values at that position are collapsed.
 type PathTrie struct {
+	mu        sync.Mutex
 	roots     map[string]*trieNode
 	threshold int
 }
@@ -31,6 +34,9 @@ func NewPathTrie() *PathTrie {
 // a new slice where promoted positions are replaced with "{param}".
 // Non-promoted segments are registered in the trie for future cardinality tracking.
 func (t *PathTrie) Fingerprint(host string, segments []string) []string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
 	root, ok := t.roots[host]
 	if !ok {
 		root = &trieNode{children: make(map[string]*trieNode)}

--- a/pkg/utils/pathtrie_test.go
+++ b/pkg/utils/pathtrie_test.go
@@ -1,0 +1,243 @@
+package utils
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestPathTrie_BasicInsertion(t *testing.T) {
+	trie := NewPathTrie()
+	segments := []string{"api", "v1", "users"}
+	result := trie.Fingerprint("example.com", segments)
+
+	for i, seg := range result {
+		if seg != segments[i] {
+			t.Errorf("segment %d = %q, want %q", i, seg, segments[i])
+		}
+	}
+}
+
+func TestPathTrie_RepeatedInsertionNoop(t *testing.T) {
+	trie := NewPathTrie()
+	host := "example.com"
+	segments := []string{"api", "v1", "users"}
+
+	// Inserting the same path many times should not trigger promotion
+	for range 100 {
+		result := trie.Fingerprint(host, segments)
+		for i, seg := range result {
+			if seg != segments[i] {
+				t.Fatalf("repeated insertion changed segment %d: got %q, want %q", i, seg, segments[i])
+			}
+		}
+	}
+}
+
+func TestPathTrie_PromotionExactThreshold(t *testing.T) {
+	trie := NewPathTrie()
+	host := "example.com"
+
+	// Insert exactly threshold distinct children — should NOT promote
+	for i := range DefaultPromotionThreshold {
+		trie.Fingerprint(host, []string{"items", fmt.Sprintf("item-%d", i)})
+	}
+	result := trie.Fingerprint(host, []string{"items", "item-0"})
+	if result[1] == "{param}" {
+		t.Error("promoted at exactly threshold, should only promote when exceeding")
+	}
+
+	// One more distinct child triggers promotion
+	result = trie.Fingerprint(host, []string{"items", "item-trigger"})
+	if result[1] != "{param}" {
+		t.Errorf("expected promotion after exceeding threshold, got %q", result[1])
+	}
+}
+
+func TestPathTrie_Promotion(t *testing.T) {
+	trie := NewPathTrie()
+	host := "example.com"
+
+	for i := range DefaultPromotionThreshold + 1 {
+		trie.Fingerprint(host, []string{"blog", fmt.Sprintf("slug-%d", i)})
+	}
+
+	result := trie.Fingerprint(host, []string{"blog", "brand-new-slug"})
+	if result[0] != "blog" {
+		t.Errorf("static segment = %q, want %q", result[0], "blog")
+	}
+	if result[1] != "{param}" {
+		t.Errorf("promoted segment = %q, want %q", result[1], "{param}")
+	}
+}
+
+func TestPathTrie_PromotionDoesNotAffectOtherHosts(t *testing.T) {
+	trie := NewPathTrie()
+
+	for i := range DefaultPromotionThreshold + 1 {
+		trie.Fingerprint("a.com", []string{"users", fmt.Sprintf("user-%d", i)})
+	}
+
+	result := trie.Fingerprint("b.com", []string{"users", "alice"})
+	if result[1] != "alice" {
+		t.Errorf("host isolation failed: got %q, want %q", result[1], "alice")
+	}
+}
+
+func TestPathTrie_DeepPath(t *testing.T) {
+	trie := NewPathTrie()
+	host := "example.com"
+
+	for i := range DefaultPromotionThreshold + 1 {
+		trie.Fingerprint(host, []string{"api", "users", fmt.Sprintf("user-%d", i), "posts"})
+	}
+
+	result := trie.Fingerprint(host, []string{"api", "users", "new-user", "posts"})
+	expected := []string{"api", "users", "{param}", "posts"}
+	for i, seg := range result {
+		if seg != expected[i] {
+			t.Errorf("segment %d = %q, want %q", i, seg, expected[i])
+		}
+	}
+}
+
+func TestPathTrie_EmptySegments(t *testing.T) {
+	trie := NewPathTrie()
+	result := trie.Fingerprint("example.com", []string{})
+	if len(result) != 0 {
+		t.Errorf("expected empty result, got %v", result)
+	}
+}
+
+func TestPathTrie_SingleSegment(t *testing.T) {
+	trie := NewPathTrie()
+
+	for i := range DefaultPromotionThreshold + 1 {
+		trie.Fingerprint("example.com", []string{fmt.Sprintf("page-%d", i)})
+	}
+
+	result := trie.Fingerprint("example.com", []string{"page-new"})
+	if result[0] != "{param}" {
+		t.Errorf("got %q, want {param}", result[0])
+	}
+}
+
+func TestPathTrie_PromotedNodeChildrenNil(t *testing.T) {
+	trie := NewPathTrie()
+	host := "example.com"
+
+	for i := range DefaultPromotionThreshold + 1 {
+		trie.Fingerprint(host, []string{fmt.Sprintf("item-%d", i)})
+	}
+
+	root := trie.roots[host]
+	if root.children != nil {
+		t.Error("expected children to be nil after promotion")
+	}
+	if !root.promoted {
+		t.Error("expected node to be promoted")
+	}
+}
+
+func TestPathTrie_PreviousValueCollapseAfterPromotion(t *testing.T) {
+	trie := NewPathTrie()
+	host := "example.com"
+
+	// Insert values before promotion
+	trie.Fingerprint(host, []string{"blog", "first-post"})
+	trie.Fingerprint(host, []string{"blog", "second-post"})
+
+	// Trigger promotion
+	for i := 2; i <= DefaultPromotionThreshold; i++ {
+		trie.Fingerprint(host, []string{"blog", fmt.Sprintf("post-%d", i)})
+	}
+
+	// Previously seen "first-post" should now collapse
+	result := trie.Fingerprint(host, []string{"blog", "first-post"})
+	if result[1] != "{param}" {
+		t.Errorf("previously seen value after promotion: got %q, want {param}", result[1])
+	}
+}
+
+func TestPathTrie_SegmentsAfterPromotedNodeTrackedIndependently(t *testing.T) {
+	trie := NewPathTrie()
+	host := "example.com"
+
+	// Promote the username segment: /users/{param}/...
+	for i := range DefaultPromotionThreshold + 1 {
+		trie.Fingerprint(host, []string{"users", fmt.Sprintf("user-%d", i), "profile"})
+	}
+
+	// After username is promoted, segments AFTER it should still track independently
+	// Feed "profile" and "settings" — two distinct values, should not promote
+	trie.Fingerprint(host, []string{"users", "someone", "settings"})
+	result := trie.Fingerprint(host, []string{"users", "anyone", "settings"})
+
+	if result[1] != "{param}" {
+		t.Errorf("promoted segment: got %q, want {param}", result[1])
+	}
+	// "settings" should still be literal since paramChild only has 2 children
+	if result[2] == "{param}" {
+		t.Errorf("segment after promoted should not be promoted yet: got %q", result[2])
+	}
+}
+
+func TestPathTrie_MultipleBranchesIndependent(t *testing.T) {
+	trie := NewPathTrie()
+	host := "example.com"
+
+	// Promote /api/users/* but not /api/posts/*
+	for i := range DefaultPromotionThreshold + 1 {
+		trie.Fingerprint(host, []string{"api", "users", fmt.Sprintf("user-%d", i)})
+	}
+	// Only add a few posts
+	trie.Fingerprint(host, []string{"api", "posts", "first"})
+	trie.Fingerprint(host, []string{"api", "posts", "second"})
+
+	// users should be promoted
+	result := trie.Fingerprint(host, []string{"api", "users", "new"})
+	if result[2] != "{param}" {
+		t.Errorf("users branch should be promoted: got %q", result[2])
+	}
+
+	// posts should NOT be promoted
+	result = trie.Fingerprint(host, []string{"api", "posts", "third"})
+	if result[2] == "{param}" {
+		t.Errorf("posts branch should not be promoted: got %q", result[2])
+	}
+}
+
+func TestPathTrie_MultiplePromotionsAtDifferentDepths(t *testing.T) {
+	trie := NewPathTrie()
+	host := "example.com"
+
+	// Promote at depth 0 (root children)
+	for i := range DefaultPromotionThreshold + 1 {
+		trie.Fingerprint(host, []string{fmt.Sprintf("section-%d", i), "page"})
+	}
+
+	result := trie.Fingerprint(host, []string{"section-new", "page"})
+	if result[0] != "{param}" {
+		t.Errorf("depth 0 promotion: got %q, want {param}", result[0])
+	}
+
+	// Depth 1 should still track normally through paramChild
+	// "page" is the only value at depth 1 through paramChild, so not promoted
+	if result[1] == "{param}" {
+		t.Errorf("depth 1 should not be promoted yet: got %q", result[1])
+	}
+}
+
+func TestPathTrie_NewHostLazyInit(t *testing.T) {
+	trie := NewPathTrie()
+
+	// Accessing new host should work without explicit init
+	result := trie.Fingerprint("new-host.com", []string{"foo", "bar"})
+	if result[0] != "foo" || result[1] != "bar" {
+		t.Errorf("lazy init failed: got %v", result)
+	}
+
+	// Verify the host was created
+	if _, exists := trie.roots["new-host.com"]; !exists {
+		t.Error("host root not created after first access")
+	}
+}

--- a/pkg/utils/pathtrie_test.go
+++ b/pkg/utils/pathtrie_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestPathTrie_BasicInsertion(t *testing.T) {
-	trie := NewPathTrie()
+	trie := NewPathTrie(0)
 	segments := []string{"api", "v1", "users"}
 	result := trie.Fingerprint("example.com", segments)
 
@@ -18,7 +18,7 @@ func TestPathTrie_BasicInsertion(t *testing.T) {
 }
 
 func TestPathTrie_RepeatedInsertionNoop(t *testing.T) {
-	trie := NewPathTrie()
+	trie := NewPathTrie(0)
 	host := "example.com"
 	segments := []string{"api", "v1", "users"}
 
@@ -34,7 +34,7 @@ func TestPathTrie_RepeatedInsertionNoop(t *testing.T) {
 }
 
 func TestPathTrie_PromotionExactThreshold(t *testing.T) {
-	trie := NewPathTrie()
+	trie := NewPathTrie(0)
 	host := "example.com"
 
 	// Insert exactly threshold distinct children — should NOT promote
@@ -54,7 +54,7 @@ func TestPathTrie_PromotionExactThreshold(t *testing.T) {
 }
 
 func TestPathTrie_Promotion(t *testing.T) {
-	trie := NewPathTrie()
+	trie := NewPathTrie(0)
 	host := "example.com"
 
 	for i := range DefaultPromotionThreshold + 1 {
@@ -71,7 +71,7 @@ func TestPathTrie_Promotion(t *testing.T) {
 }
 
 func TestPathTrie_PromotionDoesNotAffectOtherHosts(t *testing.T) {
-	trie := NewPathTrie()
+	trie := NewPathTrie(0)
 
 	for i := range DefaultPromotionThreshold + 1 {
 		trie.Fingerprint("a.com", []string{"users", fmt.Sprintf("user-%d", i)})
@@ -84,7 +84,7 @@ func TestPathTrie_PromotionDoesNotAffectOtherHosts(t *testing.T) {
 }
 
 func TestPathTrie_DeepPath(t *testing.T) {
-	trie := NewPathTrie()
+	trie := NewPathTrie(0)
 	host := "example.com"
 
 	for i := range DefaultPromotionThreshold + 1 {
@@ -101,7 +101,7 @@ func TestPathTrie_DeepPath(t *testing.T) {
 }
 
 func TestPathTrie_EmptySegments(t *testing.T) {
-	trie := NewPathTrie()
+	trie := NewPathTrie(0)
 	result := trie.Fingerprint("example.com", []string{})
 	if len(result) != 0 {
 		t.Errorf("expected empty result, got %v", result)
@@ -109,7 +109,7 @@ func TestPathTrie_EmptySegments(t *testing.T) {
 }
 
 func TestPathTrie_SingleSegment(t *testing.T) {
-	trie := NewPathTrie()
+	trie := NewPathTrie(0)
 
 	for i := range DefaultPromotionThreshold + 1 {
 		trie.Fingerprint("example.com", []string{fmt.Sprintf("page-%d", i)})
@@ -122,14 +122,17 @@ func TestPathTrie_SingleSegment(t *testing.T) {
 }
 
 func TestPathTrie_PromotedNodeChildrenNil(t *testing.T) {
-	trie := NewPathTrie()
+	trie := NewPathTrie(0)
 	host := "example.com"
 
 	for i := range DefaultPromotionThreshold + 1 {
 		trie.Fingerprint(host, []string{fmt.Sprintf("item-%d", i)})
 	}
 
-	root := trie.roots[host]
+	root, ok := trie.roots.Get(host)
+	if !ok {
+		t.Fatal("expected host root to exist")
+	}
 	if root.children != nil {
 		t.Error("expected children to be nil after promotion")
 	}
@@ -139,7 +142,7 @@ func TestPathTrie_PromotedNodeChildrenNil(t *testing.T) {
 }
 
 func TestPathTrie_PreviousValueCollapseAfterPromotion(t *testing.T) {
-	trie := NewPathTrie()
+	trie := NewPathTrie(0)
 	host := "example.com"
 
 	// Insert values before promotion
@@ -159,7 +162,7 @@ func TestPathTrie_PreviousValueCollapseAfterPromotion(t *testing.T) {
 }
 
 func TestPathTrie_SegmentsAfterPromotedNodeTrackedIndependently(t *testing.T) {
-	trie := NewPathTrie()
+	trie := NewPathTrie(0)
 	host := "example.com"
 
 	// Promote the username segment: /users/{param}/...
@@ -182,7 +185,7 @@ func TestPathTrie_SegmentsAfterPromotedNodeTrackedIndependently(t *testing.T) {
 }
 
 func TestPathTrie_MultipleBranchesIndependent(t *testing.T) {
-	trie := NewPathTrie()
+	trie := NewPathTrie(0)
 	host := "example.com"
 
 	// Promote /api/users/* but not /api/posts/*
@@ -207,7 +210,7 @@ func TestPathTrie_MultipleBranchesIndependent(t *testing.T) {
 }
 
 func TestPathTrie_MultiplePromotionsAtDifferentDepths(t *testing.T) {
-	trie := NewPathTrie()
+	trie := NewPathTrie(0)
 	host := "example.com"
 
 	// Promote at depth 0 (root children)
@@ -228,7 +231,7 @@ func TestPathTrie_MultiplePromotionsAtDifferentDepths(t *testing.T) {
 }
 
 func TestPathTrie_NewHostLazyInit(t *testing.T) {
-	trie := NewPathTrie()
+	trie := NewPathTrie(0)
 
 	// Accessing new host should work without explicit init
 	result := trie.Fingerprint("new-host.com", []string{"foo", "bar"})
@@ -236,8 +239,47 @@ func TestPathTrie_NewHostLazyInit(t *testing.T) {
 		t.Errorf("lazy init failed: got %v", result)
 	}
 
-	// Verify the host was created
-	if _, exists := trie.roots["new-host.com"]; !exists {
+	// Verify the host was created in the LRU cache
+	if !trie.roots.Contains("new-host.com") {
 		t.Error("host root not created after first access")
+	}
+}
+
+func TestPathTrie_CustomThreshold(t *testing.T) {
+	trie := NewPathTrie(3)
+	host := "example.com"
+
+	// With threshold=3, promotion happens after 4 distinct children
+	trie.Fingerprint(host, []string{"items", "a"})
+	trie.Fingerprint(host, []string{"items", "b"})
+	trie.Fingerprint(host, []string{"items", "c"})
+
+	// 3 children, not promoted yet
+	result := trie.Fingerprint(host, []string{"items", "a"})
+	if result[1] == "{param}" {
+		t.Error("should not promote at threshold")
+	}
+
+	// 4th distinct child triggers promotion
+	result = trie.Fingerprint(host, []string{"items", "d"})
+	if result[1] != "{param}" {
+		t.Errorf("expected promotion with threshold=3, got %q", result[1])
+	}
+}
+
+func TestPathTrie_LRUEviction(t *testing.T) {
+	// Create a trie with a small LRU for testing eviction behavior
+	trie := NewPathTrie(0)
+
+	// Add many hosts to verify the trie doesn't panic
+	for i := range 100 {
+		host := fmt.Sprintf("host-%d.com", i)
+		trie.Fingerprint(host, []string{"path", "segment"})
+	}
+
+	// All recently accessed hosts should still work
+	result := trie.Fingerprint("host-99.com", []string{"path", "segment"})
+	if result[0] != "path" || result[1] != "segment" {
+		t.Errorf("LRU host access failed: got %v", result)
 	}
 }

--- a/pkg/utils/urlfingerprint.go
+++ b/pkg/utils/urlfingerprint.go
@@ -1,0 +1,134 @@
+package utils
+
+import (
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// segmentPattern defines a regex pattern and its replacement placeholder
+// for identifying variable path segments.
+type segmentPattern struct {
+	regex       *regexp.Regexp
+	placeholder string
+	// validate provides an additional check beyond the regex match.
+	// When nil, the regex match alone is sufficient.
+	validate func(string) bool
+}
+
+// containsHexLetter returns true if the string has at least one a-f/A-F character.
+// Pure-numeric strings that happen to be ≥8 digits should fall through to
+// timestamp/numeric patterns instead of matching as hex.
+func containsHexLetter(s string) bool {
+	for _, c := range s {
+		if (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F') {
+			return true
+		}
+	}
+	return false
+}
+
+// segmentPatterns are tested in order from most specific to most general.
+// Each pattern is anchored (^...$) to match complete path segments only.
+var segmentPatterns = []segmentPattern{
+	{regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`), "{uuid}", nil},
+	{regexp.MustCompile(`^[0-9a-fA-F]{64}$`), "{sha256}", containsHexLetter},
+	{regexp.MustCompile(`^[0-9a-fA-F]{40}$`), "{sha1}", containsHexLetter},
+	{regexp.MustCompile(`^[0-9a-fA-F]{32}$`), "{md5}", containsHexLetter},
+	{regexp.MustCompile(`^[0-9a-fA-F]{24}$`), "{oid}", containsHexLetter},
+	{regexp.MustCompile(`^[0-9a-fA-F]{8,}$`), "{hex}", containsHexLetter},
+	{regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`), "{date}", nil},
+	{regexp.MustCompile(`^\d{10}(\d{3})?$`), "{ts}", nil},
+	{regexp.MustCompile(`^\d+$`), "{num}", nil},
+}
+
+// normalizeSegment checks a single path segment against heuristic patterns.
+// Returns the placeholder if matched, or the original segment if no pattern matches.
+func normalizeSegment(segment string) (string, bool) {
+	for _, p := range segmentPatterns {
+		if p.regex.MatchString(segment) {
+			if p.validate != nil && !p.validate(segment) {
+				continue
+			}
+			return p.placeholder, true
+		}
+	}
+	return segment, false
+}
+
+// FingerprintURL produces a structural fingerprint of the given URL by:
+// 1. Replacing variable path segments (IDs, UUIDs, hashes, dates) with placeholders
+// 2. Using the adaptive trie (if provided) to detect learned parameter positions
+// 3. Dropping query parameter values, keeping only sorted keys
+//
+// When trie is nil, only Layer 1 regex-based normalization is applied.
+func FingerprintURL(rawURL string, trie *PathTrie) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+
+	path := u.Path
+	if path == "" || path == "/" {
+		return buildFingerprint(u, path)
+	}
+
+	// Split path into segments, preserving leading slash
+	trimmed := strings.Trim(path, "/")
+	if trimmed == "" {
+		return buildFingerprint(u, "/")
+	}
+	segments := strings.Split(trimmed, "/")
+
+	// Layer 1: heuristic regex normalization
+	for i, seg := range segments {
+		if placeholder, matched := normalizeSegment(seg); matched {
+			segments[i] = placeholder
+		}
+	}
+
+	// Layer 2: adaptive trie normalization
+	if trie != nil {
+		segments = trie.Fingerprint(u.Hostname(), segments)
+	}
+
+	fingerprintedPath := "/" + strings.Join(segments, "/")
+	if strings.HasSuffix(path, "/") {
+		fingerprintedPath += "/"
+	}
+
+	return buildFingerprint(u, fingerprintedPath)
+}
+
+// buildFingerprint reconstructs the URL with the fingerprinted path
+// and sorted query keys (values dropped).
+func buildFingerprint(u *url.URL, path string) string {
+	var b strings.Builder
+	if u.Scheme != "" {
+		b.WriteString(u.Scheme)
+		b.WriteString("://")
+	}
+	b.WriteString(u.Host)
+	b.WriteString(path)
+
+	if u.RawQuery != "" {
+		keys := sortedQueryKeys(u.Query())
+		if len(keys) > 0 {
+			b.WriteByte('?')
+			b.WriteString(strings.Join(keys, "&"))
+		}
+	}
+
+	return b.String()
+}
+
+// sortedQueryKeys extracts and sorts query parameter keys.
+func sortedQueryKeys(params url.Values) []string {
+	keys := make([]string, 0, len(params))
+	for k := range params {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/pkg/utils/urlfingerprint_test.go
+++ b/pkg/utils/urlfingerprint_test.go
@@ -1,0 +1,483 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestContainsHexLetter(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"abcdef01", true},
+		{"ABCDEF01", true},
+		{"1234abcd", true},
+		{"12345678", false},
+		{"00000000", false},
+		{"0000000a", true},
+		{"", false},
+		{"g", false}, // not a hex letter
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := containsHexLetter(tt.input); got != tt.want {
+				t.Errorf("containsHexLetter(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeSegment(t *testing.T) {
+	tests := []struct {
+		segment string
+		want    string
+		matched bool
+	}{
+		// UUID
+		{"550e8400-e29b-41d4-a716-446655440000", "{uuid}", true},
+		{"550E8400-E29B-41D4-A716-446655440000", "{uuid}", true},
+		// UUID with all-numeric groups still matches (dashes are the anchor)
+		{"12345678-1234-1234-1234-123456789012", "{uuid}", true},
+
+		// SHA256
+		{"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "{sha256}", true},
+		// 64-digit pure numeric should NOT match sha256 — falls to {num}
+		{"1234567890123456789012345678901234567890123456789012345678901234", "{num}", true},
+
+		// SHA1
+		{"da39a3ee5e6b4b0d3255bfef95601890afd80709", "{sha1}", true},
+		// 40-digit pure numeric should NOT match sha1 — falls to {ts} or {num}
+		{"1234567890123456789012345678901234567890", "{num}", true},
+
+		// MD5
+		{"d41d8cd98f00b204e9800998ecf8427e", "{md5}", true},
+		// 32-digit pure numeric should NOT match md5 — falls to {num}
+		{"12345678901234567890123456789012", "{num}", true},
+
+		// ObjectId (MongoDB 24 hex chars)
+		{"507f1f77bcf86cd799439011", "{oid}", true},
+		// 24-digit pure numeric — falls to {num}
+		{"123456789012345678901234", "{num}", true},
+
+		// Long hex (>= 8 chars, requires hex letter)
+		{"abcdef01", "{hex}", true},
+		{"1234abcd5678", "{hex}", true},
+		{"DEADBEEF", "{hex}", true},
+		// 8-digit pure numeric — NOT hex, falls to {num}
+		{"12345678", "{num}", true},
+		// 9-digit pure numeric — NOT hex, falls to {num}
+		{"123456789", "{num}", true},
+
+		// ISO date
+		{"2024-01-15", "{date}", true},
+		{"2023-12-31", "{date}", true},
+		{"1999-01-01", "{date}", true},
+		// Not a date (wrong format) — pure digits, no hex letters, falls to {num}
+		{"20240115", "{num}", true},
+
+		// Timestamp (10 digits)
+		{"1704067200", "{ts}", true},
+		// Timestamp (13 digits)
+		{"1704067200000", "{ts}", true},
+		// 11 digits — not a timestamp, falls to {num}
+		{"17040672001", "{num}", true},
+		// 14 digits — not a timestamp, falls to {num}
+		{"17040672000001", "{num}", true},
+
+		// Numeric
+		{"123", "{num}", true},
+		{"0", "{num}", true},
+		{"999999", "{num}", true},
+		{"1", "{num}", true},
+
+		// Non-matching
+		{"users", "users", false},
+		{"api", "api", false},
+		{"v1", "v1", false},
+		{"v2", "v2", false},
+		{"my-awesome-post", "my-awesome-post", false},
+		{"image123.jpg", "image123.jpg", false},
+		{"style.css", "style.css", false},
+		{"index.html", "index.html", false},
+		{"abcdef", "abcdef", false},  // 6-char hex, below 8-char threshold
+		{"feedback", "feedback", false}, // valid hex chars but also contains non-hex
+		{"deadbeef-cafe", "deadbeef-cafe", false}, // dash in wrong position, not UUID format
+		{"", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.segment, func(t *testing.T) {
+			got, matched := normalizeSegment(tt.segment)
+			if got != tt.want || matched != tt.matched {
+				t.Errorf("normalizeSegment(%q) = (%q, %v), want (%q, %v)",
+					tt.segment, got, matched, tt.want, tt.matched)
+			}
+		})
+	}
+}
+
+func TestFingerprintURL_RegexOnly(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "numeric path segments",
+			url:  "https://example.com/api/v1/users/123/posts/456",
+			want: "https://example.com/api/v1/users/{num}/posts/{num}",
+		},
+		{
+			name: "uuid in path",
+			url:  "https://example.com/product/550e8400-e29b-41d4-a716-446655440000",
+			want: "https://example.com/product/{uuid}",
+		},
+		{
+			name: "date in path",
+			url:  "https://example.com/archive/2024-01-15/article",
+			want: "https://example.com/archive/{date}/article",
+		},
+		{
+			name: "query params sorted and values dropped",
+			url:  "https://example.com/search?z=1&a=2&m=3",
+			want: "https://example.com/search?a&m&z",
+		},
+		{
+			name: "no variable segments unchanged",
+			url:  "https://example.com/about/team",
+			want: "https://example.com/about/team",
+		},
+		{
+			name: "root path",
+			url:  "https://example.com/",
+			want: "https://example.com/",
+		},
+		{
+			name: "empty path",
+			url:  "https://example.com",
+			want: "https://example.com",
+		},
+		{
+			name: "mixed pattern types in one path",
+			url:  "https://example.com/users/42/posts/da39a3ee5e6b4b0d3255bfef95601890afd80709",
+			want: "https://example.com/users/{num}/posts/{sha1}",
+		},
+		{
+			name: "trailing slash preserved",
+			url:  "https://example.com/api/v1/users/123/",
+			want: "https://example.com/api/v1/users/{num}/",
+		},
+		{
+			name: "timestamp in path",
+			url:  "https://example.com/events/1704067200",
+			want: "https://example.com/events/{ts}",
+		},
+		// Scheme and port variations
+		{
+			name: "http scheme",
+			url:  "http://example.com/items/99",
+			want: "http://example.com/items/{num}",
+		},
+		{
+			name: "url with port",
+			url:  "https://example.com:8443/api/users/42",
+			want: "https://example.com:8443/api/users/{num}",
+		},
+		// Fragment should be stripped by url.Parse (not included in fingerprint)
+		{
+			name: "fragment stripped",
+			url:  "https://example.com/page/123#section",
+			want: "https://example.com/page/{num}",
+		},
+		// Combined path normalization + query normalization
+		{
+			name: "variable path with query params",
+			url:  "https://example.com/users/42/posts?sort=date&page=1",
+			want: "https://example.com/users/{num}/posts?page&sort",
+		},
+		// Multiple different pattern types
+		{
+			name: "uuid then numeric then date",
+			url:  "https://example.com/obj/550e8400-e29b-41d4-a716-446655440000/rev/5/date/2024-01-15",
+			want: "https://example.com/obj/{uuid}/rev/{num}/date/{date}",
+		},
+		{
+			name: "md5 hash in path",
+			url:  "https://cdn.example.com/assets/d41d8cd98f00b204e9800998ecf8427e/image.png",
+			want: "https://cdn.example.com/assets/{md5}/image.png",
+		},
+		{
+			name: "sha256 hash in path",
+			url:  "https://example.com/blobs/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			want: "https://example.com/blobs/{sha256}",
+		},
+		{
+			name: "mongodb objectid in path",
+			url:  "https://example.com/docs/507f1f77bcf86cd799439011",
+			want: "https://example.com/docs/{oid}",
+		},
+		{
+			name: "long hex token in path",
+			url:  "https://example.com/verify/abcdef0123456789",
+			want: "https://example.com/verify/{hex}",
+		},
+		{
+			name: "13-digit timestamp",
+			url:  "https://example.com/snapshot/1704067200000",
+			want: "https://example.com/snapshot/{ts}",
+		},
+		// Edge cases
+		{
+			name: "single segment numeric",
+			url:  "https://example.com/42",
+			want: "https://example.com/{num}",
+		},
+		{
+			name: "query with no path segments",
+			url:  "https://example.com/?q=test",
+			want: "https://example.com/?q",
+		},
+		{
+			name: "single query param",
+			url:  "https://example.com/search?q=hello",
+			want: "https://example.com/search?q",
+		},
+		{
+			name: "file extension not affected",
+			url:  "https://example.com/assets/image123.jpg",
+			want: "https://example.com/assets/image123.jpg",
+		},
+		{
+			name: "deeply nested numeric ids",
+			url:  "https://example.com/a/1/b/2/c/3/d/4",
+			want: "https://example.com/a/{num}/b/{num}/c/{num}/d/{num}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FingerprintURL(tt.url, nil)
+			if got != tt.want {
+				t.Errorf("FingerprintURL(%q, nil)\n  got  = %q\n  want = %q", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFingerprintURL_Idempotency(t *testing.T) {
+	urls := []string{
+		"https://example.com/users/123/posts/456",
+		"https://example.com/product/550e8400-e29b-41d4-a716-446655440000",
+		"https://example.com/search?z=1&a=2",
+		"https://example.com/about/team",
+	}
+	for _, rawURL := range urls {
+		first := FingerprintURL(rawURL, nil)
+		second := FingerprintURL(first, nil)
+		if first != second {
+			t.Errorf("not idempotent for %q:\n  first  = %q\n  second = %q", rawURL, first, second)
+		}
+	}
+}
+
+func TestFingerprintURL_SimilarURLsCollapse(t *testing.T) {
+	// The core use case: structurally identical URLs should produce the same fingerprint
+	groups := [][]string{
+		{
+			"https://example.com/users/1/profile",
+			"https://example.com/users/2/profile",
+			"https://example.com/users/999/profile",
+		},
+		{
+			"https://example.com/product/550e8400-e29b-41d4-a716-446655440000",
+			"https://example.com/product/6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+		},
+		{
+			"https://example.com/search?q=foo&page=1",
+			"https://example.com/search?page=5&q=bar",
+		},
+	}
+	for _, group := range groups {
+		fingerprints := make(map[string]bool)
+		for _, u := range group {
+			fp := FingerprintURL(u, nil)
+			fingerprints[fp] = true
+		}
+		if len(fingerprints) != 1 {
+			t.Errorf("URLs in group did not collapse to single fingerprint: %v → %v", group, fingerprints)
+		}
+	}
+}
+
+func TestFingerprintURL_DifferentURLsStayDistinct(t *testing.T) {
+	// Structurally different URLs should NOT collapse
+	pairs := [][2]string{
+		{
+			"https://example.com/users/123/profile",
+			"https://example.com/users/123/settings",
+		},
+		{
+			"https://example.com/api/v1/users",
+			"https://example.com/api/v2/users",
+		},
+		{
+			"https://example.com/search?q=test",
+			"https://example.com/search?q=test&page=1",
+		},
+	}
+	for _, pair := range pairs {
+		fp1 := FingerprintURL(pair[0], nil)
+		fp2 := FingerprintURL(pair[1], nil)
+		if fp1 == fp2 {
+			t.Errorf("structurally different URLs collapsed:\n  %q → %q\n  %q → %q", pair[0], fp1, pair[1], fp2)
+		}
+	}
+}
+
+func TestFingerprintURL_WithTrie_PromotionLifecycle(t *testing.T) {
+	trie := NewPathTrie()
+	host := "https://example.com"
+
+	// Before promotion: each slug is kept as-is
+	for i := range DefaultPromotionThreshold {
+		fp := FingerprintURL(fmt.Sprintf("%s/blog/post-%d", host, i), trie)
+		expected := fmt.Sprintf("%s/blog/post-%d", host, i)
+		if fp != expected {
+			t.Fatalf("before promotion: got %q, want %q", fp, expected)
+		}
+	}
+
+	// Trigger promotion with one more distinct slug
+	FingerprintURL(host+"/blog/the-trigger", trie)
+
+	// After promotion: all new slugs should collapse
+	got := FingerprintURL(host+"/blog/never-seen-before", trie)
+	want := host + "/blog/{param}"
+	if got != want {
+		t.Errorf("after promotion: got %q, want %q", got, want)
+	}
+
+	// Previously seen slugs also collapse after promotion
+	got = FingerprintURL(host+"/blog/post-0", trie)
+	if got != want {
+		t.Errorf("previously seen slug after promotion: got %q, want %q", got, want)
+	}
+}
+
+func TestFingerprintURL_WithTrie_RegexSegmentsDontInflateTrie(t *testing.T) {
+	trie := NewPathTrie()
+
+	// Feed many numeric IDs — regex catches them before trie sees them
+	for i := range 100 {
+		FingerprintURL(fmt.Sprintf("https://example.com/items/%d/details", i), trie)
+	}
+
+	// A non-numeric slug should NOT be promoted since all prior values
+	// were normalized to "{num}" by regex before reaching the trie
+	result := FingerprintURL("https://example.com/items/brand-new-slug/details", trie)
+	if strings.Contains(result, "{param}") {
+		t.Errorf("regex-detected segments leaked to trie: got %q", result)
+	}
+}
+
+func TestFingerprintURL_WithTrie_MultipleHosts(t *testing.T) {
+	trie := NewPathTrie()
+
+	// Promote /users/* on host A
+	for i := range DefaultPromotionThreshold + 1 {
+		FingerprintURL(fmt.Sprintf("https://a.com/users/user-%d", i), trie)
+	}
+
+	// Host B should be unaffected
+	got := FingerprintURL("https://b.com/users/alice", trie)
+	want := "https://b.com/users/alice"
+	if got != want {
+		t.Errorf("host isolation: got %q, want %q", got, want)
+	}
+
+	// Host A should still collapse
+	got = FingerprintURL("https://a.com/users/new-user", trie)
+	want = "https://a.com/users/{param}"
+	if got != want {
+		t.Errorf("host A after promotion: got %q, want %q", got, want)
+	}
+}
+
+func TestFingerprintURL_WithTrie_DeepPromotion(t *testing.T) {
+	trie := NewPathTrie()
+
+	// Promote only the username segment, not others
+	for i := range DefaultPromotionThreshold + 1 {
+		FingerprintURL(fmt.Sprintf("https://example.com/api/users/user-%d/posts", i), trie)
+	}
+
+	got := FingerprintURL("https://example.com/api/users/new-user/posts", trie)
+	want := "https://example.com/api/users/{param}/posts"
+	if got != want {
+		t.Errorf("deep promotion: got %q, want %q", got, want)
+	}
+
+	// The "api" and "posts" segments should NOT be promoted
+	got = FingerprintURL("https://example.com/api/users/another/settings", trie)
+	if !strings.HasPrefix(got, "https://example.com/api/users/{param}/") {
+		t.Errorf("static segments should stay: got %q", got)
+	}
+}
+
+func TestFingerprintURL_WithTrie_CombinedRegexAndTrie(t *testing.T) {
+	trie := NewPathTrie()
+
+	// Promote blog slugs
+	for i := range DefaultPromotionThreshold + 1 {
+		FingerprintURL(fmt.Sprintf("https://example.com/blog/slug-%d", i), trie)
+	}
+
+	// URL with both regex-detectable (numeric) and trie-promoted (slug) segments
+	got := FingerprintURL("https://example.com/blog/my-article", trie)
+	want := "https://example.com/blog/{param}"
+	if got != want {
+		t.Errorf("trie promotion: got %q, want %q", got, want)
+	}
+
+	// Numeric IDs should still use regex placeholder, not trie
+	got = FingerprintURL("https://example.com/items/42", trie)
+	want = "https://example.com/items/{num}"
+	if got != want {
+		t.Errorf("regex on separate path: got %q, want %q", got, want)
+	}
+}
+
+func TestFingerprintURL_InvalidURL(t *testing.T) {
+	// Malformed URL should return the original string
+	inputs := []string{
+		"://invalid",
+		"",
+	}
+	for _, raw := range inputs {
+		got := FingerprintURL(raw, nil)
+		if raw == "" {
+			// url.Parse("") succeeds with empty result
+			continue
+		}
+		if got != raw {
+			t.Errorf("FingerprintURL(%q) = %q, want original returned", raw, got)
+		}
+	}
+}
+
+func TestFingerprintURL_NilTrieSameAsRegexOnly(t *testing.T) {
+	urls := []string{
+		"https://example.com/users/123",
+		"https://example.com/about",
+		"https://example.com/search?q=test&page=1",
+	}
+	for _, u := range urls {
+		withNil := FingerprintURL(u, nil)
+		withEmpty := FingerprintURL(u, NewPathTrie())
+		if withNil != withEmpty {
+			t.Errorf("nil trie vs empty trie differ for %q:\n  nil   = %q\n  empty = %q", u, withNil, withEmpty)
+		}
+	}
+}

--- a/pkg/utils/urlfingerprint_test.go
+++ b/pkg/utils/urlfingerprint_test.go
@@ -337,7 +337,7 @@ func TestFingerprintURL_DifferentURLsStayDistinct(t *testing.T) {
 }
 
 func TestFingerprintURL_WithTrie_PromotionLifecycle(t *testing.T) {
-	trie := NewPathTrie()
+	trie := NewPathTrie(0)
 	host := "https://example.com"
 
 	// Before promotion: each slug is kept as-is
@@ -367,7 +367,7 @@ func TestFingerprintURL_WithTrie_PromotionLifecycle(t *testing.T) {
 }
 
 func TestFingerprintURL_WithTrie_RegexSegmentsDontInflateTrie(t *testing.T) {
-	trie := NewPathTrie()
+	trie := NewPathTrie(0)
 
 	// Feed many numeric IDs — regex catches them before trie sees them
 	for i := range 100 {
@@ -383,7 +383,7 @@ func TestFingerprintURL_WithTrie_RegexSegmentsDontInflateTrie(t *testing.T) {
 }
 
 func TestFingerprintURL_WithTrie_MultipleHosts(t *testing.T) {
-	trie := NewPathTrie()
+	trie := NewPathTrie(0)
 
 	// Promote /users/* on host A
 	for i := range DefaultPromotionThreshold + 1 {
@@ -406,7 +406,7 @@ func TestFingerprintURL_WithTrie_MultipleHosts(t *testing.T) {
 }
 
 func TestFingerprintURL_WithTrie_DeepPromotion(t *testing.T) {
-	trie := NewPathTrie()
+	trie := NewPathTrie(0)
 
 	// Promote only the username segment, not others
 	for i := range DefaultPromotionThreshold + 1 {
@@ -427,7 +427,7 @@ func TestFingerprintURL_WithTrie_DeepPromotion(t *testing.T) {
 }
 
 func TestFingerprintURL_WithTrie_CombinedRegexAndTrie(t *testing.T) {
-	trie := NewPathTrie()
+	trie := NewPathTrie(0)
 
 	// Promote blog slugs
 	for i := range DefaultPromotionThreshold + 1 {
@@ -475,7 +475,7 @@ func TestFingerprintURL_NilTrieSameAsRegexOnly(t *testing.T) {
 	}
 	for _, u := range urls {
 		withNil := FingerprintURL(u, nil)
-		withEmpty := FingerprintURL(u, NewPathTrie())
+		withEmpty := FingerprintURL(u, NewPathTrie(0))
 		if withNil != withEmpty {
 			t.Errorf("nil trie vs empty trie differ for %q:\n  nil   = %q\n  empty = %q", u, withNil, withEmpty)
 		}


### PR DESCRIPTION
## Proposed changes

Closes #1527

Adds `-fsu`/`--filter-similar` flag that deduplicates structurally identical URLs during crawling. Uses a two-layer approach:
- Heuristic regex to normalize known variable segments (numeric IDs, UUIDs, hashes, dates, timestamps)
- Adaptive per-host trie that learns parameter positions at runtime via cardinality tracking

### Proof

<details>
<summary>Test server (save as main.go and run with <code>go run main.go</code>)</summary>

```go
package main

import (
	"fmt"
	"net/http"
)

func main() {
	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
		fmt.Fprint(w, `<html><body>
			<a href="/details/123">Details 123</a>
			<a href="/details/456">Details 456</a>
			<a href="/details/789">Details 789</a>
		</body></html>`)
	})
	http.HandleFunc("/details/", func(w http.ResponseWriter, r *http.Request) {
		fmt.Fprintf(w, `<html><body><h1>%s</h1><a href="/">Home</a></body></html>`, r.URL.Path)
	})
	fmt.Println("listening on :8777")
	http.ListenAndServe(":8777", nil)
}
```
</details>

Without flag — all 3 detail pages crawled:
```
$ katana -u http://localhost:8777 -silent -d 2
http://localhost:8777
http://localhost:8777/
http://localhost:8777/details/123
http://localhost:8777/details/456
http://localhost:8777/details/789
```

With `-fsu` — similar paths collapsed:
```
$ katana -u http://localhost:8777 -silent -d 2 -fsu
http://localhost:8777
http://localhost:8777/
http://localhost:8777/details/123
```

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/katana/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `-fsu, -filter-similar` CLI flag to reduce redundant crawling by normalizing variable path segments (IDs, UUIDs, hashes, dates).
  * Introduced adaptive path-trie and URL fingerprinting to detect and collapse structurally similar URLs.

* **Documentation**
  * Documented the new `-fsu, -filter-similar` option in the configuration section.

* **Tests**
  * Added comprehensive unit tests covering path-trie behavior and URL fingerprinting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->