### PR TITLE
Add callbacks to headless engine

### DIFF
--- a/pkg/engine/headless/crawler/crawler.go
+++ b/pkg/engine/headless/crawler/crawler.go
@@ -13,10 +13,10 @@ import (
 	"time"
 
 	"github.com/adrianbrad/queue"
-	"github.com/happyhackingspace/dit"
 	"github.com/go-rod/rod"
 	"github.com/go-rod/rod/lib/proto"
 	"github.com/go-rod/rod/lib/utils"
+	"github.com/happyhackingspace/dit"
 	"github.com/pkg/errors"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/katana/pkg/engine/headless/browser"
@@ -75,9 +75,10 @@ type Options struct {
 	CaptchaHandler  *captcha.Handler
 	UserArguments   map[string]string
 
-	AuthUsername   string
-	AuthPassword   string
+	AuthUsername  string
+	AuthPassword  string
 	DitClassifier *dit.Classifier
+	AfterAction   func(page *rod.Page, action *types.Action)
 }
 
 var domNormalizer *normalizer.Normalizer
@@ -540,6 +541,11 @@ func (c *Crawler) executeCrawlStateAction(action *types.Action, page *browser.Br
 	default:
 		return fmt.Errorf("unknown action type: %v", action.Type)
 	}
+
+	if c.options.AfterAction != nil {
+		c.options.AfterAction(page.Page, action)
+	}
+
 	return nil
 }
 

--- a/pkg/engine/headless/crawler/crawler.go
+++ b/pkg/engine/headless/crawler/crawler.go
@@ -75,10 +75,12 @@ type Options struct {
 	CaptchaHandler  *captcha.Handler
 	UserArguments   map[string]string
 
-	AuthUsername  string
-	AuthPassword  string
-	DitClassifier *dit.Classifier
-	AfterAction   func(page *rod.Page, action *types.Action)
+	AuthUsername       string
+	AuthPassword       string
+	DitClassifier      *dit.Classifier
+	BeforeAction       func(page *rod.Page, action *types.Action)
+	AfterAction        func(page *rod.Page, action *types.Action)
+	BeforeNavigateBack func(page *rod.Page)
 }
 
 var domNormalizer *normalizer.Normalizer
@@ -481,6 +483,10 @@ func (c *Crawler) crawlFn(ctx context.Context, action *types.Action, page *brows
 var ErrElementNotVisible = errors.New("element not visible")
 
 func (c *Crawler) executeCrawlStateAction(action *types.Action, page *browser.BrowserPage) error {
+	if c.options.BeforeAction != nil {
+		c.options.BeforeAction(page.Page, action)
+	}
+
 	var err error
 	switch action.Type {
 	case types.ActionTypeLoadURL:

--- a/pkg/engine/headless/crawler/crawler.go
+++ b/pkg/engine/headless/crawler/crawler.go
@@ -75,12 +75,13 @@ type Options struct {
 	CaptchaHandler  *captcha.Handler
 	UserArguments   map[string]string
 
-	AuthUsername       string
-	AuthPassword       string
-	DitClassifier      *dit.Classifier
-	BeforeAction       func(page *rod.Page, action *types.Action)
-	AfterAction        func(page *rod.Page, action *types.Action)
-	BeforeNavigateBack func(page *rod.Page)
+	AuthUsername  string
+	AuthPassword  string
+	DitClassifier *dit.Classifier
+
+	// Hooks installs optional lifecycle callbacks. See Hooks for semantics.
+	// The zero value disables all callbacks.
+	Hooks Hooks
 }
 
 var domNormalizer *normalizer.Normalizer
@@ -483,10 +484,12 @@ func (c *Crawler) crawlFn(ctx context.Context, action *types.Action, page *brows
 var ErrElementNotVisible = errors.New("element not visible")
 
 func (c *Crawler) executeCrawlStateAction(action *types.Action, page *browser.BrowserPage) error {
-	if c.options.BeforeAction != nil {
-		c.options.BeforeAction(page.Page, action)
-	}
+	return runWithActionHooks(c.options.Hooks, page, action, func() error {
+		return c.dispatchCrawlAction(action, page)
+	})
+}
 
+func (c *Crawler) dispatchCrawlAction(action *types.Action, page *browser.BrowserPage) error {
 	var err error
 	switch action.Type {
 	case types.ActionTypeLoadURL:
@@ -546,10 +549,6 @@ func (c *Crawler) executeCrawlStateAction(action *types.Action, page *browser.Br
 		}
 	default:
 		return fmt.Errorf("unknown action type: %v", action.Type)
-	}
-
-	if c.options.AfterAction != nil {
-		c.options.AfterAction(page.Page, action)
 	}
 
 	return nil

--- a/pkg/engine/headless/crawler/hooks.go
+++ b/pkg/engine/headless/crawler/hooks.go
@@ -1,0 +1,77 @@
+package crawler
+
+import (
+	"github.com/projectdiscovery/katana/pkg/engine/headless/browser"
+	"github.com/projectdiscovery/katana/pkg/engine/headless/types"
+)
+
+// Hooks bundles optional lifecycle callbacks invoked by the headless crawler.
+// All fields are optional; nil callbacks are skipped.
+//
+// Callbacks run synchronously on the crawler's own goroutine and block its
+// progress for their duration — they should return quickly. A non-nil error
+// returned from any callback aborts the surrounding crawl step and is
+// propagated back to the caller of Crawl.
+//
+// A Hooks value is consulted on every action; callers may safely mutate the
+// fields between Crawl invocations but should not mutate them while a Crawl
+// is in flight. If multiple Crawl invocations run concurrently on the same
+// engine the callbacks must themselves be safe to call concurrently.
+//
+// The supplied *browser.BrowserPage embeds *rod.Page (page.Page) for callers
+// that want to reach the raw rod API. Callbacks should treat the page as
+// read-only — navigating, closing, or otherwise mutating it from inside a
+// callback races with the crawler.
+type Hooks struct {
+	// BeforeAction is invoked just before each action is dispatched, including
+	// actions that will subsequently fail. A non-nil error aborts the action.
+	BeforeAction func(page *browser.BrowserPage, action *types.Action) error
+	// AfterAction is invoked only after an action completes successfully.
+	// It is not called when the action returns an error. A non-nil error from
+	// AfterAction is returned in place of the (otherwise nil) action error.
+	AfterAction func(page *browser.BrowserPage, action *types.Action) error
+	// BeforeNavigateBack is invoked once per browser-history back step during
+	// state restoration, immediately before page.NavigateBack(). A non-nil
+	// error aborts the navigation.
+	BeforeNavigateBack func(page *browser.BrowserPage) error
+}
+
+// runWithActionHooks invokes hooks.BeforeAction, then fn, then on success
+// hooks.AfterAction, returning the first non-nil error encountered. The
+// semantics are:
+//
+//   - BeforeAction error → fn and AfterAction are skipped; error is returned.
+//   - fn error           → AfterAction is skipped; fn error is returned.
+//   - fn nil, AfterAction error → AfterAction error is returned.
+//
+// runWithActionHooks must remain side-effect-free beyond the supplied hooks
+// so its semantics can be verified in isolation.
+func runWithActionHooks(hooks Hooks, page *browser.BrowserPage, action *types.Action, fn func() error) (err error) {
+	if cb := hooks.BeforeAction; cb != nil {
+		if err := cb(page, action); err != nil {
+			return err
+		}
+	}
+	defer func() {
+		if err != nil {
+			return
+		}
+		if cb := hooks.AfterAction; cb != nil {
+			if cerr := cb(page, action); cerr != nil {
+				err = cerr
+			}
+		}
+	}()
+	return fn()
+}
+
+// runWithNavigateBackHook invokes hooks.BeforeNavigateBack and then fn,
+// short-circuiting on a non-nil error from either.
+func runWithNavigateBackHook(hooks Hooks, page *browser.BrowserPage, fn func() error) error {
+	if cb := hooks.BeforeNavigateBack; cb != nil {
+		if err := cb(page); err != nil {
+			return err
+		}
+	}
+	return fn()
+}

--- a/pkg/engine/headless/crawler/hooks_test.go
+++ b/pkg/engine/headless/crawler/hooks_test.go
@@ -1,0 +1,158 @@
+package crawler
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/projectdiscovery/katana/pkg/engine/headless/browser"
+	"github.com/projectdiscovery/katana/pkg/engine/headless/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// trace captures the relative ordering of hook and dispatch invocations so
+// individual cases can both assert "what ran" and "in what order".
+type trace struct{ steps []string }
+
+func (tr *trace) add(s string) { tr.steps = append(tr.steps, s) }
+
+func TestRunWithActionHooks_Success(t *testing.T) {
+	var tr trace
+	hooks := Hooks{
+		BeforeAction: func(_ *browser.BrowserPage, _ *types.Action) error { tr.add("before"); return nil },
+		AfterAction:  func(_ *browser.BrowserPage, _ *types.Action) error { tr.add("after"); return nil },
+	}
+
+	err := runWithActionHooks(hooks, nil, &types.Action{}, func() error {
+		tr.add("dispatch")
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"before", "dispatch", "after"}, tr.steps,
+		"BeforeAction → dispatch → AfterAction must run in order on success")
+}
+
+func TestRunWithActionHooks_DispatchError_SkipsAfter(t *testing.T) {
+	var tr trace
+	sentinel := errors.New("dispatch failed")
+	hooks := Hooks{
+		BeforeAction: func(_ *browser.BrowserPage, _ *types.Action) error { tr.add("before"); return nil },
+		AfterAction:  func(_ *browser.BrowserPage, _ *types.Action) error { tr.add("after"); return nil },
+	}
+
+	err := runWithActionHooks(hooks, nil, &types.Action{}, func() error {
+		tr.add("dispatch")
+		return sentinel
+	})
+
+	require.ErrorIs(t, err, sentinel)
+	assert.Equal(t, []string{"before", "dispatch"}, tr.steps,
+		"AfterAction must not run when dispatch returns an error")
+}
+
+func TestRunWithActionHooks_BeforeError_SkipsDispatchAndAfter(t *testing.T) {
+	var tr trace
+	sentinel := errors.New("aborted by BeforeAction")
+	hooks := Hooks{
+		BeforeAction: func(_ *browser.BrowserPage, _ *types.Action) error { tr.add("before"); return sentinel },
+		AfterAction:  func(_ *browser.BrowserPage, _ *types.Action) error { tr.add("after"); return nil },
+	}
+
+	err := runWithActionHooks(hooks, nil, &types.Action{}, func() error {
+		tr.add("dispatch")
+		return nil
+	})
+
+	require.ErrorIs(t, err, sentinel)
+	assert.Equal(t, []string{"before"}, tr.steps,
+		"BeforeAction error must short-circuit dispatch and AfterAction")
+}
+
+func TestRunWithActionHooks_AfterError_PropagatedOnSuccess(t *testing.T) {
+	var tr trace
+	sentinel := errors.New("post-action failure")
+	hooks := Hooks{
+		AfterAction: func(_ *browser.BrowserPage, _ *types.Action) error { tr.add("after"); return sentinel },
+	}
+
+	err := runWithActionHooks(hooks, nil, &types.Action{}, func() error {
+		tr.add("dispatch")
+		return nil
+	})
+
+	require.ErrorIs(t, err, sentinel)
+	assert.Equal(t, []string{"dispatch", "after"}, tr.steps)
+}
+
+func TestRunWithActionHooks_ZeroValue_NoPanicNoCallbacks(t *testing.T) {
+	called := false
+	err := runWithActionHooks(Hooks{}, nil, &types.Action{}, func() error {
+		called = true
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.True(t, called, "dispatch must run even when no hooks are installed")
+}
+
+func TestRunWithNavigateBackHook_Success(t *testing.T) {
+	var tr trace
+	hooks := Hooks{
+		BeforeNavigateBack: func(_ *browser.BrowserPage) error { tr.add("before"); return nil },
+	}
+
+	err := runWithNavigateBackHook(hooks, nil, func() error {
+		tr.add("navigate")
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"before", "navigate"}, tr.steps)
+}
+
+func TestRunWithNavigateBackHook_BeforeError_SkipsNavigation(t *testing.T) {
+	var tr trace
+	sentinel := errors.New("aborted")
+	hooks := Hooks{
+		BeforeNavigateBack: func(_ *browser.BrowserPage) error { tr.add("before"); return sentinel },
+	}
+
+	err := runWithNavigateBackHook(hooks, nil, func() error {
+		tr.add("navigate")
+		return nil
+	})
+
+	require.ErrorIs(t, err, sentinel)
+	assert.Equal(t, []string{"before"}, tr.steps,
+		"BeforeNavigateBack error must short-circuit the navigation")
+}
+
+func TestRunWithNavigateBackHook_NavigationError_Propagated(t *testing.T) {
+	sentinel := errors.New("nav failed")
+	err := runWithNavigateBackHook(Hooks{}, nil, func() error { return sentinel })
+
+	require.ErrorIs(t, err, sentinel)
+}
+
+// TestExecuteCrawlStateAction_DispatchesThroughHooks is the integration sanity
+// check that executeCrawlStateAction actually routes through runWithActionHooks.
+// The dispatch unavoidably fails for ActionTypeUnknown (no real browser), so
+// we only assert the hooks behave as the runner contract demands on that path.
+func TestExecuteCrawlStateAction_DispatchesThroughHooks(t *testing.T) {
+	var beforeCalled, afterCalled bool
+	c := &Crawler{
+		options: Options{
+			Hooks: Hooks{
+				BeforeAction: func(_ *browser.BrowserPage, _ *types.Action) error { beforeCalled = true; return nil },
+				AfterAction:  func(_ *browser.BrowserPage, _ *types.Action) error { afterCalled = true; return nil },
+			},
+		},
+	}
+
+	err := c.executeCrawlStateAction(&types.Action{Type: types.ActionTypeUnknown}, &browser.BrowserPage{})
+
+	require.Error(t, err)
+	assert.True(t, beforeCalled)
+	assert.False(t, afterCalled)
+}

--- a/pkg/engine/headless/crawler/state.go
+++ b/pkg/engine/headless/crawler/state.go
@@ -247,10 +247,8 @@ func (c *Crawler) tryBrowserHistoryNavigation(page *browser.BrowserPage, originP
 
 	var navigatedSuccessfully bool
 	for i := 0; i < stepsBack; i++ {
-		if c.options.BeforeNavigateBack != nil {
-			c.options.BeforeNavigateBack(page.Page)
-		}
-		if err := page.NavigateBack(); err != nil {
+		err := runWithNavigateBackHook(c.options.Hooks, page, page.NavigateBack)
+		if err != nil {
 			return "", err
 		}
 		navigatedSuccessfully = true

--- a/pkg/engine/headless/crawler/state.go
+++ b/pkg/engine/headless/crawler/state.go
@@ -247,6 +247,9 @@ func (c *Crawler) tryBrowserHistoryNavigation(page *browser.BrowserPage, originP
 
 	var navigatedSuccessfully bool
 	for i := 0; i < stepsBack; i++ {
+		if c.options.BeforeNavigateBack != nil {
+			c.options.BeforeNavigateBack(page.Page)
+		}
 		if err := page.NavigateBack(); err != nil {
 			return "", err
 		}

--- a/pkg/engine/headless/crawler/state_test.go
+++ b/pkg/engine/headless/crawler/state_test.go
@@ -4,9 +4,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-rod/rod"
 	"github.com/pkg/errors"
+	"github.com/projectdiscovery/katana/pkg/engine/headless/browser"
 	"github.com/projectdiscovery/katana/pkg/engine/headless/crawler/normalizer/simhash"
+	"github.com/projectdiscovery/katana/pkg/engine/headless/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPageFingerprint_Stability(t *testing.T) {
@@ -170,4 +174,22 @@ func TestSimHashSimilarity(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestExecuteCrawlStateAction_Callbacks(t *testing.T) {
+	var beforeCalled, afterCalled bool
+
+	c := &Crawler{
+		options: Options{
+			BeforeAction: func(_ *rod.Page, _ *types.Action) { beforeCalled = true },
+			AfterAction:  func(_ *rod.Page, _ *types.Action) { afterCalled = true },
+		},
+	}
+
+	action := &types.Action{Type: types.ActionTypeUnknown} // hits default branch in switch
+	err := c.executeCrawlStateAction(action, &browser.BrowserPage{})
+
+	require.Error(t, err)
+	assert.True(t, beforeCalled, "BeforeAction should be called before executing the action")
+	assert.False(t, afterCalled, "AfterAction should not be called when action returns an error")
 }

--- a/pkg/engine/headless/crawler/state_test.go
+++ b/pkg/engine/headless/crawler/state_test.go
@@ -4,13 +4,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-rod/rod"
 	"github.com/pkg/errors"
-	"github.com/projectdiscovery/katana/pkg/engine/headless/browser"
 	"github.com/projectdiscovery/katana/pkg/engine/headless/crawler/normalizer/simhash"
-	"github.com/projectdiscovery/katana/pkg/engine/headless/types"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestPageFingerprint_Stability(t *testing.T) {
@@ -174,22 +170,4 @@ func TestSimHashSimilarity(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestExecuteCrawlStateAction_Callbacks(t *testing.T) {
-	var beforeCalled, afterCalled bool
-
-	c := &Crawler{
-		options: Options{
-			BeforeAction: func(_ *rod.Page, _ *types.Action) { beforeCalled = true },
-			AfterAction:  func(_ *rod.Page, _ *types.Action) { afterCalled = true },
-		},
-	}
-
-	action := &types.Action{Type: types.ActionTypeUnknown} // hits default branch in switch
-	err := c.executeCrawlStateAction(action, &browser.BrowserPage{})
-
-	require.Error(t, err)
-	assert.True(t, beforeCalled, "BeforeAction should be called before executing the action")
-	assert.False(t, afterCalled, "AfterAction should not be called when action returns an error")
 }

--- a/pkg/engine/headless/headless.go
+++ b/pkg/engine/headless/headless.go
@@ -26,6 +26,8 @@ type Headless struct {
 	pathTrie *utils.PathTrie
 
 	debugger *CrawlDebugger
+
+	hooks *Hooks
 }
 
 // New returns a new headless crawler instance
@@ -181,9 +183,9 @@ func (h *Headless) Crawl(URL string) error {
 		CookieConsentBypass: true,
 		UserArguments:       h.options.Options.ParseHeadlessOptionalArguments(),
 		DitClassifier:       h.options.DitClassifier,
-		BeforeAction:        h.options.Options.BeforeAction,
-		AfterAction:         h.options.Options.AfterAction,
-		BeforeNavigateBack:  h.options.Options.BeforeNavigateBack,
+	}
+	if h.hooks != nil {
+		crawlOpts.Hooks = *h.hooks
 	}
 
 	if creds := h.options.Options.AuthCredentials; creds != "" {

--- a/pkg/engine/headless/headless.go
+++ b/pkg/engine/headless/headless.go
@@ -181,7 +181,9 @@ func (h *Headless) Crawl(URL string) error {
 		CookieConsentBypass: true,
 		UserArguments:       h.options.Options.ParseHeadlessOptionalArguments(),
 		DitClassifier:       h.options.DitClassifier,
+		BeforeAction:        h.options.Options.BeforeAction,
 		AfterAction:         h.options.Options.AfterAction,
+		BeforeNavigateBack:  h.options.Options.BeforeNavigateBack,
 	}
 
 	if creds := h.options.Options.AuthCredentials; creds != "" {

--- a/pkg/engine/headless/headless.go
+++ b/pkg/engine/headless/headless.go
@@ -27,7 +27,7 @@ type Headless struct {
 
 	debugger *CrawlDebugger
 
-	hooks *Hooks
+	hooks Hooks
 }
 
 // New returns a new headless crawler instance
@@ -183,9 +183,7 @@ func (h *Headless) Crawl(URL string) error {
 		CookieConsentBypass: true,
 		UserArguments:       h.options.Options.ParseHeadlessOptionalArguments(),
 		DitClassifier:       h.options.DitClassifier,
-	}
-	if h.hooks != nil {
-		crawlOpts.Hooks = *h.hooks
+		Hooks:               h.hooks,
 	}
 
 	if creds := h.options.Options.AuthCredentials; creds != "" {

--- a/pkg/engine/headless/headless.go
+++ b/pkg/engine/headless/headless.go
@@ -180,7 +180,8 @@ func (h *Headless) Crawl(URL string) error {
 		Trace:               h.options.Options.EnableDiagnostics,
 		CookieConsentBypass: true,
 		UserArguments:       h.options.Options.ParseHeadlessOptionalArguments(),
-		DitClassifier:      h.options.DitClassifier,
+		DitClassifier:       h.options.DitClassifier,
+		AfterAction:         h.options.Options.AfterAction,
 	}
 
 	if creds := h.options.Options.AuthCredentials; creds != "" {

--- a/pkg/engine/headless/hooks.go
+++ b/pkg/engine/headless/hooks.go
@@ -1,0 +1,15 @@
+package headless
+
+import "github.com/projectdiscovery/katana/pkg/engine/headless/crawler"
+
+// Hooks re-exports crawler.Hooks so library users can configure headless
+// lifecycle callbacks without importing the internal crawler sub-package.
+// See crawler.Hooks for field-level documentation and semantics.
+type Hooks = crawler.Hooks
+
+// SetHooks installs lifecycle callbacks on the headless engine. The callbacks
+// are picked up by subsequent calls to Crawl. Passing nil clears any previously
+// installed hooks.
+func (h *Headless) SetHooks(hooks *Hooks) {
+	h.hooks = hooks
+}

--- a/pkg/engine/headless/hooks.go
+++ b/pkg/engine/headless/hooks.go
@@ -7,9 +7,15 @@ import "github.com/projectdiscovery/katana/pkg/engine/headless/crawler"
 // See crawler.Hooks for field-level documentation and semantics.
 type Hooks = crawler.Hooks
 
-// SetHooks installs lifecycle callbacks on the headless engine. The callbacks
-// are picked up by subsequent calls to Crawl. Passing nil clears any previously
-// installed hooks.
+// SetHooks installs lifecycle callbacks on the headless engine. The supplied
+// struct is copied, so mutating it after SetHooks returns has no effect on the
+// engine; call SetHooks again to change the installed hooks. Passing nil clears
+// any previously installed hooks. SetHooks is not safe to call concurrently
+// with Crawl on the same engine.
 func (h *Headless) SetHooks(hooks *Hooks) {
-	h.hooks = hooks
+	if hooks == nil {
+		h.hooks = Hooks{}
+		return
+	}
+	h.hooks = *hooks
 }

--- a/pkg/engine/headless/hooks_test.go
+++ b/pkg/engine/headless/hooks_test.go
@@ -1,0 +1,40 @@
+package headless
+
+import (
+	"testing"
+
+	"github.com/projectdiscovery/katana/pkg/engine/headless/browser"
+	"github.com/projectdiscovery/katana/pkg/engine/headless/types"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSetHooks_SnapshotsCallerStruct guards the contract that SetHooks copies
+// the supplied Hooks value: mutating the caller's struct after SetHooks
+// returns must not affect the engine's installed hooks.
+func TestSetHooks_SnapshotsCallerStruct(t *testing.T) {
+	original := func(_ *browser.BrowserPage, _ *types.Action) error { return nil }
+	mutated := func(_ *browser.BrowserPage, _ *types.Action) error { return assert.AnError }
+
+	hooks := &Hooks{BeforeAction: original}
+	h := &Headless{}
+	h.SetHooks(hooks)
+
+	hooks.BeforeAction = mutated
+
+	require := assert.New(t)
+	require.NotNil(h.hooks.BeforeAction, "BeforeAction should still be installed")
+	require.NoError(
+		h.hooks.BeforeAction(nil, nil),
+		"engine must keep the snapshot taken at SetHooks time, not the caller's mutated pointer",
+	)
+}
+
+// TestSetHooks_NilClears verifies that passing nil resets the engine to the
+// zero-value Hooks, which is in turn safe to invoke at every callback site.
+func TestSetHooks_NilClears(t *testing.T) {
+	h := &Headless{}
+	h.SetHooks(&Hooks{BeforeAction: func(_ *browser.BrowserPage, _ *types.Action) error { return nil }})
+	h.SetHooks(nil)
+
+	assert.Equal(t, Hooks{}, h.hooks, "passing nil to SetHooks should clear all installed hooks")
+}

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -6,9 +6,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-rod/rod"
 	"github.com/projectdiscovery/goflags"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/gologger/levels"
+	"github.com/projectdiscovery/katana/pkg/engine/headless/types"
 	"github.com/projectdiscovery/katana/pkg/output"
 	fileutil "github.com/projectdiscovery/utils/file"
 	logutil "github.com/projectdiscovery/utils/log"
@@ -19,6 +21,9 @@ type OnResultCallback func(output.Result)
 
 // OnSkipURLCallback (string)
 type OnSkipURLCallback func(string)
+
+// AfterActionCallback (page *rod.Page, action *types.Action)
+type AfterActionCallback func(page *rod.Page, action *types.Action)
 
 type Options struct {
 	// URLs contains a list of URLs for crawling
@@ -203,7 +208,7 @@ type Options struct {
 	// MaxOnclickLinks is the maximum number of onclick links to process per page (default: 10)
 	MaxOnclickLinks int
 	// PageLoadStrategy specifies how to wait for pages to load (heuristic, load, domcontentloaded, networkidle, none)
-	PageLoadStrategy      string
+	PageLoadStrategy string
 	// DOMWaitTime is the time in seconds to wait after domcontentloaded strategy (default: 5)
 	DOMWaitTime           int
 	CaptchaSolverProvider string
@@ -216,6 +221,8 @@ type Options struct {
 	AuthCredentials string
 	// MaxDomainPages is the maximum number of pages to crawl per domain (0 = unlimited)
 	MaxDomainPages int
+	// AfterAction is called after each action is successfully performed in headless mode
+	AfterAction AfterActionCallback
 }
 
 func (options *Options) ParseCustomHeaders() map[string]string {

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -6,11 +6,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-rod/rod"
 	"github.com/projectdiscovery/goflags"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/gologger/levels"
-	"github.com/projectdiscovery/katana/pkg/engine/headless/types"
 	"github.com/projectdiscovery/katana/pkg/output"
 	fileutil "github.com/projectdiscovery/utils/file"
 	logutil "github.com/projectdiscovery/utils/log"
@@ -21,9 +19,6 @@ type OnResultCallback func(output.Result)
 
 // OnSkipURLCallback (string)
 type OnSkipURLCallback func(string)
-
-// ActionCallback (page *rod.Page, action *types.Action)
-type ActionCallback func(page *rod.Page, action *types.Action)
 
 type Options struct {
 	// URLs contains a list of URLs for crawling
@@ -221,12 +216,6 @@ type Options struct {
 	AuthCredentials string
 	// MaxDomainPages is the maximum number of pages to crawl per domain (0 = unlimited)
 	MaxDomainPages int
-	// BeforeAction is called before each action is performed in headless mode
-	BeforeAction ActionCallback
-	// AfterAction is called after each action is successfully performed in headless mode
-	AfterAction ActionCallback
-	// BeforeNavigateBack is called before each browser-history NavigateBack during state restoration
-	BeforeNavigateBack func(*rod.Page)
 }
 
 func (options *Options) ParseCustomHeaders() map[string]string {

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -22,8 +22,8 @@ type OnResultCallback func(output.Result)
 // OnSkipURLCallback (string)
 type OnSkipURLCallback func(string)
 
-// AfterActionCallback (page *rod.Page, action *types.Action)
-type AfterActionCallback func(page *rod.Page, action *types.Action)
+// ActionCallback (page *rod.Page, action *types.Action)
+type ActionCallback func(page *rod.Page, action *types.Action)
 
 type Options struct {
 	// URLs contains a list of URLs for crawling
@@ -221,8 +221,12 @@ type Options struct {
 	AuthCredentials string
 	// MaxDomainPages is the maximum number of pages to crawl per domain (0 = unlimited)
 	MaxDomainPages int
+	// BeforeAction is called before each action is performed in headless mode
+	BeforeAction ActionCallback
 	// AfterAction is called after each action is successfully performed in headless mode
-	AfterAction AfterActionCallback
+	AfterAction ActionCallback
+	// BeforeNavigateBack is called before each browser-history NavigateBack during state restoration
+	BeforeNavigateBack func(*rod.Page)
 }
 
 func (options *Options) ParseCustomHeaders() map[string]string {


### PR DESCRIPTION
## Proposed changes

I am working on a project which involves using the Katana headless crawler to extract pages from a web app. 

I need to know every time an action is taken or navigation is about to happen in order to know if the URL changed because of an automatic redirect, i.e. from JS checking if a cookie is present, or if it changed because the crawler took some kind of action, like clicking a link.

This allows me to build up a table of pages crawled which includes the URL, but also the "final URL" of that page. So for an unauthenticated user, a page might have URL `https://example.com/admin`, but the final URL will be `https://example.com/login`.

### Proof

I set callback functions for these three new callbacks and verified the code inside them was excuted.

## Checklist

Lint and unit tests pass, integration tests are failing on the dev branch currently. I strongly recommend running these checks in CI which is extremely easy to do with Github actions. Let me know if you want I can contribute a PR to add this.

- [X] Pull request is created against the [dev](https://github.com/projectdiscovery/katana/tree/dev) branch
- [ ] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional lifecycle hooks for the headless crawler allow intercepting actions and back-navigation; hooks can be configured via the engine's SetHooks API and are optional (zero-value/no-op).
  * Installed hooks are snapshotted; passing nil clears configured hooks.

* **Tests**
  * Added tests covering hook execution order, error handling, back-navigation behavior, and integration with the crawler.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectdiscovery/katana/pull/1662?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->