### PR TITLE
adding helper functions + tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,17 @@ Automatic form filling is experimental feature.
 katana -u https://tesla.com -aff
 ```
 
+Form config values support DSL helper functions for dynamic data generation. All `rand_*` functions from the [projectdiscovery/dsl](https://github.com/projectdiscovery/dsl) library are available:
+
+```yaml
+# $HOME/.config/katana/form-config.yaml
+email: "rand_email()"
+phone: "rand_phone()"
+placeholder: "rand_first_name()"
+password: 'rand_base(16, "")'
+color: "#e66465"
+```
+
 *`-filter-similar`*
 ----
 

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -91,6 +91,7 @@ func readCustomFormConfig(formConfig string) error {
 	if err := yaml.NewDecoder(file).Decode(&data); err != nil {
 		return errkit.Wrap(err, "could not decode form config")
 	}
+	data.Resolve()
 	utils.FormData = data
 	return nil
 }

--- a/pkg/utils/formfill.go
+++ b/pkg/utils/formfill.go
@@ -3,8 +3,11 @@ package utils
 import (
 	"fmt"
 	"strconv"
+	"strings"
+	"sync"
 
 	"github.com/PuerkitoBio/goquery"
+	"github.com/projectdiscovery/dsl"
 	mapsutil "github.com/projectdiscovery/utils/maps"
 	"github.com/rs/xid"
 )
@@ -31,6 +34,64 @@ var DefaultFormFillData = FormFillData{
 	Password:    "katanaP@assw0rd1",
 	PhoneNumber: "2124567890",
 	Placeholder: "katana",
+}
+
+var formDSLEngine *dsl.Engine
+var formDSLOnce sync.Once
+
+func getFormDSLEngine() *dsl.Engine {
+	formDSLOnce.Do(func() {
+		engine, err := dsl.NewEngine()
+		if err != nil {
+			return
+		}
+		for name, fn := range dsl.FakerFunctions() {
+			engine.HelperFunctions[name] = fn
+		}
+		formDSLEngine = engine
+	})
+	return formDSLEngine
+}
+
+// resolveField evaluates a string through the DSL engine if it
+// looks like a function call (contains parentheses). Plain values
+// like "test@example.com" or "5551234567" are returned as-is.
+func resolveField(value string) string {
+	if value == "" || !strings.Contains(value, "(") {
+		return value
+	}
+	engine := getFormDSLEngine()
+	if engine == nil {
+		return value
+	}
+	result, err := safeEvalExpr(engine, value)
+	if err != nil {
+		return value
+	}
+	return fmt.Sprintf("%v", result)
+}
+
+// safeEvalExpr wraps engine.EvalExpr with panic recovery since the
+// underlying govaluate library can panic on inputs that aren't
+// valid expressions (e.g. plain strings treated as undefined variables).
+func safeEvalExpr(engine *dsl.Engine, expr string) (result interface{}, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("expression eval panic: %v", r)
+		}
+	}()
+	return engine.EvalExpr(expr, map[string]interface{}{})
+}
+
+// Resolve evaluates all fields through the DSL engine, resolving any
+// helper function calls like rand_email() or rand_password(8, true).
+// Plain string values pass through unchanged.
+func (f *FormFillData) Resolve() {
+	f.Email = resolveField(f.Email)
+	f.Color = resolveField(f.Color)
+	f.Password = resolveField(f.Password)
+	f.PhoneNumber = resolveField(f.PhoneNumber)
+	f.Placeholder = resolveField(f.Placeholder)
 }
 
 // FormInput is an input for a form field

--- a/pkg/utils/formfill_test.go
+++ b/pkg/utils/formfill_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 
 	"github.com/PuerkitoBio/goquery"
+	mapsutil "github.com/projectdiscovery/utils/maps"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 var htmlFormInputExample = `<html>
@@ -83,5 +85,431 @@ func TestFormInputFillSuggestions(t *testing.T) {
 		})
 		value := queryValuesWriter.Encode()
 		require.Equal(t, "Startdate=katana&color=green&country=india&firstname=katana&food=pasta&message=katana&num=51&password=katana&sport1=cricket&sport2=tennis&sport3=football&telephone=katanaP%40assw0rd1&upclick=%23a52a2a", value, "could not get correct encoded form")
+	})
+}
+
+func TestDefaultFormFillDataIsStatic(t *testing.T) {
+	require.Contains(t, DefaultFormFillData.Email, "@example.org")
+	require.Equal(t, "#e66465", DefaultFormFillData.Color)
+	require.Equal(t, "katanaP@assw0rd1", DefaultFormFillData.Password)
+	require.Equal(t, "2124567890", DefaultFormFillData.PhoneNumber)
+	require.Equal(t, "katana", DefaultFormFillData.Placeholder)
+}
+
+func TestDefaultFormDataInitMatchesDefault(t *testing.T) {
+	require.Equal(t, DefaultFormFillData.Color, FormData.Color)
+	require.Equal(t, DefaultFormFillData.Password, FormData.Password)
+	require.Equal(t, DefaultFormFillData.PhoneNumber, FormData.PhoneNumber)
+	require.Equal(t, DefaultFormFillData.Placeholder, FormData.Placeholder)
+}
+
+func TestResolveDoesNotAlterDefaultValues(t *testing.T) {
+	data := DefaultFormFillData
+	data.Resolve()
+
+	require.Contains(t, data.Email, "@example.org", "default email has no parens, should stay as-is")
+	require.Equal(t, "#e66465", data.Color)
+	require.Equal(t, "katanaP@assw0rd1", data.Password)
+	require.Equal(t, "2124567890", data.PhoneNumber)
+	require.Equal(t, "katana", data.Placeholder)
+}
+
+func TestFormInputFillSuggestionsWithDefaults(t *testing.T) {
+	original := FormData
+	defer func() { FormData = original }()
+
+	FormData = DefaultFormFillData
+
+	inputs := []FormInput{
+		{Name: "user_email", Type: "email"},
+		{Name: "user_pass", Type: "password"},
+		{Name: "user_phone", Type: "tel"},
+		{Name: "nickname", Type: "text"},
+		{Name: "bg", Type: "color"},
+	}
+	suggestions := FormInputFillSuggestions(inputs)
+
+	emailVal, _ := suggestions.Get("user_email")
+	require.Equal(t, DefaultFormFillData.Email, emailVal)
+
+	passVal, _ := suggestions.Get("user_pass")
+	require.Equal(t, DefaultFormFillData.Password, passVal)
+
+	phoneVal, _ := suggestions.Get("user_phone")
+	require.Equal(t, DefaultFormFillData.Password, phoneVal, "tel type uses Password field")
+
+	nickVal, _ := suggestions.Get("nickname")
+	require.Equal(t, DefaultFormFillData.Placeholder, nickVal)
+
+	colorVal, _ := suggestions.Get("bg")
+	require.Equal(t, DefaultFormFillData.Color, colorVal)
+}
+
+func TestFormSelectFillPicksSelectedOption(t *testing.T) {
+	selects := []FormSelect{
+		{
+			Name: "lang",
+			SelectOptions: []SelectOption{
+				{Value: "en"},
+				{Value: "fr", Selected: "selected"},
+				{Value: "de"},
+			},
+		},
+	}
+	result := FormSelectFill(selects)
+	val, _ := result.Get("lang")
+	require.Equal(t, "fr", val)
+}
+
+func TestFormSelectFillDefaultsToFirst(t *testing.T) {
+	selects := []FormSelect{
+		{
+			Name: "country",
+			SelectOptions: []SelectOption{
+				{Value: "us"},
+				{Value: "uk"},
+			},
+		},
+	}
+	result := FormSelectFill(selects)
+	val, _ := result.Get("country")
+	require.Equal(t, "us", val)
+}
+
+func TestFormTextAreaFillUsesPlaceholder(t *testing.T) {
+	original := FormData
+	defer func() { FormData = original }()
+	FormData = DefaultFormFillData
+
+	areas := []FormTextArea{
+		{Name: "bio"},
+		{Name: "notes"},
+	}
+	result := FormTextAreaFill(areas)
+
+	bioVal, _ := result.Get("bio")
+	require.Equal(t, "katana", bioVal)
+	notesVal, _ := result.Get("notes")
+	require.Equal(t, "katana", notesVal)
+}
+
+func TestFormInputRadioPicksFirstValue(t *testing.T) {
+	inputs := []FormInput{
+		{Name: "size", Type: "radio", Value: "small"},
+		{Name: "size", Type: "radio", Value: "medium"},
+		{Name: "size", Type: "radio", Value: "large"},
+	}
+	result := FormInputFillSuggestions(inputs)
+	val, _ := result.Get("size")
+	require.Equal(t, "small", val, "radio should keep the first value encountered")
+}
+
+func TestFormInputCheckboxKeepsAllValues(t *testing.T) {
+	inputs := []FormInput{
+		{Name: "opt_a", Type: "checkbox", Value: "a"},
+		{Name: "opt_b", Type: "checkbox", Value: "b"},
+	}
+	result := FormInputFillSuggestions(inputs)
+	a, _ := result.Get("opt_a")
+	b, _ := result.Get("opt_b")
+	require.Equal(t, "a", a)
+	require.Equal(t, "b", b)
+}
+
+func TestFormInputNumberRespectsMinMaxStep(t *testing.T) {
+	attrs := mapsutil.NewOrderedMap[string, string]()
+	attrs.Set("min", "10")
+	attrs.Set("max", "20")
+	attrs.Set("step", "5")
+	inputs := []FormInput{
+		{Name: "qty", Type: "number", Attributes: attrs},
+	}
+	result := FormInputFillSuggestions(inputs)
+	val, _ := result.Get("qty")
+	require.Equal(t, "15", val, "should be min+step = 10+5")
+}
+
+func TestFormInputPreservesExistingValue(t *testing.T) {
+	inputs := []FormInput{
+		{Name: "token", Type: "hidden", Value: "abc123"},
+	}
+	result := FormInputFillSuggestions(inputs)
+	val, _ := result.Get("token")
+	require.Equal(t, "abc123", val, "pre-filled values should be kept")
+}
+
+func TestCustomFormConfigOverridesDefaults(t *testing.T) {
+	original := FormData
+	defer func() { FormData = original }()
+
+	yamlConfig := `
+email: "custom@test.org"
+color: "#112233"
+password: "customP@ss"
+phone: "9876543210"
+placeholder: "custom"
+`
+	var data FormFillData
+	err := yaml.Unmarshal([]byte(yamlConfig), &data)
+	require.NoError(t, err)
+
+	data.Resolve()
+	FormData = data
+
+	inputs := []FormInput{
+		{Name: "em", Type: "email"},
+		{Name: "pw", Type: "password"},
+		{Name: "ph", Type: "tel"},
+		{Name: "nm", Type: "text"},
+		{Name: "cl", Type: "color"},
+	}
+	suggestions := FormInputFillSuggestions(inputs)
+
+	emVal, _ := suggestions.Get("em")
+	require.Equal(t, "custom@test.org", emVal)
+	pwVal, _ := suggestions.Get("pw")
+	require.Equal(t, "customP@ss", pwVal)
+	phVal, _ := suggestions.Get("ph")
+	require.Equal(t, "customP@ss", phVal, "tel uses Password field")
+	nmVal, _ := suggestions.Get("nm")
+	require.Equal(t, "custom", nmVal)
+	clVal, _ := suggestions.Get("cl")
+	require.Equal(t, "#112233", clVal)
+}
+
+func TestResolveFieldPlainStrings(t *testing.T) {
+	data := FormFillData{
+		Email:       "alice@example.com",
+		Color:       "#ff0000",
+		Password:    "s3cret!",
+		PhoneNumber: "5551234567",
+		Placeholder: "hello",
+	}
+	data.Resolve()
+
+	require.Equal(t, "alice@example.com", data.Email)
+	require.Equal(t, "#ff0000", data.Color)
+	require.Equal(t, "s3cret!", data.Password)
+	require.Equal(t, "5551234567", data.PhoneNumber)
+	require.Equal(t, "hello", data.Placeholder)
+}
+
+func TestResolveFieldDSLExpressions(t *testing.T) {
+	data := FormFillData{
+		Email:       "rand_email()",
+		Password:    `rand_base(16, "")`,
+		PhoneNumber: "rand_phone()",
+		Placeholder: "rand_first_name()",
+		Color:       "#e66465",
+	}
+	data.Resolve()
+
+	require.Contains(t, data.Email, "@", "rand_email() should produce an email address")
+	require.NotEqual(t, "rand_email()", data.Email, "expression should have been evaluated")
+	require.Len(t, data.Password, 16)
+	require.NotEmpty(t, data.PhoneNumber)
+	require.NotEqual(t, "rand_phone()", data.PhoneNumber)
+	require.NotEmpty(t, data.Placeholder)
+	require.NotEqual(t, "rand_first_name()", data.Placeholder)
+	require.Equal(t, "#e66465", data.Color, "plain color value should be unchanged")
+}
+
+func TestResolveFieldMixed(t *testing.T) {
+	data := FormFillData{
+		Email:       "rand_email()",
+		Color:       "#abcdef",
+		Password:    "myStaticPass!",
+		PhoneNumber: "rand_phone()",
+		Placeholder: "katana",
+	}
+	data.Resolve()
+
+	require.Contains(t, data.Email, "@")
+	require.NotEqual(t, "rand_email()", data.Email)
+	require.Equal(t, "#abcdef", data.Color)
+	require.Equal(t, "myStaticPass!", data.Password)
+	require.NotEqual(t, "rand_phone()", data.PhoneNumber)
+	require.Equal(t, "katana", data.Placeholder)
+}
+
+func TestResolveFieldEmpty(t *testing.T) {
+	data := FormFillData{}
+	data.Resolve()
+
+	require.Empty(t, data.Email)
+	require.Empty(t, data.Color)
+	require.Empty(t, data.Password)
+	require.Empty(t, data.PhoneNumber)
+	require.Empty(t, data.Placeholder)
+}
+
+func TestResolveFieldRandBase(t *testing.T) {
+	data := FormFillData{
+		Placeholder: `rand_base(16, "")`,
+	}
+	data.Resolve()
+
+	require.Len(t, data.Placeholder, 16, "rand_base(16) should produce a 16-char string")
+}
+
+func TestResolveProducesUniqueValues(t *testing.T) {
+	a := FormFillData{Email: "rand_email()"}
+	b := FormFillData{Email: "rand_email()"}
+	a.Resolve()
+	b.Resolve()
+
+	require.NotEqual(t, a.Email, b.Email, "successive calls should produce different random values")
+}
+
+func TestResolveFromYAML(t *testing.T) {
+	yamlConfig := `
+email: "rand_email()"
+color: "#e66465"
+password: 'rand_base(16, "")'
+phone: "rand_phone()"
+placeholder: "rand_first_name()"
+`
+	var data FormFillData
+	err := yaml.Unmarshal([]byte(yamlConfig), &data)
+	require.NoError(t, err)
+
+	data.Resolve()
+
+	require.Contains(t, data.Email, "@")
+	require.NotEqual(t, "rand_email()", data.Email)
+	require.Equal(t, "#e66465", data.Color)
+	require.Len(t, data.Password, 16)
+	require.NotEmpty(t, data.PhoneNumber)
+	require.NotEqual(t, "rand_phone()", data.PhoneNumber)
+	require.NotEmpty(t, data.Placeholder)
+	require.NotEqual(t, "rand_first_name()", data.Placeholder)
+}
+
+func TestResolveFromYAMLPlainValues(t *testing.T) {
+	yamlConfig := `
+email: "admin@corp.com"
+color: "#000000"
+password: "hunter2"
+phone: "18005551234"
+placeholder: "test"
+`
+	var data FormFillData
+	err := yaml.Unmarshal([]byte(yamlConfig), &data)
+	require.NoError(t, err)
+
+	data.Resolve()
+
+	require.Equal(t, "admin@corp.com", data.Email)
+	require.Equal(t, "#000000", data.Color)
+	require.Equal(t, "hunter2", data.Password)
+	require.Equal(t, "18005551234", data.PhoneNumber)
+	require.Equal(t, "test", data.Placeholder)
+}
+
+func TestFormFillSuggestionsWithDSLConfig(t *testing.T) {
+	original := FormData
+	defer func() { FormData = original }()
+
+	FormData = FormFillData{
+		Email:       "rand_email()",
+		Password:    `rand_base(16, "")`,
+		PhoneNumber: "rand_phone()",
+		Placeholder: "rand_first_name()",
+		Color:       "#e66465",
+	}
+	FormData.Resolve()
+
+	inputs := []FormInput{
+		{Name: "email", Type: "email"},
+		{Name: "pass", Type: "password"},
+		{Name: "phone", Type: "tel"},
+		{Name: "username", Type: "text"},
+	}
+	suggestions := FormInputFillSuggestions(inputs)
+
+	emailVal, _ := suggestions.Get("email")
+	require.Contains(t, emailVal, "@", "email field should have a resolved email")
+
+	passVal, _ := suggestions.Get("pass")
+	require.NotEmpty(t, passVal, "password field should be filled")
+
+	phoneVal, _ := suggestions.Get("phone")
+	require.NotEmpty(t, phoneVal, "phone field should be filled")
+
+	usernameVal, _ := suggestions.Get("username")
+	require.NotEmpty(t, usernameVal, "text field should use resolved placeholder")
+}
+
+func TestMixedConfigEndToEnd(t *testing.T) {
+	original := FormData
+	defer func() { FormData = original }()
+
+	yamlConfig := `
+email: "rand_email()"
+color: "#facade"
+password: "H@rdC0ded!"
+phone: "rand_phone()"
+placeholder: "static-user"
+`
+	var data FormFillData
+	err := yaml.Unmarshal([]byte(yamlConfig), &data)
+	require.NoError(t, err)
+	data.Resolve()
+	FormData = data
+
+	require.Contains(t, FormData.Email, "@")
+	require.NotEqual(t, "rand_email()", FormData.Email)
+	require.Equal(t, "#facade", FormData.Color)
+	require.Equal(t, "H@rdC0ded!", FormData.Password)
+	require.NotEqual(t, "rand_phone()", FormData.PhoneNumber)
+	require.Equal(t, "static-user", FormData.Placeholder)
+
+	htmlForm := `<html><body>
+	<form action="/submit">
+		<input type="email" name="contact_email">
+		<input type="password" name="secret">
+		<input type="tel" name="mobile">
+		<input type="text" name="display_name">
+		<input type="color" name="theme">
+		<textarea name="bio"></textarea>
+		<select name="role">
+			<option value="admin">Admin</option>
+			<option value="user" selected>User</option>
+		</select>
+		<input type="submit" value="Go">
+	</form>
+	</body></html>`
+
+	document, err := goquery.NewDocumentFromReader(strings.NewReader(htmlForm))
+	require.NoError(t, err)
+
+	document.Find("form[action]").Each(func(i int, item *goquery.Selection) {
+		var formFields []interface{}
+		item.Find("input, textarea, select").Each(func(_ int, el *goquery.Selection) {
+			if len(el.Nodes) == 0 {
+				return
+			}
+			field := ConvertGoquerySelectionToFormField(el)
+			if field != nil {
+				formFields = append(formFields, field)
+			}
+		})
+
+		suggestions := FormFillSuggestions(formFields)
+		values := make(url.Values)
+		suggestions.Iterate(func(k, v string) bool {
+			if k != "" && v != "" {
+				values.Set(k, v)
+			}
+			return true
+		})
+
+		require.Contains(t, values.Get("contact_email"), "@", "email should be a resolved random address")
+		require.Equal(t, "H@rdC0ded!", values.Get("secret"), "password should be the static value")
+		require.Equal(t, "H@rdC0ded!", values.Get("mobile"), "tel uses Password field value")
+		require.Equal(t, "static-user", values.Get("display_name"), "text should use static placeholder")
+		require.Equal(t, "#facade", values.Get("theme"), "color should be the static value")
+		require.Equal(t, "static-user", values.Get("bio"), "textarea should use static placeholder")
+		require.Equal(t, "user", values.Get("role"), "select should pick the selected option")
 	})
 }


### PR DESCRIPTION
## Proposed changes
Close #1227 

## Checklist
- [ ] Pull request is created against the [dev](https://github.com/projectdiscovery/katana/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Form configuration now supports DSL helper functions for dynamic value generation, including `rand_email()`, `rand_phone()`, `rand_first_name()`, and `rand_base()` functions.

* **Documentation**
  * Added guide for using DSL helper functions in the experimental `-automatic-form-fill` feature within form configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->