### PR TITLE
Fix headless Chrome profile persistence with -no-incognito and -chrome-data-dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,12 @@ Runs headless chrome browser without incognito mode, useful when using the local
 katana -u https://tesla.com -headless -no-incognito
 ```
 
+To preserve cookies and other browser session data across runs, combine `-no-incognito` with `-chrome-data-dir` so Katana reuses your chosen Chrome profile directory instead of an isolated temporary one.
+
+```console
+katana -u https://tesla.com -headless -no-incognito -chrome-data-dir /tmp/katana-profile
+```
+
 *`-headless-options`*
 ----
 

--- a/pkg/engine/headless/browser/browser.go
+++ b/pkg/engine/headless/browser/browser.go
@@ -47,6 +47,7 @@ type LauncherOptions struct {
 	PageMaxTimeout      time.Duration
 	ShowBrowser         bool
 	NoSandbox           bool
+	NoIncognito         bool
 	Proxy               string
 	SlowMotion          bool
 	Trace               bool
@@ -54,6 +55,7 @@ type LauncherOptions struct {
 	PageLoadStrategy    string
 	ChromeWSUrl         string // WebSocket URL to connect to existing Chrome
 	DOMWaitTime         int    // Time in seconds to wait for DOM (used with domcontentloaded strategy)
+	UserDataDir         string // User-provided chrome data directory to preserve sessions
 	ChromeUser          *user.User // optional chrome user to use
 
 	ScopeValidator  ScopeValidator
@@ -102,14 +104,29 @@ func (l *Launcher) launchBrowserWithDataDir(userDataDir string) (*rod.Browser, e
 			Set("hide-scrollbars", "true").
 			Set("window-size", fmt.Sprintf("%d,%d", 1080, 1920)).
 			Set("mute-audio", "true").
-			Set("incognito", "true").
 			Delete("use-mock-keychain").
 			Delete("disable-ipc-flooding-protection").
 			Headless(true)
 
+		if !l.opts.NoIncognito {
+			chromeLauncher = chromeLauncher.Set("incognito", "true")
+		}
+
+		skipFlags := map[string]bool{}
+		if l.opts.UserDataDir != "" && l.opts.NoIncognito {
+			skipFlags["use-mock-keychain"] = true
+			skipFlags["password-store"] = true
+			skipFlags["disable-extensions"] = true
+			skipFlags["enable-automation"] = true
+		}
+
 		for _, flag := range headlessFlags {
 			splitted := strings.TrimPrefix(flag, "--")
 			values := strings.Split(splitted, "=")
+			flagName := values[0]
+			if skipFlags[flagName] {
+				continue
+			}
 			if len(values) == 2 {
 				chromeLauncher = chromeLauncher.Set(flags.Flag(values[0]), strings.Split(values[1], ",")...)
 			} else {
@@ -330,8 +347,11 @@ func (l *Launcher) createBrowserPageFunc() (*BrowserPage, error) {
 	shouldCleanupTempDir := false
 	
 	if l.opts.ChromeWSUrl == "" {
-		// Only create temp dir if we're launching our own browser
-		if l.opts.ChromeUser != nil {
+		if l.opts.UserDataDir != "" {
+			// Use user-provided data directory (preserve sessions/cookies)
+			tempDir = l.opts.UserDataDir
+			shouldCleanupTempDir = false
+		} else if l.opts.ChromeUser != nil {
 			var err error
 			tempDir, err = os.MkdirTemp(l.opts.ChromeUser.HomeDir, "chrome-data-*")
 			if err != nil {
@@ -647,15 +667,15 @@ func isBrowserConnected(browser *rod.Browser) bool {
 
 func (b *BrowserPage) CloseBrowserPage() {
 	_ = b.Close() // Close the page/tab
-	
+
 	// Only close the browser if we launched it ourselves (not connecting via ChromeWSUrl)
 	// If ChromeWSUrl was used, we should leave the browser running
 	if b.launcher.opts.ChromeWSUrl == "" {
 		_ = b.Browser.Close()
 	}
-	
-	// Only cleanup temp data dir if we created it
-	if b.userDataDir != "" {
+
+	// Only cleanup temp data dir if we created it (not user-provided)
+	if b.userDataDir != "" && b.userDataDir != b.launcher.opts.UserDataDir {
 		_ = os.RemoveAll(b.userDataDir)
 	}
 }

--- a/pkg/engine/headless/browser/browser.go
+++ b/pkg/engine/headless/browser/browser.go
@@ -87,6 +87,27 @@ func (l *Launcher) ScopeValidator() ScopeValidator {
 	return l.opts.ScopeValidator
 }
 
+func (l *Launcher) shouldUseIncognito() bool {
+	return !l.opts.NoIncognito
+}
+
+func (l *Launcher) shouldSkipHeadlessFlag(flagName string) bool {
+	if l.opts.UserDataDir == "" || !l.opts.NoIncognito {
+		return false
+	}
+
+	switch flagName {
+	case "use-mock-keychain", "password-store", "disable-extensions", "enable-automation":
+		return true
+	default:
+		return false
+	}
+}
+
+func (l *Launcher) shouldPreserveUserDataDir(tempDir string) bool {
+	return tempDir != "" && tempDir == l.opts.UserDataDir
+}
+
 func (l *Launcher) launchBrowserWithDataDir(userDataDir string) (*rod.Browser, error) {
 	var launcherURL string
 	
@@ -108,23 +129,15 @@ func (l *Launcher) launchBrowserWithDataDir(userDataDir string) (*rod.Browser, e
 			Delete("disable-ipc-flooding-protection").
 			Headless(true)
 
-		if !l.opts.NoIncognito {
+		if l.shouldUseIncognito() {
 			chromeLauncher = chromeLauncher.Set("incognito", "true")
-		}
-
-		skipFlags := map[string]bool{}
-		if l.opts.UserDataDir != "" && l.opts.NoIncognito {
-			skipFlags["use-mock-keychain"] = true
-			skipFlags["password-store"] = true
-			skipFlags["disable-extensions"] = true
-			skipFlags["enable-automation"] = true
 		}
 
 		for _, flag := range headlessFlags {
 			splitted := strings.TrimPrefix(flag, "--")
 			values := strings.Split(splitted, "=")
 			flagName := values[0]
-			if skipFlags[flagName] {
+			if l.shouldSkipHeadlessFlag(flagName) {
 				continue
 			}
 			if len(values) == 2 {
@@ -675,7 +688,7 @@ func (b *BrowserPage) CloseBrowserPage() {
 	}
 
 	// Only cleanup temp data dir if we created it (not user-provided)
-	if b.userDataDir != "" && b.userDataDir != b.launcher.opts.UserDataDir {
+	if b.userDataDir != "" && !b.launcher.shouldPreserveUserDataDir(b.userDataDir) {
 		_ = os.RemoveAll(b.userDataDir)
 	}
 }

--- a/pkg/engine/headless/browser/browser_test.go
+++ b/pkg/engine/headless/browser/browser_test.go
@@ -1,6 +1,7 @@
 package browser
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -59,5 +60,59 @@ func TestNewLauncherDefaults(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, "ws://localhost:9222/devtools/browser/abc", l.opts.ChromeWSUrl)
+	})
+}
+
+func TestLauncherIncognitoAndProfilePreservation(t *testing.T) {
+	t.Run("incognito remains enabled by default", func(t *testing.T) {
+		l, err := NewLauncher(LauncherOptions{MaxBrowsers: 1})
+		require.NoError(t, err)
+		require.True(t, l.shouldUseIncognito())
+	})
+
+	t.Run("incognito is disabled when requested", func(t *testing.T) {
+		l, err := NewLauncher(LauncherOptions{
+			MaxBrowsers: 1,
+			NoIncognito: true,
+			UserDataDir: "/tmp/profile",
+		})
+		require.NoError(t, err)
+		require.False(t, l.shouldUseIncognito())
+	})
+
+	t.Run("profile preserving mode skips conflicting flags", func(t *testing.T) {
+		l, err := NewLauncher(LauncherOptions{
+			MaxBrowsers: 1,
+			NoIncognito: true,
+			UserDataDir: "/tmp/profile",
+		})
+		require.NoError(t, err)
+
+		for _, flagName := range []string{"use-mock-keychain", "password-store", "disable-extensions", "enable-automation"} {
+			require.True(t, l.shouldSkipHeadlessFlag(flagName), "expected %s to be skipped", flagName)
+		}
+		require.False(t, l.shouldSkipHeadlessFlag("disable-gpu"))
+	})
+
+	t.Run("default mode keeps standard headless flags", func(t *testing.T) {
+		l, err := NewLauncher(LauncherOptions{
+			MaxBrowsers: 1,
+			UserDataDir: "/tmp/profile",
+		})
+		require.NoError(t, err)
+		require.False(t, l.shouldSkipHeadlessFlag("use-mock-keychain"))
+	})
+
+	t.Run("only exact user supplied profile directory is preserved", func(t *testing.T) {
+		profileDir := filepath.Join(t.TempDir(), "profile")
+		l, err := NewLauncher(LauncherOptions{
+			MaxBrowsers: 1,
+			UserDataDir: profileDir,
+		})
+		require.NoError(t, err)
+
+		require.True(t, l.shouldPreserveUserDataDir(profileDir))
+		require.False(t, l.shouldPreserveUserDataDir(filepath.Join(profileDir, "nested")))
+		require.False(t, l.shouldPreserveUserDataDir(""))
 	})
 }

--- a/pkg/engine/headless/crawler/crawler.go
+++ b/pkg/engine/headless/crawler/crawler.go
@@ -44,6 +44,7 @@ type Options struct {
 	MaxDepth            int
 	PageMaxTimeout      time.Duration
 	NoSandbox           bool
+	NoIncognito         bool
 	ShowBrowser         bool
 	SlowMotion          bool
 	MaxCrawlDuration    time.Duration
@@ -54,6 +55,7 @@ type Options struct {
 	PageLoadStrategy    string
 	ChromeWSUrl         string
 	DOMWaitTime         int
+	UserDataDir         string
 
 	// EnableDiagnostics enables the diagnostics mode
 	// which writes diagnostic information to a directory
@@ -104,9 +106,11 @@ func New(opts Options) (*Crawler, error) {
 		Trace:               opts.Trace,
 		CookieConsentBypass: opts.CookieConsentBypass,
 		NoSandbox:           opts.NoSandbox,
+		NoIncognito:         opts.NoIncognito,
 		PageLoadStrategy:    opts.PageLoadStrategy,
 		ChromeWSUrl:         opts.ChromeWSUrl,
 		DOMWaitTime:         opts.DOMWaitTime,
+		UserDataDir:         opts.UserDataDir,
 		Proxy:               opts.Proxy,
 	})
 	if err != nil {

--- a/pkg/engine/headless/headless.go
+++ b/pkg/engine/headless/headless.go
@@ -111,6 +111,8 @@ func (h *Headless) Crawl(URL string) error {
 		MaxCrawlDuration:  h.options.Options.CrawlDuration,
 		MaxFailureCount:   h.options.Options.MaxFailureCount,
 		NoSandbox:         h.options.Options.HeadlessNoSandbox,
+		NoIncognito:       h.options.Options.HeadlessNoIncognito,
+		UserDataDir:       h.options.Options.ChromeDataDir,
 		Proxy:             h.options.Options.Proxy,
 		MaxBrowsers:       1,
 		PageMaxTimeout:    30 * time.Second,


### PR DESCRIPTION
## Proposed changes

This updates headless Chrome startup so session persistence works correctly when using a custom `-chrome-data-dir` together with `-no-incognito`.

Previously, headless mode could still launch with flags that conflicted with reusing a real browser profile, and the supplied user data directory could be treated like a temporary directory and cleaned up on shutdown. That caused cookies and other session state to be lost between runs.

This enables it to use the session and crawl authenticated pages.

This change:
  - propagates `NoIncognito` and `UserDataDir` through the pure headless
  launcher path
  - skips conflicting default headless flags when Katana is reusing a user-
  provided Chrome profile
  - preserves the supplied profile directory instead of deleting it during
  cleanup
  - adds focused tests for incognito/profile-preservation behavior
  - documents the correct `-no-incognito` + `-chrome-data-dir` usage in the
  README

  ### Proof

  Tested with:

  ```bash
  env GOCACHE=<###> go
  test ./pkg/engine/headless/browser ./pkg/engine/headless ./internal/
  runner
```

  Passed:

  - github.com/projectdiscovery/katana/pkg/engine/headless/browser
  - github.com/projectdiscovery/katana/pkg/engine/headless
  - github.com/projectdiscovery/katana/internal/runner

  Additional coverage added:

  - launcher behavior now has unit tests verifying that incognito is disabled when requested
  - conflicting flags are skipped when reusing a persistent Chrome profile
  - user-provided profile directories are preserved and not treated as temporary cleanup targets


## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/katana/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `NoIncognito` configuration option to disable Chrome incognito mode, enabling browser state persistence.
  * Added `UserDataDir` configuration option to specify a custom Chrome profile directory for session and cookie preservation across crawl runs.

* **Tests**
  * Added comprehensive test coverage for incognito mode behavior and profile preservation logic.

* **Documentation**
  * Updated README with guidance on combining `-no-incognito` with `-chrome-data-dir` to achieve cookie and session persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->