### PR TITLE
Fix onclick link discovery for dynamic JS navigations

### DIFF
--- a/pkg/engine/headless/browser/element.go
+++ b/pkg/engine/headless/browser/element.go
@@ -172,6 +172,27 @@ func (b *BrowserPage) FindNavigations() ([]*types.Action, error) {
 		navigations = append(navigations, types.ActionFromEventListener(listener))
 	}
 
+	navLinks, err := b.GetNavigatedLinks()
+	if err == nil {
+		for _, link := range navLinks {
+			if link.URL == "" {
+				continue
+			}
+			resolved, err := resolveURL(info.URL, link.URL)
+			if err != nil {
+				continue
+			}
+			if _, found := unique[resolved]; found {
+				continue
+			}
+			unique[resolved] = struct{}{}
+			navigations = append(navigations, &types.Action{
+				Type:  types.ActionTypeLoadURL,
+				Input: resolved,
+			})
+		}
+	}
+
 	return navigations, nil
 }
 

--- a/pkg/engine/headless/types/types.go
+++ b/pkg/engine/headless/types/types.go
@@ -249,6 +249,7 @@ func getStableAttributes(attrs map[string]string) []string {
 		"action":      {},
 		"method":      {},
 		"placeholder": {},
+		"onclick":     {},
 	}
 
 	var stableAttrs []string


### PR DESCRIPTION
## Proposed changes

Fixes #1623, ref #1358

Two fixes:
- Add `onclick` to element hash stable attributes so `<a href="#">` elements with different onclick handlers are not deduped
- Collect `__navigatedLinks` (pushState, replaceState, window.open) in `FindNavigations`

### Proof

Test page:
```html
<html><head><script>
function r1(e){e.preventDefault();window.location.href="/r1.html";}
function r2(e){e.preventDefault();document.location="/r2.html";}
function r3(e){e.preventDefault();location.assign("/r3.html");}
</script></head><body>
<a href="#" onclick="r1(event)">R1</a>
<a href="#" onclick="r2(event)">R2</a>
<a href="#" onclick="r3(event)">R3</a>
<a href="/r4.html">R4</a>
</body></html>
```

Before (dev):
```
$ katana -u http://127.0.0.1:19003 -hl -d 2 -silent -ct 30s -ns
http://127.0.0.1:19003/
http://127.0.0.1:19003/r1.html
http://127.0.0.1:19003/r4.html
```

After (this branch):
```
$ katana -u http://127.0.0.1:19003 -hl -d 2 -silent -ct 30s -ns
http://127.0.0.1:19003/
http://127.0.0.1:19003/r1.html
http://127.0.0.1:19003/r2.html
http://127.0.0.1:19003/r3.html
http://127.0.0.1:19003/r4.html
```

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/katana/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Navigation detection now captures additional navigated URLs during page analysis, improving link discovery
  * Clickable element attribute handling has been enhanced to better recognize interactive components on web pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->