### PR TITLE
feat: make jsluice optional behind build tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,14 @@
 katana requires Go 1.24+ to install successfully. If you encounter any installation issues, we recommend trying with the latest available version of Go, as the minimum required version may have changed. Run the command below or download a pre-compiled binary from the [release page](https://github.com/projectdiscovery/katana/releases).
 
 ```console
-CGO_ENABLED=1 go install github.com/projectdiscovery/katana/cmd/katana@latest
+go install github.com/projectdiscovery/katana/cmd/katana@latest
+```
+
+If you want to enable jsluice-based JavaScript parsing (`-jsl`), build with the
+`jsluice` build tag and CGO enabled:
+
+```console
+CGO_ENABLED=1 go install -tags jsluice github.com/projectdiscovery/katana/cmd/katana@latest
 ```
 
 **More options to install / run katana-**
@@ -122,7 +129,7 @@ CONFIGURATION:
    -r, -resolvers string[]       list of custom resolver (file or comma separated)
    -d, -depth int                maximum depth to crawl (default 3)
    -jc, -js-crawl                enable endpoint parsing / crawling in javascript file
-   -jsl, -jsluice                enable jsluice parsing in javascript file (memory intensive)
+   -jsl, -jsluice                enable jsluice parsing in javascript file (memory intensive, requires binary built with -tags jsluice)
    -ct, -crawl-duration value    maximum duration to crawl the target for (s, m, h, d) (default s)
    -kf, -known-files string      enable crawling of known files (all,robotstxt,sitemapxml), a minimum depth of 3 is required to ensure all known files are properly crawled.
    -mrs, -max-response-size int  maximum response size to read (default 4194304)

--- a/pkg/engine/parser/parser_generic.go
+++ b/pkg/engine/parser/parser_generic.go
@@ -1,4 +1,4 @@
-//go:build !(386 || windows)
+//go:build jsluice && !(386 || windows)
 
 package parser
 

--- a/pkg/engine/parser/parser_nojs.go
+++ b/pkg/engine/parser/parser_nojs.go
@@ -13,6 +13,7 @@ func (p *Parser) InitWithOptions(options *Options) {
 	if options.AutomaticFormFill {
 		*p = append(*p, responseParser{bodyParser, bodyFormTagParser})
 	}
+	// In non-jsluice builds, ScrapeJSLuiceResponses is intentionally ignored.
 	if options.ScrapeJSResponses {
 		*p = append(*p, responseParser{bodyParser, scriptContentRegexParser})
 		*p = append(*p, responseParser{contentParser, scriptJSFileRegexParser})

--- a/pkg/engine/parser/parser_nojs.go
+++ b/pkg/engine/parser/parser_nojs.go
@@ -1,4 +1,4 @@
-//go:build windows || 386
+//go:build !jsluice || windows || 386
 
 package parser
 

--- a/pkg/engine/parser/parser_nojs_default_test.go
+++ b/pkg/engine/parser/parser_nojs_default_test.go
@@ -1,0 +1,21 @@
+//go:build !jsluice || windows || 386
+
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitWithOptionsWithoutJSLuiceTagSkipsJSLuiceParsers(t *testing.T) {
+	responseParser := NewResponseParser()
+	baseParsers := len(*responseParser)
+
+	responseParser.InitWithOptions(&Options{
+		ScrapeJSLuiceResponses: true,
+		DisableRedirects:       true,
+	})
+
+	require.Equal(t, baseParsers, len(*responseParser))
+}

--- a/pkg/utils/jsluice.go
+++ b/pkg/utils/jsluice.go
@@ -24,7 +24,6 @@ func ExtractJsluiceEndpoints(data string) []JSLuiceEndpoint {
 	foundURLs := analyzer.GetURLs()
 
 	for _, url := range foundURLs {
-		url := url
 		endpoints = append(endpoints, JSLuiceEndpoint{
 			Endpoint: url.URL,
 			Type:     url.Type,

--- a/pkg/utils/jsluice.go
+++ b/pkg/utils/jsluice.go
@@ -1,28 +1,10 @@
-//go:build !(386 || windows)
+//go:build jsluice && !(386 || windows)
 
 package utils
 
 import (
-	"regexp"
-
 	"github.com/BishopFox/jsluice"
 )
-
-var (
-	// CommonJSLibraryFileRegex is a regex to match common js library files.
-	CommonJSLibraryFileRegex = `(?i)(?:amplify|quantserve|slideshow|jquery|modernizr|polyfill|vendor|modules|gtm|underscore?|tween|retina|selectivizr|cufon|angular|swf|sha1|freestyle|bootstrap|d3|backbone|videojs|google[-_]analytics|material|redux|knockout|datepicker|datetimepicker|ember|react|ng|fusion|analytics|libs?|vendors?|node[-_]modules|lodash|moment|chart|highcharts|raphael|prototype|mootools|dojo|ext|yui|web[-_]?components|polymer|vue|svelte|next|nuxt|gatsby|express|koa|hapi|socket[-_.]?io|axios|superagent|request|bluebird|rxjs|ramda|immutable|flux|redux[-_]saga|mobx|relay|apollo|graphql|three|phaser|pixi|babylon|cannon|hammer|howler|gsap|velocity|mo[-_.]?js|popper|shepherd|prism|highlight|markdown[-_]?it|codemirror|ace[-_]?editor|tinymce|ckeditor|quill|simplemde|monaco[-_]?editor|pdf[-_.]?js|jspdf|fabric|paper|konva|p5|processing|matter[-_.]?js|box2d|planck|chart[-_.]?js|plotly|echarts|d3[-_.]?force|sigma|c3|nvd3|amcharts|vis[-_.]?js|dagre[-_.]?d3|cytoscape|leaflet|openlayers|ol3|mapbox|cesium|turf|moment[-_.]?timezone|luxon|dayjs|date[-_.]?fns|date[-_.]?io|flatpickr|pikaday|fullcalendar|draggable|interact|sortable|dragula|dropzone|filepond|uppy|fine[-_.]?uploader|plyr|mediaelement|flowplayer|jwplayer|video[-_.]?js|mediaelement[-_.]?js|dash[-_.]?js|hls[-_.]?js|videojs|wavesurfer|soundmanager|amplitude|pizzicato|tone|adroll|doubleclick|facebook-pixel|ga-audiences|googlesyndication|adsbygoogle|gpt|amazon-adsystem|criteo|taboola|outbrain|bidswitch|bidswitch.net|spotxchange|yahoo|media.net|contextweb|openx|pubmatic|rubiconproject|indexexchange|appnexus|liveintent|triplelift|verizonmedia|synacor|sonobi|yieldmo|gumgum|smartadserver|mopub|pubnative|inmobi|chartboost|tapjoy|admob|unityads|vungle|flurry|matomy|altitude|dataxu|thetradedesk|exponential|zypmedia|quantcast|mediamath|bidswitch|mgid|revcontent|powerlinks|rhythmone|airpush|smaato|adcolony|mopub|leadbolt|mobfox|nativo|revjet|smartyads|avocarrot|epom|imobile|supersonicads|loopme|applovin|pandora|mytarget|bidvertiser|chitika|popads|propellerads|buysellads|adhit|hilltopads|plugrush|popcash|popunder|revenuehits|trafficjunky|trafficfactory|zero-|smartoasis)(?:[-._][\w\d]*)*\.js$`
-	commonJSLibraryFileRegexCompiled = regexp.MustCompile(CommonJSLibraryFileRegex)
-)
-
-// IsPathCommonJSLibraryFile checks if a given path is a common js library file.
-func IsPathCommonJSLibraryFile(path string) bool {
-	return commonJSLibraryFileRegexCompiled.MatchString(path)
-}
-
-type JSLuiceEndpoint struct {
-	Endpoint string
-	Type     string
-}
 
 // ExtractJsluiceEndpoints extracts jsluice endpoints from a given string.
 //

--- a/pkg/utils/jsluice_common.go
+++ b/pkg/utils/jsluice_common.go
@@ -1,0 +1,19 @@
+package utils
+
+import "regexp"
+
+var (
+	// CommonJSLibraryFileRegex is a regex to match common js library files.
+	CommonJSLibraryFileRegex         = `(?i)(?:amplify|quantserve|slideshow|jquery|modernizr|polyfill|vendor|modules|gtm|underscore?|tween|retina|selectivizr|cufon|angular|swf|sha1|freestyle|bootstrap|d3|backbone|videojs|google[-_]analytics|material|redux|knockout|datepicker|datetimepicker|ember|react|ng|fusion|analytics|libs?|vendors?|node[-_]modules|lodash|moment|chart|highcharts|raphael|prototype|mootools|dojo|ext|yui|web[-_]?components|polymer|vue|svelte|next|nuxt|gatsby|express|koa|hapi|socket[-_.]?io|axios|superagent|request|bluebird|rxjs|ramda|immutable|flux|redux[-_]saga|mobx|relay|apollo|graphql|three|phaser|pixi|babylon|cannon|hammer|howler|gsap|velocity|mo[-_.]?js|popper|shepherd|prism|highlight|markdown[-_]?it|codemirror|ace[-_]?editor|tinymce|ckeditor|quill|simplemde|monaco[-_]?editor|pdf[-_.]?js|jspdf|fabric|paper|konva|p5|processing|matter[-_.]?js|box2d|planck|chart[-_.]?js|plotly|echarts|d3[-_.]?force|sigma|c3|nvd3|amcharts|vis[-_.]?js|dagre[-_.]?d3|cytoscape|leaflet|openlayers|ol3|mapbox|cesium|turf|moment[-_.]?timezone|luxon|dayjs|date[-_.]?fns|date[-_.]?io|flatpickr|pikaday|fullcalendar|draggable|interact|sortable|dragula|dropzone|filepond|uppy|fine[-_.]?uploader|plyr|mediaelement|flowplayer|jwplayer|video[-_.]?js|mediaelement[-_.]?js|dash[-_.]?js|hls[-_.]?js|videojs|wavesurfer|soundmanager|amplitude|pizzicato|tone|adroll|doubleclick|facebook-pixel|ga-audiences|googlesyndication|adsbygoogle|gpt|amazon-adsystem|criteo|taboola|outbrain|bidswitch|bidswitch.net|spotxchange|yahoo|media.net|contextweb|openx|pubmatic|rubiconproject|indexexchange|appnexus|liveintent|triplelift|verizonmedia|synacor|sonobi|yieldmo|gumgum|smartadserver|mopub|pubnative|inmobi|chartboost|tapjoy|admob|unityads|vungle|flurry|matomy|altitude|dataxu|thetradedesk|exponential|zypmedia|quantcast|mediamath|bidswitch|mgid|revcontent|powerlinks|rhythmone|airpush|smaato|adcolony|mopub|leadbolt|mobfox|nativo|revjet|smartyads|avocarrot|epom|imobile|supersonicads|loopme|applovin|pandora|mytarget|bidvertiser|chitika|popads|propellerads|buysellads|adhit|hilltopads|plugrush|popcash|popunder|revenuehits|trafficjunky|trafficfactory|zero-|smartoasis)(?:[-._][\w\d]*)*\.js$`
+	commonJSLibraryFileRegexCompiled = regexp.MustCompile(CommonJSLibraryFileRegex)
+)
+
+// IsPathCommonJSLibraryFile checks if a given path is a common js library file.
+func IsPathCommonJSLibraryFile(path string) bool {
+	return commonJSLibraryFileRegexCompiled.MatchString(path)
+}
+
+type JSLuiceEndpoint struct {
+	Endpoint string
+	Type     string
+}

--- a/pkg/utils/jsluice_disabled.go
+++ b/pkg/utils/jsluice_disabled.go
@@ -1,0 +1,9 @@
+//go:build !jsluice || windows || 386
+
+package utils
+
+// ExtractJsluiceEndpoints returns no endpoints when jsluice support is not
+// enabled for the current build.
+func ExtractJsluiceEndpoints(data string) []JSLuiceEndpoint {
+	return nil
+}

--- a/pkg/utils/jsluice_disabled_test.go
+++ b/pkg/utils/jsluice_disabled_test.go
@@ -1,0 +1,14 @@
+//go:build !jsluice || windows || 386
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractJsluiceEndpointsDisabledWithoutBuildTag(t *testing.T) {
+	endpoints := ExtractJsluiceEndpoints(`fetch("/api/v1/users")`)
+	require.Empty(t, endpoints)
+}


### PR DESCRIPTION
## Proposed changes

This PR makes `jsluice` optional behind a build tag so the default build path no longer requires CGO while preserving current behavior for tagged builds.

- split parser and utils implementation paths with `jsluice` / non-`jsluice` build tags
- keep non-jsluice fallback behavior explicit and deterministic
- preserve jsluice extraction path for `-tags jsluice` builds
- update install docs for default build and optional jsluice-enabled build
- add regression tests for non-jsluice default behavior
- address follow-up review nits (clarifying comment in non-jsluice parser path + loop cleanup in jsluice extractor)

Fixes #1367

### Proof

Executed locally:

- `go test ./pkg/engine/parser ./pkg/utils -count=1` ✅
- `CGO_ENABLED=0 go test ./pkg/engine/parser ./pkg/utils -count=1` ✅
- `CGO_ENABLED=1 go test -tags jsluice ./pkg/engine/parser ./pkg/utils -count=1` ✅
- `CGO_ENABLED=0 go build ./cmd/katana` ✅
- `CGO_ENABLED=1 go build -tags jsluice ./cmd/katana` ✅

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/katana/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified installation instructions—CGO flag no longer required by default.
  * Added guidance for enabling optional JavaScript parsing via a build tag and updated flag help to note build requirements and memory implications.

* **New Features**
  * Introduced opt-in JavaScript parsing support (enabled only for builds with the jsluice tag).
  * Added utilities to detect common JS library filenames and extract JS endpoints.

* **Tests**
  * Added tests ensuring JS parsing is disabled when the jsluice tag is not present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->