### PR TITLE
Fallback to captured response body on headless DOM errors

### DIFF
--- a/pkg/engine/hybrid/crawl.go
+++ b/pkg/engine/hybrid/crawl.go
@@ -285,16 +285,32 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 
 	var getDocumentDepth = int(-1)
 	getDocument := &proto.DOMGetDocument{Depth: &getDocumentDepth, Pierce: true}
+	var domErr error
 	result, err := getDocument.Call(page)
 	if err != nil {
-		return nil, errkit.Wrap(err, "hybrid: could not get dom")
-	}
-	var builder strings.Builder
-	traverseDOMNode(result.Root, &builder)
+		domErr = errkit.Wrap(err, "hybrid: could not get dom")
+	} else {
+		var builder strings.Builder
+		traverseDOMNode(result.Root, &builder)
 
-	body, err := page.HTML()
+		// Create a copy of interpolated shadow DOM elements and parse them separately.
+		responseCopy := *response
+		responseCopy.Body = builder.String()
+		responseCopy.Reader, _ = goquery.NewDocumentFromReader(strings.NewReader(responseCopy.Body))
+		if responseCopy.Reader != nil {
+			navigationRequests := c.Options.Parser.ParseResponse(&responseCopy)
+			c.Enqueue(s.Queue, navigationRequests...)
+		}
+	}
+
+	body, err := getOutputBody(func() (string, error) {
+		return page.HTML()
+	}, response)
 	if err != nil {
-		return nil, errkit.Wrap(err, "hybrid: could not get html")
+		if domErr != nil {
+			return response, domErr
+		}
+		return response, err
 	}
 
 	parsed, err := urlutil.Parse(request.URL)
@@ -308,16 +324,6 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 	}
 	response.Resp.Request.URL = parsed.URL
 
-	// Create a copy of intrapolated shadow DOM elements and parse them separately
-	responseCopy := *response
-	responseCopy.Body = builder.String()
-
-	responseCopy.Reader, _ = goquery.NewDocumentFromReader(strings.NewReader(responseCopy.Body))
-	if responseCopy.Reader != nil {
-		navigationRequests := c.Options.Parser.ParseResponse(&responseCopy)
-		c.Enqueue(s.Queue, navigationRequests...)
-	}
-
 	response.Body = body
 	if response.Reader != nil {
 		response.Reader.Url, _ = url.Parse(request.URL)
@@ -328,7 +334,10 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 
 	response.Reader, err = goquery.NewDocumentFromReader(strings.NewReader(response.Body))
 	if err != nil {
-		return nil, errkit.Wrap(err, "hybrid: could not parse html")
+		if domErr != nil {
+			return response, domErr
+		}
+		return response, errkit.Wrap(err, "hybrid: could not parse html")
 	}
 
 	response.XhrRequests = xhrRequests
@@ -351,6 +360,20 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 	})
 
 	return response, nil
+}
+
+func getOutputBody(htmlFetcher func() (string, error), response *navigation.Response) (string, error) {
+	body, err := htmlFetcher()
+	if err == nil {
+		return body, nil
+	}
+
+	if response != nil && response.Body != "" {
+		gologger.Debug().Msgf("headless: falling back to captured response body after html extraction failed: %v", err)
+		return response.Body, nil
+	}
+
+	return "", errkit.Wrap(err, "hybrid: could not get html")
 }
 
 func (c *Crawler) addHeadersToPage(page *rod.Page) {

--- a/pkg/engine/hybrid/crawl.go
+++ b/pkg/engine/hybrid/crawl.go
@@ -2,6 +2,7 @@ package hybrid
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -368,7 +369,7 @@ func getOutputBody(htmlFetcher func() (string, error), response *navigation.Resp
 		return body, nil
 	}
 
-	if response != nil && response.Resp != nil {
+	if response != nil && response.Resp != nil && errors.Is(err, context.DeadlineExceeded) {
 		gologger.Debug().Msgf("headless: falling back to captured response body after html extraction failed: %v", err)
 		return response.Body, nil
 	}

--- a/pkg/engine/hybrid/crawl.go
+++ b/pkg/engine/hybrid/crawl.go
@@ -368,7 +368,7 @@ func getOutputBody(htmlFetcher func() (string, error), response *navigation.Resp
 		return body, nil
 	}
 
-	if response != nil && response.Body != "" {
+	if response != nil && response.Resp != nil {
 		gologger.Debug().Msgf("headless: falling back to captured response body after html extraction failed: %v", err)
 		return response.Body, nil
 	}

--- a/pkg/engine/hybrid/crawl_test.go
+++ b/pkg/engine/hybrid/crawl_test.go
@@ -2,6 +2,7 @@ package hybrid
 
 import (
 	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/projectdiscovery/katana/pkg/navigation"
@@ -9,7 +10,10 @@ import (
 )
 
 func TestGetOutputBodyFallsBackToCapturedResponse(t *testing.T) {
-	resp := &navigation.Response{Body: "<html>fallback</html>"}
+	resp := &navigation.Response{
+		Resp: &http.Response{},
+		Body: "<html>fallback</html>",
+	}
 
 	body, err := getOutputBody(func() (string, error) {
 		return "", errors.New("could not get dom")
@@ -25,5 +29,19 @@ func TestGetOutputBodyErrorsWithoutFallback(t *testing.T) {
 	}, &navigation.Response{})
 
 	require.Error(t, err)
+	require.Empty(t, body)
+}
+
+func TestGetOutputBodyReturnsCapturedEmptyBody(t *testing.T) {
+	resp := &navigation.Response{
+		Resp: &http.Response{},
+		Body: "",
+	}
+
+	body, err := getOutputBody(func() (string, error) {
+		return "", errors.New("could not get dom")
+	}, resp)
+
+	require.NoError(t, err)
 	require.Empty(t, body)
 }

--- a/pkg/engine/hybrid/crawl_test.go
+++ b/pkg/engine/hybrid/crawl_test.go
@@ -1,0 +1,29 @@
+package hybrid
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/projectdiscovery/katana/pkg/navigation"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetOutputBodyFallsBackToCapturedResponse(t *testing.T) {
+	resp := &navigation.Response{Body: "<html>fallback</html>"}
+
+	body, err := getOutputBody(func() (string, error) {
+		return "", errors.New("could not get dom")
+	}, resp)
+
+	require.NoError(t, err)
+	require.Equal(t, "<html>fallback</html>", body)
+}
+
+func TestGetOutputBodyErrorsWithoutFallback(t *testing.T) {
+	body, err := getOutputBody(func() (string, error) {
+		return "", errors.New("could not get dom")
+	}, &navigation.Response{})
+
+	require.Error(t, err)
+	require.Empty(t, body)
+}

--- a/pkg/engine/hybrid/crawl_test.go
+++ b/pkg/engine/hybrid/crawl_test.go
@@ -1,6 +1,7 @@
 package hybrid
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"testing"
@@ -16,7 +17,7 @@ func TestGetOutputBodyFallsBackToCapturedResponse(t *testing.T) {
 	}
 
 	body, err := getOutputBody(func() (string, error) {
-		return "", errors.New("could not get dom")
+		return "", context.DeadlineExceeded
 	}, resp)
 
 	require.NoError(t, err)
@@ -32,6 +33,15 @@ func TestGetOutputBodyErrorsWithoutFallback(t *testing.T) {
 	require.Empty(t, body)
 }
 
+func TestGetOutputBodyErrorsOnNonDeadlineFailures(t *testing.T) {
+	body, err := getOutputBody(func() (string, error) {
+		return "", errors.New("could not get dom")
+	}, &navigation.Response{Resp: &http.Response{}, Body: "<html>fallback</html>"})
+
+	require.Error(t, err)
+	require.Empty(t, body)
+}
+
 func TestGetOutputBodyReturnsCapturedEmptyBody(t *testing.T) {
 	resp := &navigation.Response{
 		Resp: &http.Response{},
@@ -39,7 +49,7 @@ func TestGetOutputBodyReturnsCapturedEmptyBody(t *testing.T) {
 	}
 
 	body, err := getOutputBody(func() (string, error) {
-		return "", errors.New("could not get dom")
+		return "", context.DeadlineExceeded
 	}, resp)
 
 	require.NoError(t, err)

--- a/pkg/engine/hybrid/crawl_test.go
+++ b/pkg/engine/hybrid/crawl_test.go
@@ -17,7 +17,7 @@ func TestGetOutputBodyFallsBackToCapturedResponse(t *testing.T) {
 	}
 
 	body, err := getOutputBody(func() (string, error) {
-		return "", context.DeadlineExceeded
+		return "", errors.New("could not get dom")
 	}, resp)
 
 	require.NoError(t, err)
@@ -33,10 +33,10 @@ func TestGetOutputBodyErrorsWithoutFallback(t *testing.T) {
 	require.Empty(t, body)
 }
 
-func TestGetOutputBodyErrorsOnNonDeadlineFailures(t *testing.T) {
+func TestGetOutputBodyErrorsWithNilResponse(t *testing.T) {
 	body, err := getOutputBody(func() (string, error) {
-		return "", errors.New("could not get dom")
-	}, &navigation.Response{Resp: &http.Response{}, Body: "<html>fallback</html>"})
+		return "", context.DeadlineExceeded
+	}, nil)
 
 	require.Error(t, err)
 	require.Empty(t, body)
@@ -49,7 +49,7 @@ func TestGetOutputBodyReturnsCapturedEmptyBody(t *testing.T) {
 	}
 
 	body, err := getOutputBody(func() (string, error) {
-		return "", context.DeadlineExceeded
+		return "", errors.New("could not get dom")
 	}, resp)
 
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
- make hybrid headless crawling tolerate DOM snapshot failures instead of failing the whole result immediately
- fall back to the already captured HTTP response body when `page.HTML()` cannot complete within the headless budget
- add focused tests for the fallback helper used by the hybrid crawler

/claim #611

## Why
Some `-jsonl -headless` crawls currently emit only `"[hybrid:RUNTIME] ... could not get dom"` even when the HTTP response has already been captured successfully. This change keeps the response path usable and only treats DOM extraction as best-effort.

## Validation
- `git diff --check`

## Notes
- this machine does not have `go`/`gofmt`, so I could not run Go tests locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust HTML extraction with fallback to captured response and improved error selection when DOM retrieval fails.
* **Refactor**
  * Centralized HTML extraction and reordered processing so DOM parsing and response enrichment only run on successful DOM retrieval.
* **Tests**
  * Added unit tests covering fallback behaviors and error cases for the HTML extraction logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->