### PR TITLE
fix(hybrid): recover from DOM timeouts in headless JSONL crawls

### DIFF
--- a/pkg/engine/hybrid/crawl.go
+++ b/pkg/engine/hybrid/crawl.go
@@ -371,7 +371,7 @@ func shouldFallbackOnDOMError(err error) bool {
 	if err == nil {
 		return false
 	}
-	return errors.Is(err, context.DeadlineExceeded)
+	return errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)
 }
 
 func fallbackBodyFromResponse(response *navigation.Response) (string, bool) {

--- a/pkg/engine/hybrid/crawl.go
+++ b/pkg/engine/hybrid/crawl.go
@@ -2,6 +2,7 @@ package hybrid
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -285,16 +286,29 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 
 	var getDocumentDepth = int(-1)
 	getDocument := &proto.DOMGetDocument{Depth: &getDocumentDepth, Pierce: true}
+	var builder strings.Builder
+
+	page = page.CancelTimeout().Timeout(timeout)
 	result, err := getDocument.Call(page)
 	if err != nil {
-		return nil, errkit.Wrap(err, "hybrid: could not get dom")
+		if shouldFallbackOnDOMError(err) {
+			gologger.Debug().Msgf("hybrid: dom extraction failed for %s: %v; continuing with response fallback", request.URL, err)
+		} else {
+			return nil, errkit.Wrap(err, "hybrid: could not get dom")
+		}
+	} else {
+		traverseDOMNode(result.Root, &builder)
 	}
-	var builder strings.Builder
-	traverseDOMNode(result.Root, &builder)
 
+	page = page.CancelTimeout().Timeout(timeout)
 	body, err := page.HTML()
 	if err != nil {
-		return nil, errkit.Wrap(err, "hybrid: could not get html")
+		fallbackBody, ok := fallbackBodyFromResponse(response)
+		if !ok {
+			return nil, errkit.Wrap(err, "hybrid: could not get html")
+		}
+		gologger.Debug().Msgf("hybrid: html extraction failed for %s: %v; using captured response body", request.URL, err)
+		body = fallbackBody
 	}
 
 	parsed, err := urlutil.Parse(request.URL)
@@ -351,6 +365,20 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 	})
 
 	return response, nil
+}
+
+func shouldFallbackOnDOMError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, context.DeadlineExceeded)
+}
+
+func fallbackBodyFromResponse(response *navigation.Response) (string, bool) {
+	if response == nil || response.Body == "" {
+		return "", false
+	}
+	return response.Body, true
 }
 
 func (c *Crawler) addHeadersToPage(page *rod.Page) {

--- a/pkg/engine/hybrid/crawl_test.go
+++ b/pkg/engine/hybrid/crawl_test.go
@@ -1,0 +1,31 @@
+package hybrid
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/projectdiscovery/katana/pkg/navigation"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldFallbackOnDOMError(t *testing.T) {
+	require.True(t, shouldFallbackOnDOMError(context.DeadlineExceeded))
+	require.True(t, shouldFallbackOnDOMError(fmt.Errorf("dom error: %w", context.DeadlineExceeded)))
+	require.False(t, shouldFallbackOnDOMError(errors.New("context deadline exceeded")))
+	require.False(t, shouldFallbackOnDOMError(errors.New("navigation failed")))
+	require.False(t, shouldFallbackOnDOMError(nil))
+}
+
+func TestFallbackBodyFromResponse(t *testing.T) {
+	body, ok := fallbackBodyFromResponse(&navigation.Response{Body: "<html>ok</html>"})
+	require.True(t, ok)
+	require.Equal(t, "<html>ok</html>", body)
+
+	_, ok = fallbackBodyFromResponse(&navigation.Response{})
+	require.False(t, ok)
+
+	_, ok = fallbackBodyFromResponse(nil)
+	require.False(t, ok)
+}


### PR DESCRIPTION
/claim #611

## Proposed Changes
- refresh the page timeout budget before DOM extraction and before `page.HTML()` so the post-navigation extraction path does not inherit an already-expired headless timeout
- treat DOM extraction deadline-exceeded errors as recoverable in the hybrid crawler instead of returning a runtime record immediately
- fall back to the captured HTTP response body when headless HTML extraction fails, preserving a successful JSONL response for pages that were fetched correctly
- add focused regression tests for DOM-timeout fallback detection and response-body fallback behavior

## Proof
- `go test ./pkg/engine/hybrid -run "TestShouldFallbackOnDOMError|TestFallbackBodyFromResponse"`
- `go test ./pkg/engine/hybrid`
- `go build ./cmd/katana`

## Notes
- I also tried the real reproduction command against `https://projectdiscovery.io` with `-headless -system-chrome`, but this workstation did not produce a stable local headless run in a reasonable time window, so I am only claiming the package-level verification above rather than overstating runtime proof.

## Checklist
- [x] PR created against the `dev` branch
- [x] Tests added that cover the fallback behavior
- [x] Relevant package tests passed locally
- [x] `katana` CLI builds locally
- [ ] All remote CI checks passed
- [ ] Additional documentation added (not needed for this fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More resilient content extraction: DOM and HTML retrieval now use guarded extraction with timeout handling and automatic fallbacks to captured responses, reducing failures and improving crawl reliability. Added clearer debug logging when fallbacks occur.

* **Tests**
  * Added tests covering fallback decision logic and response-body extraction to ensure robust error handling and recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->