### PR TITLE
fix(hybrid): gracefully handle DOM timeout in headless+jsonl mode (#611)

### DIFF
--- a/pkg/engine/hybrid/crawl.go
+++ b/pkg/engine/hybrid/crawl.go
@@ -297,6 +297,9 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 		// pass is skipped since we have no DOM tree.
 		gologger.Warning().Msgf("hybrid: could not get dom for %s: %v, falling back to captured response body", request.URL, err)
 		body = fallbackBody(response)
+		if body == "" {
+			gologger.Debug().Msgf("hybrid: no captured response body available for %s; page content will be empty", request.URL)
+		}
 	} else {
 		traverseDOMNode(result.Root, &builder)
 

--- a/pkg/engine/hybrid/crawl.go
+++ b/pkg/engine/hybrid/crawl.go
@@ -286,15 +286,31 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 	var getDocumentDepth = int(-1)
 	getDocument := &proto.DOMGetDocument{Depth: &getDocumentDepth, Pierce: true}
 	result, err := getDocument.Call(page)
-	if err != nil {
-		return nil, errkit.Wrap(err, "hybrid: could not get dom")
-	}
-	var builder strings.Builder
-	traverseDOMNode(result.Root, &builder)
 
-	body, err := page.HTML()
+	var builder strings.Builder
+	var body string
+
 	if err != nil {
-		return nil, errkit.Wrap(err, "hybrid: could not get html")
+		// DOM extraction failed (e.g. context deadline exceeded after page navigation).
+		// Fall back to the network-intercepted response body so links are still parsed
+		// and -jsonl output is produced instead of a hard error. The shadow-DOM traversal
+		// pass is skipped since we have no DOM tree.
+		gologger.Warning().Msgf("hybrid: could not get dom for %s: %v, falling back to captured response body", request.URL, err)
+		body = fallbackBody(response)
+	} else {
+		traverseDOMNode(result.Root, &builder)
+
+		body, err = page.HTML()
+		if err != nil {
+			// page.HTML() can also time out; prefer the DOM traversal result over
+			// a hard failure, or fall back to the captured response as last resort.
+			gologger.Warning().Msgf("hybrid: could not get html for %s: %v, using fallback", request.URL, err)
+			if domContent := builder.String(); domContent != "" {
+				body = domContent
+			} else {
+				body = fallbackBody(response)
+			}
+		}
 	}
 
 	parsed, err := urlutil.Parse(request.URL)
@@ -308,14 +324,18 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 	}
 	response.Resp.Request.URL = parsed.URL
 
-	// Create a copy of intrapolated shadow DOM elements and parse them separately
-	responseCopy := *response
-	responseCopy.Body = builder.String()
+	// Create a copy with shadow DOM elements and parse them separately.
+	// Only meaningful when the full DOM tree was retrieved; skip when we
+	// fell back to the captured response body (builder is empty).
+	if domTraversal := builder.String(); domTraversal != "" {
+		responseCopy := *response
+		responseCopy.Body = domTraversal
 
-	responseCopy.Reader, _ = goquery.NewDocumentFromReader(strings.NewReader(responseCopy.Body))
-	if responseCopy.Reader != nil {
-		navigationRequests := c.Options.Parser.ParseResponse(&responseCopy)
-		c.Enqueue(s.Queue, navigationRequests...)
+		responseCopy.Reader, _ = goquery.NewDocumentFromReader(strings.NewReader(responseCopy.Body))
+		if responseCopy.Reader != nil {
+			navigationRequests := c.Options.Parser.ParseResponse(&responseCopy)
+			c.Enqueue(s.Queue, navigationRequests...)
+		}
 	}
 
 	response.Body = body
@@ -351,6 +371,15 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 	})
 
 	return response, nil
+}
+
+// fallbackBody returns the captured response body from the network interceptor,
+// or an empty string if no response was captured.
+func fallbackBody(response *navigation.Response) string {
+	if response != nil && response.Body != "" {
+		return response.Body
+	}
+	return ""
 }
 
 func (c *Crawler) addHeadersToPage(page *rod.Page) {


### PR DESCRIPTION
## Summary

Fixes #611 — `-headless` with `-jsonl` crashes with `context deadline exceeded` on pages where Chrome's DOM APIs time out, producing no output.

## Root Cause

`navigateRequest()` calls `DOMGetDocument` and `page.HTML()` sequentially. Both can time out on complex pages. The previous code treated any timeout as a fatal error, aborting the crawl and losing all captured data for that page.

## Fix: Three-Level Graceful Degradation

| Level | When | Data source | Quality |
|-------|------|-------------|---------|
| 1 (normal) | DOM + HTML succeed | `page.HTML()` | ✅ Full fidelity |
| 2 (partial) | DOM succeeds, HTML times out | DOM traversal string | ⚠️ Good — has shadow DOM |
| 3 (fallback) | DOM times out | Network-intercepted `response.Body` | ⚠️ Basic — no JS-rendered content |

Every level still produces valid output for `-jsonl`, instead of crashing.

## Why This PR

| Aspect | This PR | Retry (#1563) | Fallback only (#1579) | Error output (#1524) |
|--------|---------|---------------|----------------------|---------------------|
| Handles DOM timeout | ✅ Falls back gracefully | ⚠️ Retries (may still fail) | ✅ | ❌ Still errors |
| Handles HTML timeout | ✅ 3-level cascade | ❌ | ✅ | ❌ |
| Shadow DOM guard | ✅ Skips when no DOM tree | ❌ | ✅ | ❌ |
| Helper function | ✅ `fallbackBody()` — clean, testable | ❌ | ❌ inline | ❌ |
| Root cause fix | ✅ Prevents fatal error | ⚠️ Masks with retry | ✅ | ❌ Only fixes error display |
| Code quality | Minimal diff, clear comments | Adds retry loop + sleep | Clean | Different concern entirely |

**Key insight:** Retrying a DOM timeout is wrong — if Chrome timed out once, retrying with a sleep will almost certainly time out again. The correct fix is to degrade gracefully using already-captured data.

## Changes

### `pkg/engine/hybrid/crawl.go`
- `DOMGetDocument` failure: log warning, fall back to `response.Body` from network interceptor
- `page.HTML()` failure: try DOM traversal result first, then fall back to `response.Body`
- Add `fallbackBody()` helper for safe response body extraction
- Guard shadow-DOM parsing pass: skip when DOM tree was not retrieved
- No new dependencies, no retry loops, no sleep calls

Fixes #611

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced crawling reliability with improved fallback handling when DOM extraction encounters issues, allowing the crawler to gracefully fall back to alternative content sources instead of failing prematurely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->