### PR TITLE
adding none to filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ FILTER:
    -fr, -filter-regex string[]            regex or list of regex to filter on output url (cli, file)
    -f, -field string                      field to display in output (url,path,fqdn,rdn,rurl,qurl,qpath,file,ufile,key,value,kv,dir,udir) (Deprecated: use -output-template instead)
    -sf, -store-field string               field to store in per-host output (url,path,fqdn,rdn,rurl,qurl,qpath,file,ufile,key,value,kv,dir,udir)
-   -em, -extension-match string[]         match output for given extension (eg, -em php,html,js)
+   -em, -extension-match string[]         match output for given extension (eg, -em php,html,js,none)
    -ef, -extension-filter string[]        filter output for given extension (eg, -ef png,css)
    -ndef, -no-default-ext-filter bool     remove default extensions from the filter list
    -mdc, -match-condition string          match response with dsl based condition
@@ -781,6 +781,12 @@ Crawl output can be easily matched for specific extension using `-em` option to 
 katana -u https://tesla.com -silent -em js,jsp,json
 ```
 
+Use the special value `none` to also include URLs without a file extension in the output:
+
+```
+katana -u https://tesla.com -silent -em js,jsp,json,none
+```
+
 *`-extension-filter`*
 ---
 
@@ -847,7 +853,7 @@ FILTER:
    -fr, -filter-regex string[]            regex or list of regex to filter on output url (cli, file)
    -f, -field string                      field to display in output (url,path,fqdn,rdn,rurl,qurl,qpath,file,ufile,key,value,kv,dir,udir)
    -sf, -store-field string               field to store in per-host output (url,path,fqdn,rdn,rurl,qurl,qpath,file,ufile,key,value,kv,dir,udir)
-   -em, -extension-match string[]         match output for given extension (eg, -em php,html,js)
+   -em, -extension-match string[]         match output for given extension (eg, -em php,html,js,none)
    -ef, -extension-filter string[]        filter output for given extension (eg, -ef png,css)
    -ndef, -no-default-ext-filter bool     remove default extensions from the filter list
    -mdc, -match-condition string          match response with dsl based condition

--- a/cmd/katana/main.go
+++ b/cmd/katana/main.go
@@ -212,7 +212,7 @@ pipelines offering both headless and non-headless crawling.`)
 		flagSet.StringSliceVarP(&options.OutputFilterRegex, "filter-regex", "fr", nil, "regex or list of regex to filter on output url (cli, file)", goflags.FileStringSliceOptions),
 		flagSet.StringVarP(&options.Fields, "field", "f", "", fmt.Sprintf("field to display in output (%s) (Deprecated: use -output-template instead)", availableFields)),
 		flagSet.StringVarP(&options.StoreFields, "store-field", "sf", "", fmt.Sprintf("field to store in per-host output (%s)", availableFields)),
-		flagSet.StringSliceVarP(&options.ExtensionsMatch, "extension-match", "em", nil, "match output for given extension (eg, -em php,html,js)", goflags.CommaSeparatedStringSliceOptions),
+		flagSet.StringSliceVarP(&options.ExtensionsMatch, "extension-match", "em", nil, "match output for given extension (eg, -em php,html,js,none)", goflags.CommaSeparatedStringSliceOptions),
 		flagSet.StringSliceVarP(&options.ExtensionFilter, "extension-filter", "ef", nil, "filter output for given extension (eg, -ef png,css)", goflags.CommaSeparatedStringSliceOptions),
 		flagSet.BoolVarP(&options.NoDefaultExtFilter, "no-default-ext-filter", "ndef", false, "remove default extensions from the filter list"),
 		flagSet.StringVarP(&options.OutputMatchCondition, "match-condition", "mdc", "", "match response with dsl based condition"),

--- a/pkg/utils/extensions/extensions.go
+++ b/pkg/utils/extensions/extensions.go
@@ -52,7 +52,8 @@ func (e *Validator) ValidatePath(item string) bool {
 		extension = strings.ToLower(path.Ext(item))
 	}
 	if extension == "" && len(e.extensionsMatch) > 0 {
-		return false
+		_, ok := e.extensionsMatch[""]
+		return ok
 	}
 	if len(e.extensionsMatch) > 0 {
 		if _, ok := e.extensionsMatch[extension]; ok {
@@ -69,6 +70,9 @@ func (e *Validator) ValidatePath(item string) bool {
 
 func normalizeExtension(extension string) string {
 	extension = strings.ToLower(extension)
+	if extension == "none" {
+		return ""
+	}
 	if strings.HasPrefix(extension, ".") {
 		return extension
 	}

--- a/pkg/utils/extensions/extensions_test.go
+++ b/pkg/utils/extensions/extensions_test.go
@@ -24,3 +24,38 @@ func TestValidatorValidate(t *testing.T) {
 	validator = NewValidator(nil, []string{"png"}, true)
 	require.False(t, validator.ValidatePath("main.png"), "could not validate correct data with no default extension filter and custom filter")
 }
+
+func TestValidatorExtensionMatchNone(t *testing.T) {
+	t.Run("em without none rejects extensionless URLs", func(t *testing.T) {
+		validator := NewValidator([]string{"css", "js"}, nil, false)
+		require.True(t, validator.ValidatePath("https://example.com/style.css"))
+		require.True(t, validator.ValidatePath("https://example.com/app.js"))
+		require.False(t, validator.ValidatePath("https://example.com/page"))
+		require.False(t, validator.ValidatePath("https://example.com/"))
+	})
+
+	t.Run("em with none accepts extensionless URLs", func(t *testing.T) {
+		validator := NewValidator([]string{"css", "js", "none"}, nil, false)
+		require.True(t, validator.ValidatePath("https://example.com/style.css"))
+		require.True(t, validator.ValidatePath("https://example.com/app.js"))
+		require.True(t, validator.ValidatePath("https://example.com/page"))
+		require.True(t, validator.ValidatePath("https://example.com/"))
+		require.False(t, validator.ValidatePath("https://example.com/image.png"))
+	})
+
+	t.Run("em with only none accepts only extensionless URLs", func(t *testing.T) {
+		validator := NewValidator([]string{"none"}, nil, false)
+		require.True(t, validator.ValidatePath("https://example.com/page"))
+		require.True(t, validator.ValidatePath("https://example.com/"))
+		require.False(t, validator.ValidatePath("https://example.com/style.css"))
+		require.False(t, validator.ValidatePath("https://example.com/app.js"))
+	})
+
+	t.Run("none is case insensitive", func(t *testing.T) {
+		validator := NewValidator([]string{"None"}, nil, false)
+		require.True(t, validator.ValidatePath("https://example.com/page"))
+
+		validator = NewValidator([]string{"NONE"}, nil, false)
+		require.True(t, validator.ValidatePath("https://example.com/page"))
+	})
+}


### PR DESCRIPTION
## Proposed changes
adding `none` filter
Close #764 

## Checklist
- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/katana/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `-em/--extension-match` flag now supports a special `none` value to match URLs without file extensions. The value is case-insensitive and can be combined with other extension filters.

* **Documentation**
  * Updated README sections and CLI help text with examples demonstrating the usage of the `none` value for extension matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->