### PR TITLE
chore(readme): update Ubuntu installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,19 @@ docker run projectdiscovery/katana:latest -u https://tesla.com -system-chrome -h
 
 ```sh
 sudo apt update
+sudo apt install zip curl wget git snapd
 sudo snap refresh
-sudo apt install zip curl wget git
 sudo snap install golang --classic
-wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add - 
-sudo sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-sudo apt update 
+
+sudo install -d -m 0755 /etc/apt/keyrings
+curl -fsSL https://dl.google.com/linux/linux_signing_key.pub \
+  | sudo gpg --dearmor -o /etc/apt/keyrings/google-chrome.gpg
+
+echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/google-chrome.gpg] \
+  http://dl.google.com/linux/chrome/deb/ stable main" \
+  | sudo tee /etc/apt/sources.list.d/google-chrome.list > /dev/null
+
+sudo apt update
 sudo apt install google-chrome-stable
 ```
 


### PR DESCRIPTION
## Proposed changes
Apt-key has been deprecated in Ubuntu starting from version 22.04 due to security vulnerabilities. This change updates the Ubuntu installation instructions to use  /etc/apt/keyrings/ with signed-by= in the source list entry.

Compatible with Ubuntu 18.04+.

### Proof

Running the `apt-key` command on a newer Ubuntu version shows a warning: 
```bash
user@host:~$ wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
[sudo] password for user:
Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).
OK
```
This generally works but shows a warning. In other distros like Parrot OS, `apt-key` has been removed entirely (`sudo: apt-key: command not found`), causing the original instructions to hard-fail.  

## Checklist
- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/katana/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes [Not Applicable]
- [ ] I have added tests that prove my fix is effective or that my feature works [Not Applicable]
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Updated Ubuntu installation instructions** for Google Chrome with an improved setup process for modern systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->