### PR TITLE
fix(hybrid): fall back to captured response body on DOM timeout (#611)

### DIFF
--- a/pkg/engine/hybrid/crawl.go
+++ b/pkg/engine/hybrid/crawl.go
@@ -286,15 +286,28 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 	var getDocumentDepth = int(-1)
 	getDocument := &proto.DOMGetDocument{Depth: &getDocumentDepth, Pierce: true}
 	result, err := getDocument.Call(page)
-	if err != nil {
-		return nil, errkit.Wrap(err, "hybrid: could not get dom")
-	}
-	var builder strings.Builder
-	traverseDOMNode(result.Root, &builder)
 
-	body, err := page.HTML()
+	var builder strings.Builder
+	var body string
+
 	if err != nil {
-		return nil, errkit.Wrap(err, "hybrid: could not get html")
+		// DOM is unavailable (e.g. context deadline exceeded after page navigation).
+		// Fall back to the raw body captured by the network interceptor so that
+		// the crawl can continue and links are still parsed; the shadow-DOM pass
+		// is simply skipped in this case.
+		gologger.Warning().Msgf("[hybrid] could not get dom for %s: %s, falling back to captured response body", request.URL, err)
+		if response != nil {
+			body = response.Body
+		}
+	} else {
+		traverseDOMNode(result.Root, &builder)
+
+		body, err = page.HTML()
+		if err != nil {
+			// page.HTML() can also time out; use the DOM traversal result instead.
+			gologger.Warning().Msgf("[hybrid] could not get html for %s: %s, using DOM traversal result", request.URL, err)
+			body = builder.String()
+		}
 	}
 
 	parsed, err := urlutil.Parse(request.URL)
@@ -308,14 +321,18 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 	}
 	response.Resp.Request.URL = parsed.URL
 
-	// Create a copy of intrapolated shadow DOM elements and parse them separately
-	responseCopy := *response
-	responseCopy.Body = builder.String()
+	// Create a copy with interpolated shadow DOM elements and parse them separately.
+	// This pass is only meaningful when the full DOM tree was retrieved; skip it
+	// when we fell back to the captured response body (builder is empty).
+	if domTraversal := builder.String(); domTraversal != "" {
+		responseCopy := *response
+		responseCopy.Body = domTraversal
 
-	responseCopy.Reader, _ = goquery.NewDocumentFromReader(strings.NewReader(responseCopy.Body))
-	if responseCopy.Reader != nil {
-		navigationRequests := c.Options.Parser.ParseResponse(&responseCopy)
-		c.Enqueue(s.Queue, navigationRequests...)
+		responseCopy.Reader, _ = goquery.NewDocumentFromReader(strings.NewReader(responseCopy.Body))
+		if responseCopy.Reader != nil {
+			navigationRequests := c.Options.Parser.ParseResponse(&responseCopy)
+			c.Enqueue(s.Queue, navigationRequests...)
+		}
 	}
 
 	response.Body = body


### PR DESCRIPTION
## Summary

When `-headless` is combined with `-jsonl`, the `DOMGetDocument` CDP call can hit a context-deadline after page-navigation events (SPA transitions, JS redirects), surfacing `[hybrid:RUNTIME] context deadline exceeded <- could not get dom` in every JSON line instead of a useful crawl result. Fixes #611.

## Root cause

Lines 286-290 (before this change):

```go
result, err := getDocument.Call(page)
if err != nil {
    return nil, errkit.Wrap(err, "hybrid: could not get dom")
}
```

On a timeout `getDocument.Call` returns a non-nil error. The function returns that error immediately, which the JSONL writer encodes as an `error` field.

## Fix

Instead of failing the entire request, fall back gracefully to the raw HTTP response body captured earlier by the network interceptor. This body is already stored in `response.Body` by the time we reach `getDocument`.

Two-level fallback:
1. `getDocument.Call` fails → use `response.Body` (skip shadow-DOM traversal, log a warning)
2. `page.HTML()` fails (also times out) → use the DOM traversal builder result (log a warning)

The shadow-DOM copy (`responseCopy`) is only created when the full DOM tree is available; when we fell back, the builder is empty so that pass is skipped entirely, avoiding a parse of an empty body.

## Behaviour before / after

| Scenario | Before | After |
|---|---|---|
| DOM timeout, response captured | `error: "…context deadline exceeded…"` in JSONL | warning log + links extracted from captured body |
| DOM timeout, no response | `error` in JSONL | same (response is nil, body stays empty) |
| `page.HTML()` timeout | `error` in JSONL | warning log + DOM traversal result used |
| Normal crawl | unchanged | unchanged |

## Testing

```bash
echo "https://example.com" | katana -headless -jsonl -d 1
```

No `context deadline exceeded` entries appear in the JSONL stream on targets that previously triggered the bug.

Build:
```
go build ./pkg/engine/hybrid/...   # passes
go vet ./pkg/engine/hybrid/...     # clean
```