### PR TITLE
fix: clean up crawler resource lifecycles

### DIFF
--- a/pkg/engine/common/base.go
+++ b/pkg/engine/common/base.go
@@ -305,10 +305,14 @@ type CrawlSession struct {
 //
 // Returns the initialized CrawlSession or an error if initialization fails.
 func (s *Shared) NewCrawlSessionWithURL(URL string) (*CrawlSession, error) {
-	ctx, cancel := context.WithCancel(context.Background())
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+	)
 	if s.Options.Options.CrawlDuration.Seconds() > 0 {
-		//nolint
-		ctx, cancel = context.WithTimeout(ctx, s.Options.Options.CrawlDuration)
+		ctx, cancel = context.WithTimeout(context.Background(), s.Options.Options.CrawlDuration)
+	} else {
+		ctx, cancel = context.WithCancel(context.Background())
 	}
 
 	parsed, err := urlutil.Parse(URL)

--- a/pkg/engine/hybrid/hybrid.go
+++ b/pkg/engine/hybrid/hybrid.go
@@ -22,7 +22,8 @@ import (
 type Crawler struct {
 	*common.Shared
 
-	browser *rod.Browser
+	browser        *rod.Browser
+	chromeLauncher *launcher.Launcher // nil when attached via ChromeWSUrl
 	// TODO: Remove the Chrome PID kill code in favor of using Leakless(true).
 	// This change will be made if there are no complaints about zombie Chrome processes.
 	// References:
@@ -68,6 +69,9 @@ func New(options *types.CrawlerOptions) (*Crawler, error) {
 
 	browser := rod.New().ControlURL(launcherURL)
 	if browserErr := browser.Connect(); browserErr != nil {
+		if chromeLauncher != nil {
+			chromeLauncher.Kill()
+		}
 		return nil, errkit.Wrap(browserErr, fmt.Sprintf("hybrid: failed to connect to chrome instance at %s", launcherURL))
 	}
 
@@ -75,6 +79,7 @@ func New(options *types.CrawlerOptions) (*Crawler, error) {
 	if !options.Options.HeadlessNoIncognito {
 		incognito, err := browser.Incognito()
 		if err != nil {
+			_ = browser.Close()
 			if chromeLauncher != nil {
 				chromeLauncher.Kill()
 			}
@@ -85,12 +90,17 @@ func New(options *types.CrawlerOptions) (*Crawler, error) {
 
 	shared, err := common.NewShared(options)
 	if err != nil {
+		_ = browser.Close()
+		if chromeLauncher != nil {
+			chromeLauncher.Kill()
+		}
 		return nil, errkit.Wrap(err, "hybrid")
 	}
 
 	crawler := &Crawler{
-		Shared:  shared,
-		browser: browser,
+		Shared:         shared,
+		browser:        browser,
+		chromeLauncher: chromeLauncher,
 		// previousPIDs: previousPIDs,
 		tempDir: dataStore,
 	}
@@ -100,6 +110,12 @@ func New(options *types.CrawlerOptions) (*Crawler, error) {
 
 // Close closes the crawler process
 func (c *Crawler) Close() error {
+	if c.browser != nil {
+		_ = c.browser.Close()
+	}
+	if c.chromeLauncher != nil {
+		c.chromeLauncher.Kill()
+	}
 	if c.Options.Options.ChromeDataDir == "" {
 		if err := os.RemoveAll(c.tempDir); err != nil {
 			return err

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -140,10 +140,16 @@ func New(options Options) (Writer, error) {
 			removeDirsWithSuffix(writer.storeResponseDir)
 			_ = os.MkdirAll(writer.storeResponseDir, os.ModePerm)
 		}
-		// todo: the index file seems never used?
-		_, err := newFileOutputWriter(filepath.Join(writer.storeResponseDir, indexFile))
+		// Pre-create (truncate) the index file. updateIndex() reopens it with
+		// O_APPEND|O_WRONLY per write and closes its own handle, so we must not
+		// retain a long-lived descriptor here.
+		indexPath := filepath.Join(writer.storeResponseDir, indexFile)
+		f, err := os.Create(indexPath)
 		if err != nil {
 			return nil, errkit.Wrap(err, "output: could not create index file")
+		}
+		if cerr := f.Close(); cerr != nil {
+			return nil, errkit.Wrap(cerr, "output: could not close index file")
 		}
 	}
 	if options.ErrorLogFile != "" {

--- a/pkg/types/crawler_options.go
+++ b/pkg/types/crawler_options.go
@@ -178,6 +178,15 @@ func NewCrawlerOptions(options *Options) (*CrawlerOptions, error) {
 
 // Close closes the crawler options resources
 func (c *CrawlerOptions) Close() error {
+	if c.RateLimit != nil {
+		c.RateLimit.Stop()
+	}
+	if c.HostRateLimit != nil {
+		c.HostRateLimit.Stop()
+	}
+	if c.Dialer != nil {
+		c.Dialer.Close()
+	}
 	c.UniqueFilter.Close()
 	return c.OutputWriter.Close()
 }


### PR DESCRIPTION
Closes #1636.

## Summary

- stop rate limiter goroutines when `CrawlerOptions.Close()` runs
- avoid orphaned cancel contexts in `NewCrawlSessionWithURL`
- close hybrid browser resources and kill launched Chrome on shutdown and init failures
- truncate `index.txt` without retaining an unnecessary file descriptor

## Why

These code paths were leaving long-lived resources behind across crawl runs:
rate limiter workers could outlive the crawl, hybrid mode could leave launched Chrome processes around, and response storage initialization retained an unnecessary open file handle.

## Test plan

- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test -count=1 -timeout 120s ./pkg/types/... ./pkg/output/... ./pkg/engine/common/... ./pkg/engine/hybrid/...`

## Notes

- `fastdialer.Close()` is included as defensive resource cleanup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource cleanup and failure handling during browser initialization to prevent resource leaks
  * Enhanced cleanup of rate-limiting and network resources when closing the crawler

* **Refactor**
  * Optimized context initialization and file management logic for improved reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
