### PR TITLE
fix: use fresh timeout for DOM retrieval in headless mode

### DIFF
--- a/pkg/engine/hybrid/crawl.go
+++ b/pkg/engine/hybrid/crawl.go
@@ -283,16 +283,22 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 		}
 	}
 
+	// Use a dedicated timeout for DOM operations so they are not affected
+	// by time already spent on navigation, WaitStable, and onclick simulation.
+	// The shared page timeout set earlier may be nearly or fully exhausted by
+	// this point, causing "context deadline exceeded" errors (see #611).
+	domPage := page.Timeout(timeout)
+
 	var getDocumentDepth = int(-1)
 	getDocument := &proto.DOMGetDocument{Depth: &getDocumentDepth, Pierce: true}
-	result, err := getDocument.Call(page)
+	result, err := getDocument.Call(domPage)
 	if err != nil {
 		return nil, errkit.Wrap(err, "hybrid: could not get dom")
 	}
 	var builder strings.Builder
 	traverseDOMNode(result.Root, &builder)
 
-	body, err := page.HTML()
+	body, err := domPage.HTML()
 	if err != nil {
 		return nil, errkit.Wrap(err, "hybrid: could not get html")
 	}


### PR DESCRIPTION
/claim #611
  
Fixes #611.

## Problem

Using `-jsonl` with `-headless` produces `context deadline exceeded <- could not get dom` because `DOMGetDocument` shares the same rod page timeout that was set at the start of `navigateRequest`. By the time the crawler finishes navigation, `WaitStable`, and onclick simulation, the timeout budget is exhausted and DOM retrieval inherits an expired (or nearly expired) context.

## Root Cause

In `navigateRequest` (line 188), `page.Timeout(timeout)` sets a single 10-second deadline for the entire sequence:

1. `page.Navigate` + `waitNavigation` — page load
2. `page.WaitStable` — stability check (default 1s)
3. onclick link simulation — up to N links with `time.Sleep(1s)` each
4. `DOMGetDocument` — DOM serialization
5. `page.HTML` — HTML extraction

Steps 1-3 can easily consume the full 10s on complex pages, leaving no time for steps 4-5.

## Fix

Create a fresh `page.Timeout(timeout)` specifically for DOM operations, so they get their own full timeout window independent of time already spent on navigation and page interaction. This addresses the root context handling issue identified by @dwisiswant0 and @Mzack9999 in #1524.

## Testing

- All existing tests pass (`go test ./pkg/...`)
- Verified compilation (`go build ./...`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout handling for DOM extraction and HTML operations to ensure they have adequate time windows instead of consuming remaining time from earlier page operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->