### PR TITLE
fix: add retry logic and extended timeout for getDocument (#611)

### DIFF
--- a/pkg/engine/hybrid/crawl.go
+++ b/pkg/engine/hybrid/crawl.go
@@ -283,8 +283,28 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 	}
 
 	var getDocumentDepth = int(-1)
-	getDocument := &proto.DOMGetDocument{Depth: &getDocumentDepth, Pierce: true}
-	result, err := getDocument.Call(page)
+	
+	// FIX #611: Use extended timeout and retry logic for getDocument
+	// This prevents "context deadline exceeded" errors on complex websites when using -headless -jsonl
+	var result *proto.DOMGetDocumentReturn
+	var err error
+	maxRetries := 2
+	
+	// Use extended timeout for DOM operations on complex pages (2x original timeout)
+	getDocTimeout := time.Duration(c.Options.Options.Timeout*2) * time.Second
+	pageWithDocTimeout := page.Timeout(getDocTimeout)
+	
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		getDocument := &proto.DOMGetDocument{Depth: &getDocumentDepth, Pierce: true}
+		result, err = getDocument.Call(pageWithDocTimeout)
+		if err == nil {
+			break
+		}
+		if attempt < maxRetries {
+			gologger.Debug().Msgf("getDocument failed (attempt %d/%d): %v, retrying...", attempt+1, maxRetries+1, err)
+			time.Sleep(500 * time.Millisecond)
+		}
+	}
 	if err != nil {
 		return nil, errkit.Wrap(err, "hybrid: could not get dom")
 	}

--- a/pkg/engine/hybrid/crawl.go
+++ b/pkg/engine/hybrid/crawl.go
@@ -301,6 +301,7 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 			break
 		}
 		if attempt < maxRetries {
+			// Debug logging only enabled with -debug flag (gologger.Debug() respects log level)
 			gologger.Debug().Msgf("getDocument failed (attempt %d/%d): %v, retrying...", attempt+1, maxRetries+1, err)
 			time.Sleep(500 * time.Millisecond)
 		}


### PR DESCRIPTION
Fixes #611.

## Problem
Error when using `-jsonl` with `-headless` on complex websites:
```
[hybrid:RUNTIME] context deadline exceeded <- could not get dom
```

## Solution
1. Extended timeout: 10s → 20s (2x)
2. Retry logic: up to 2 retries with 500ms delay
3. Debug logging

## Testing
```bash
echo https://projectdiscovery.io | katana -silent -d 1 -jsonl -ob -or -headless | jq
```

## Bounty
This PR addresses issue #611 ($75).