### PR TITLE
fix(hybrid): treat DOM context deadline as recoverable (#611)

### DIFF
--- a/pkg/engine/hybrid/crawl.go
+++ b/pkg/engine/hybrid/crawl.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
@@ -52,6 +53,7 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 	})
 
 	xhrRequests := []navigation.Request{}
+	var sharedMu sync.RWMutex
 	go pageRouter.Start(func(e *proto.FetchRequestPaused) error {
 		URL, err := urlutil.Parse(e.Request.URL)
 		if err != nil {
@@ -158,7 +160,9 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 			} else {
 				networkReq.Headers = utils.FlattenHeaders(requestHeaders)
 			}
+			sharedMu.Lock()
 			xhrRequests = append(xhrRequests, networkReq)
+			sharedMu.Unlock()
 		}
 
 		// trim trailing /
@@ -166,7 +170,9 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 		matchOriginalURL := stringsutil.EqualFoldAny(request.URL, e.Request.URL, normalizedheadlessURL)
 		if matchOriginalURL {
 			request.Raw = string(rawBytesRequest)
+			sharedMu.Lock()
 			response = resp
+			sharedMu.Unlock()
 		}
 
 		// process the raw response
@@ -302,15 +308,25 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 	}
 
 	body, err := page.HTML()
+	var finalResponse *navigation.Response
 	if err != nil {
 		if isContextDeadlineError(err) {
 			gologger.Warning().Msgf("HTML extraction timed out for %s, using captured response\n", request.URL)
-			if response != nil {
-				body = response.Body
+			sharedMu.RLock()
+			finalResponse = response
+			if finalResponse != nil && finalResponse.Resp != nil {
+				body = finalResponse.Body
 			}
+			sharedMu.RUnlock()
 		} else {
 			return nil, errkit.Wrap(err, "hybrid: could not get html")
 		}
+	}
+
+	if finalResponse == nil {
+		sharedMu.RLock()
+		finalResponse = response
+		sharedMu.RUnlock()
 	}
 
 	parsed, err := urlutil.Parse(request.URL)
@@ -318,15 +334,15 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 		return nil, errkit.Wrap(err, "hybrid: url could not be parsed")
 	}
 
-	if response == nil || response.Resp == nil {
+	if finalResponse == nil || finalResponse.Resp == nil {
 		// err is guaranteed to be nil, due to previous checks.
 		return nil, errors.New("hybrid: response is nil")
 	}
-	response.Resp.Request.URL = parsed.URL
+	finalResponse.Resp.Request.URL = parsed.URL
 
 	// Create a copy of intrapolated shadow DOM elements and parse them separately
 	if domReady {
-		responseCopy := *response
+		responseCopy := *finalResponse
 		responseCopy.Body = builder.String()
 
 		responseCopy.Reader, _ = goquery.NewDocumentFromReader(strings.NewReader(responseCopy.Body))
@@ -336,20 +352,23 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 		}
 	}
 
-	response.Body = body
-	if response.Reader != nil {
-		response.Reader.Url, _ = url.Parse(request.URL)
+	finalResponse.Body = body
+	if finalResponse.Reader != nil {
+		finalResponse.Reader.Url, _ = url.Parse(request.URL)
 		if c.Options.Options.FormExtraction {
-			response.Forms = append(response.Forms, utils.ParseFormFields(response.Reader)...)
+			finalResponse.Forms = append(finalResponse.Forms, utils.ParseFormFields(finalResponse.Reader)...)
 		}
 	}
 
-	response.Reader, err = goquery.NewDocumentFromReader(strings.NewReader(response.Body))
+	finalResponse.Reader, err = goquery.NewDocumentFromReader(strings.NewReader(finalResponse.Body))
 	if err != nil {
 		return nil, errkit.Wrap(err, "hybrid: could not parse html")
 	}
 
-	response.XhrRequests = xhrRequests
+	sharedMu.RLock()
+	finalResponse.XhrRequests = make([]navigation.Request, len(xhrRequests))
+	copy(finalResponse.XhrRequests, xhrRequests)
+	sharedMu.RUnlock()
 
 	// enqueue JS-triggered navigation URLs that were detected
 	navigatedURLs.Each(func(i int, navURL string) error {
@@ -368,7 +387,7 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 		return nil
 	})
 
-	return response, nil
+	return finalResponse, nil
 }
 
 func (c *Crawler) addHeadersToPage(page *rod.Page) {

--- a/pkg/engine/hybrid/crawl.go
+++ b/pkg/engine/hybrid/crawl.go
@@ -2,6 +2,7 @@ package hybrid
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -283,18 +284,33 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 		}
 	}
 
+	var builder strings.Builder
+	domReady := false
+
 	var getDocumentDepth = int(-1)
 	getDocument := &proto.DOMGetDocument{Depth: &getDocumentDepth, Pierce: true}
 	result, err := getDocument.Call(page)
 	if err != nil {
-		return nil, errkit.Wrap(err, "hybrid: could not get dom")
+		if isContextDeadlineError(err) {
+			gologger.Warning().Msgf("DOM extraction timed out for %s, falling back to response body\n", request.URL)
+		} else {
+			return nil, errkit.Wrap(err, "hybrid: could not get dom")
+		}
+	} else {
+		traverseDOMNode(result.Root, &builder)
+		domReady = true
 	}
-	var builder strings.Builder
-	traverseDOMNode(result.Root, &builder)
 
 	body, err := page.HTML()
 	if err != nil {
-		return nil, errkit.Wrap(err, "hybrid: could not get html")
+		if isContextDeadlineError(err) {
+			gologger.Warning().Msgf("HTML extraction timed out for %s, using captured response\n", request.URL)
+			if response != nil {
+				body = response.Body
+			}
+		} else {
+			return nil, errkit.Wrap(err, "hybrid: could not get html")
+		}
 	}
 
 	parsed, err := urlutil.Parse(request.URL)
@@ -309,13 +325,15 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 	response.Resp.Request.URL = parsed.URL
 
 	// Create a copy of intrapolated shadow DOM elements and parse them separately
-	responseCopy := *response
-	responseCopy.Body = builder.String()
+	if domReady {
+		responseCopy := *response
+		responseCopy.Body = builder.String()
 
-	responseCopy.Reader, _ = goquery.NewDocumentFromReader(strings.NewReader(responseCopy.Body))
-	if responseCopy.Reader != nil {
-		navigationRequests := c.Options.Parser.ParseResponse(&responseCopy)
-		c.Enqueue(s.Queue, navigationRequests...)
+		responseCopy.Reader, _ = goquery.NewDocumentFromReader(strings.NewReader(responseCopy.Body))
+		if responseCopy.Reader != nil {
+			navigationRequests := c.Options.Parser.ParseResponse(&responseCopy)
+			c.Enqueue(s.Queue, navigationRequests...)
+		}
 	}
 
 	response.Body = body
@@ -380,6 +398,16 @@ func (c *Crawler) addHeadersToPage(page *rod.Page) {
 			gologger.Error().Msgf("headless: could not set extra headers: %v", err)
 		}
 	}
+}
+
+// isContextDeadlineError checks whether an error is caused by a context
+// deadline being exceeded. It uses errors.Is for wrapped errors and falls
+// back to string matching for opaque wrappers.
+func isContextDeadlineError(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	return strings.Contains(err.Error(), "context deadline exceeded")
 }
 
 // traverseDOMNode performs traversal of node completely building a pseudo-HTML


### PR DESCRIPTION
## Summary

Fixes #611 — context deadline exceeded errors in the hybrid engine now degrade gracefully instead of crashing the crawler.

## Root Cause

`navigateRequest()` uses `page.Timeout(timeout)` which sets a context deadline on all subsequent page operations. When DOM extraction (`getDocument.Call()` or `page.HTML()`) exceeds this deadline, the error was treated as fatal — killing the request entirely.

However, the page hijack interceptor has **already captured the full HTTP response body** before DOM extraction begins. The DOM extraction only adds shadow DOM / pseudo-element parsing. A timeout here means partial data loss, not total failure.

## Changes

**`pkg/engine/hybrid/crawl.go`** (39 additions, 11 deletions):

- **`isContextDeadlineError()`** — new helper using `errors.Is(err, context.DeadlineExceeded)` with string fallback for opaque wrappers
- **`getDocument.Call()` recovery** — context deadline → warning log, skip DOM traversal (`domReady = false`)
- **`page.HTML()` recovery** — context deadline → warning log, fallback to `response.Body` captured by the hijacker
- **Shadow DOM gating** — `traverseDOMNode` and shadow DOM copy run only when `domReady == true`

All other errors (network failures, protocol errors, etc.) continue to propagate as fatal, preserving existing behavior.

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| DOM extraction times out | Fatal error, request dropped | Warning logged, response body used |
| `page.HTML()` times out | Fatal error, request dropped | Warning logged, hijacked body used |
| Non-timeout DOM error | Fatal error | Fatal error (unchanged) |
| Successful DOM extraction | Full processing | Full processing (unchanged) |

## Testing

- `go build ./pkg/engine/hybrid/...` ✅
- `go vet ./pkg/engine/hybrid/...` ✅
- Static analysis (gosec): 0 findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout handling: when full extraction times out, the system logs a warning and falls back to previously captured page content to reduce failed fetches.
  * More resilient DOM processing: shadow DOM parsing and enqueueing only run when a reliable pseudo-DOM is available, avoiding wasted work.
  * Stronger concurrency safeguards to prevent inconsistent or lost request/response captures during page processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->