### PR TITLE
feat: add endpoints extractor to knowledgebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ CONFIGURATION:
    -kb, -knowledge-base          enable knowledge base classification
    -kb-secrets                   enable secrets extractor in the knowledge base
    -kb-validate-secrets          validate detected secrets against their provider (sends live API calls)
+   -kb-endpoints                 enable endpoints extractor (classifies REST/GraphQL/SOAP/XHR requests)
    -mdp, -max-domain-pages int   maximum number of pages to crawl per domain (default unlimited)
 
 DEBUG:

--- a/cmd/katana/main.go
+++ b/cmd/katana/main.go
@@ -174,6 +174,7 @@ pipelines offering both headless and non-headless crawling.`)
 		flagSet.BoolVarP(&options.KnowledgeBase, "knowledge-base", "kb", false, "enable knowledge base classification"),
 		flagSet.BoolVar(&options.Secrets, "kb-secrets", false, "enable secrets extractor in the knowledge base"),
 		flagSet.BoolVar(&options.ValidateSecrets, "kb-validate-secrets", false, "validate detected secrets against their provider (sends live API calls)"),
+		flagSet.BoolVar(&options.Endpoints, "kb-endpoints", false, "enable endpoints extractor (classifies REST/GraphQL/SOAP/XHR requests)"),
 		flagSet.IntVarP(&options.MaxDomainPages, "max-domain-pages", "mdp", 0, "maximum number of pages to crawl per domain (default unlimited)"),
 	)
 

--- a/pkg/engine/common/base.go
+++ b/pkg/engine/common/base.go
@@ -368,7 +368,7 @@ func (s *Shared) NewCrawlSessionWithURL(URL string) (*CrawlSession, error) {
 			Technologies:  technologyKeys,
 			StatusCode:    resp.StatusCode,
 			Headers:       utils.FlattenHeaders(resp.Header),
-			KnowledgeBase: s.Options.BuildKnowledgeBase(string(body)),
+			KnowledgeBase: s.Options.BuildKnowledgeBase(string(body), resp.Request, resp),
 		}
 		navigationRequests := s.Options.Parser.ParseResponse(navigationResponse)
 		s.Enqueue(queue, navigationRequests...)

--- a/pkg/engine/headless/headless.go
+++ b/pkg/engine/headless/headless.go
@@ -2,6 +2,7 @@ package headless
 
 import (
 	"log/slog"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -160,7 +161,11 @@ func (h *Headless) Crawl(URL string) error {
 			}
 
 			if rr.Response != nil {
-				rr.Response.KnowledgeBase = h.options.BuildKnowledgeBase(rr.Response.Body)
+				var req *http.Request
+				if rr.Response.Resp != nil {
+					req = rr.Response.Resp.Request
+				}
+				rr.Response.KnowledgeBase = h.options.BuildKnowledgeBase(rr.Response.Body, req, rr.Response.Resp)
 				if h.options.Options.OmitRaw {
 					rr.Response.Raw = ""
 				}

--- a/pkg/engine/hybrid/crawl.go
+++ b/pkg/engine/hybrid/crawl.go
@@ -139,7 +139,7 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 			Headers:       utils.FlattenHeaders(headers),
 			Raw:           string(rawBytesResponse),
 			ContentLength: httpresp.ContentLength,
-			KnowledgeBase: c.Options.BuildKnowledgeBase(string(body)),
+			KnowledgeBase: c.Options.BuildKnowledgeBase(string(body), httpreq, httpresp),
 		}
 		response.ContentLength = resp.ContentLength
 

--- a/pkg/engine/standard/crawl.go
+++ b/pkg/engine/standard/crawl.go
@@ -109,7 +109,7 @@ func (c *Crawler) makeRequest(s *common.CrawlSession, request *navigation.Reques
 		response.Technologies = mapsutil.GetKeys(technologies)
 	}
 
-	response.KnowledgeBase = c.Options.BuildKnowledgeBase(string(data))
+	response.KnowledgeBase = c.Options.BuildKnowledgeBase(string(data), resp.Request, resp)
 
 	// Restore the read data to resp.Body for further use.
 	resp.Body = io.NopCloser(strings.NewReader(string(data)))

--- a/pkg/knowledgebase/extractor.go
+++ b/pkg/knowledgebase/extractor.go
@@ -4,7 +4,12 @@
 // Name(), to keep outputs collision-free across detectors.
 package knowledgebase
 
+import "net/http"
+
+// Extractor mines structured facts from a crawled response. Extractors that
+// only need the body can ignore req and resp; extractors that classify by
+// request shape (method, headers, URL) use them.
 type Extractor interface {
 	Name() string
-	Extract(body string) map[string]any
+	Extract(body string, req *http.Request, resp *http.Response) map[string]any
 }

--- a/pkg/knowledgebase/extractor.go
+++ b/pkg/knowledgebase/extractor.go
@@ -9,6 +9,11 @@ import "net/http"
 // Extractor mines structured facts from a crawled response. Extractors that
 // only need the body can ignore req and resp; extractors that classify by
 // request shape (method, headers, URL) use them.
+//
+// Implementations MUST treat body, req, and resp as read-only: do not mutate
+// req/resp headers, URL, or body, and do not read resp.Body. The response
+// body has already been drained upstream and is passed as the body argument;
+// resp is supplied for status, header, and Request access only.
 type Extractor interface {
 	Name() string
 	Extract(body string, req *http.Request, resp *http.Response) map[string]any

--- a/pkg/knowledgebase/extractors/endpoints/endpoints.go
+++ b/pkg/knowledgebase/extractors/endpoints/endpoints.go
@@ -2,10 +2,23 @@
 // request as an API endpoint (REST, GraphQL, SOAP, AJAX/XHR) by inspecting
 // method, URL, headers, and content types. Emits per-response, one entry
 // per qualifying request.
+//
+// Output schema (all values strings unless noted):
+//
+//	class        : "rest" | "graphql" | "soap" | "xhr"
+//	method       : uppercase HTTP verb
+//	url          : request URL with userinfo and fragment stripped
+//	content_type : lowercased media type without parameters (optional)
+//	auth         : lowercased auth scheme, e.g. "bearer" / "basic" (optional)
+//	params       : []string of query parameter names in first-seen order (optional)
+//
+// The extractor is read-only with respect to its inputs: it MUST NOT mutate
+// req or resp (headers, body, URL).
 package endpoints
 
 import (
 	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -23,9 +36,10 @@ func (e *Extractor) Extract(_ string, req *http.Request, resp *http.Response) ma
 	}
 
 	method := strings.ToUpper(req.Method)
-	urlStr := ""
+	urlStr := safeURLString(req.URL)
+	pathLower := ""
 	if req.URL != nil {
-		urlStr = req.URL.String()
+		pathLower = strings.ToLower(req.URL.Path)
 	}
 	reqCT := req.Header.Get("Content-Type")
 	respCT := ""
@@ -33,9 +47,8 @@ func (e *Extractor) Extract(_ string, req *http.Request, resp *http.Response) ma
 		respCT = resp.Header.Get("Content-Type")
 	}
 	soapAction := req.Header.Get("SOAPAction")
-	hasAuth := req.Header.Get("Authorization") != ""
 
-	class := classify(method, urlStr, reqCT, respCT, soapAction)
+	class := classify(method, pathLower, reqCT, respCT, soapAction)
 	if class == "" {
 		return nil
 	}
@@ -48,8 +61,8 @@ func (e *Extractor) Extract(_ string, req *http.Request, resp *http.Response) ma
 	if ct := primaryContentType(respCT, reqCT); ct != "" {
 		out["content_type"] = ct
 	}
-	if hasAuth {
-		out["auth"] = authScheme(req.Header.Get("Authorization"))
+	if scheme := authScheme(req.Header.Get("Authorization")); scheme != "" {
+		out["auth"] = scheme
 	}
 	if req.URL != nil {
 		if params := paramNames(req.URL.RawQuery); len(params) > 0 {
@@ -59,13 +72,23 @@ func (e *Extractor) Extract(_ string, req *http.Request, resp *http.Response) ma
 	return out
 }
 
-func classify(method, urlStr, reqCT, respCT, soapAction string) string {
-	pathLower := strings.ToLower(urlStr)
-
+// classify decides which endpoint family a request belongs to. Decision tree
+// (first match wins):
+//
+//  1. SOAPAction header or soap+xml content-type on either side -> "soap"
+//  2. "graphql" path component or application/graphql content-type -> "graphql"
+//  3. JSON/XML body and (mutating verb OR API-looking path)       -> "rest"
+//  4. JSON GET to a non-API path                                  -> "xhr"
+//  5. form-urlencoded or multipart on a mutating verb             -> "rest"
+//  6. otherwise                                                   -> "" (skip)
+//
+// pathLower is the lowercased URL path (no scheme/host/query) so that
+// substring/segment checks aren't fooled by hostnames or query params.
+func classify(method, pathLower, reqCT, respCT, soapAction string) string {
 	if soapAction != "" || containsAny(reqCT, "soap+xml") || containsAny(respCT, "soap+xml") {
 		return "soap"
 	}
-	if strings.Contains(pathLower, "/graphql") ||
+	if hasPathSegment(pathLower, "graphql") ||
 		containsAny(reqCT, "application/graphql") ||
 		containsAny(respCT, "application/graphql") {
 		return "graphql"
@@ -90,6 +113,11 @@ func classify(method, urlStr, reqCT, respCT, soapAction string) string {
 	return ""
 }
 
+// apiPathSegments are substrings whose presence in the URL path strongly
+// suggests an API endpoint. Kept intentionally generous; the classifier still
+// requires a structured content-type or a mutating verb to actually return
+// "rest", so individual false positives don't surface as endpoints on their
+// own.
 var apiPathSegments = []string{
 	"/api/", "/v1/", "/v2/", "/v3/", "/rest/", "/rpc/",
 	"/jsonrpc", "/.well-known/", "/oauth/", "/openapi",
@@ -98,6 +126,17 @@ var apiPathSegments = []string{
 func matchesAPIPath(pathLower string) bool {
 	for _, seg := range apiPathSegments {
 		if strings.Contains(pathLower, seg) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasPathSegment reports whether name appears as a full "/"-separated segment
+// of pathLower (e.g. "/graphql", "/api/graphql", but not "/notgraphql/blob").
+func hasPathSegment(pathLower, name string) bool {
+	for _, seg := range strings.Split(pathLower, "/") {
+		if seg == name {
 			return true
 		}
 	}
@@ -133,6 +172,11 @@ func primaryContentType(respCT, reqCT string) string {
 	return strings.TrimSpace(strings.ToLower(pick))
 }
 
+// authScheme returns the lowercased scheme of an Authorization header (the
+// token before the first space, e.g. "bearer" or "basic"). Returns "" when
+// the header is empty or doesn't follow the "<scheme> <credentials>" shape,
+// in which case the auth field is omitted from the output to avoid emitting
+// noise for non-RFC headers.
 func authScheme(authHeader string) string {
 	authHeader = strings.TrimSpace(authHeader)
 	if authHeader == "" {
@@ -141,9 +185,12 @@ func authScheme(authHeader string) string {
 	if i := strings.Index(authHeader, " "); i > 0 {
 		return strings.ToLower(authHeader[:i])
 	}
-	return "unknown"
+	return ""
 }
 
+// paramNames returns the deduplicated names of query parameters in first-seen
+// order. Dedup is intentionally case-sensitive: "Q" and "q" are kept as two
+// names because most APIs treat parameter casing as significant.
 func paramNames(rawQuery string) []string {
 	if rawQuery == "" {
 		return nil
@@ -168,4 +215,17 @@ func paramNames(rawQuery string) []string {
 		out = append(out, name)
 	}
 	return out
+}
+
+// safeURLString returns u as a string with userinfo and fragment stripped so
+// credentials embedded in the URL never reach knowledgebase output.
+func safeURLString(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+	clone := *u
+	clone.User = nil
+	clone.Fragment = ""
+	clone.RawFragment = ""
+	return clone.String()
 }

--- a/pkg/knowledgebase/extractors/endpoints/endpoints.go
+++ b/pkg/knowledgebase/extractors/endpoints/endpoints.go
@@ -1,0 +1,171 @@
+// Package endpoints is a knowledgebase.Extractor that classifies a crawled
+// request as an API endpoint (REST, GraphQL, SOAP, AJAX/XHR) by inspecting
+// method, URL, headers, and content types. Emits per-response, one entry
+// per qualifying request.
+package endpoints
+
+import (
+	"net/http"
+	"strings"
+)
+
+const Name = "endpoints"
+
+type Extractor struct{}
+
+func New() *Extractor { return &Extractor{} }
+
+func (e *Extractor) Name() string { return Name }
+
+func (e *Extractor) Extract(_ string, req *http.Request, resp *http.Response) map[string]any {
+	if req == nil {
+		return nil
+	}
+
+	method := strings.ToUpper(req.Method)
+	urlStr := ""
+	if req.URL != nil {
+		urlStr = req.URL.String()
+	}
+	reqCT := req.Header.Get("Content-Type")
+	respCT := ""
+	if resp != nil {
+		respCT = resp.Header.Get("Content-Type")
+	}
+	soapAction := req.Header.Get("SOAPAction")
+	hasAuth := req.Header.Get("Authorization") != ""
+
+	class := classify(method, urlStr, reqCT, respCT, soapAction)
+	if class == "" {
+		return nil
+	}
+
+	out := map[string]any{
+		"class":  class,
+		"method": method,
+		"url":    urlStr,
+	}
+	if ct := primaryContentType(respCT, reqCT); ct != "" {
+		out["content_type"] = ct
+	}
+	if hasAuth {
+		out["auth"] = authScheme(req.Header.Get("Authorization"))
+	}
+	if req.URL != nil {
+		if params := paramNames(req.URL.RawQuery); len(params) > 0 {
+			out["params"] = params
+		}
+	}
+	return out
+}
+
+func classify(method, urlStr, reqCT, respCT, soapAction string) string {
+	pathLower := strings.ToLower(urlStr)
+
+	if soapAction != "" || containsAny(reqCT, "soap+xml") || containsAny(respCT, "soap+xml") {
+		return "soap"
+	}
+	if strings.Contains(pathLower, "/graphql") ||
+		containsAny(reqCT, "application/graphql") ||
+		containsAny(respCT, "application/graphql") {
+		return "graphql"
+	}
+
+	isJSON := containsAny(reqCT, "application/json") || containsAny(respCT, "application/json")
+	isXML := containsAny(reqCT, "application/xml") || containsAny(respCT, "application/xml")
+	isForm := containsAny(reqCT, "application/x-www-form-urlencoded") || containsAny(reqCT, "multipart/form-data")
+
+	apiPath := matchesAPIPath(pathLower)
+	mutating := isMutatingVerb(method)
+
+	if (isJSON || isXML) && (mutating || apiPath) {
+		return "rest"
+	}
+	if isJSON && method == "GET" {
+		return "xhr"
+	}
+	if isForm && mutating {
+		return "rest"
+	}
+	return ""
+}
+
+var apiPathSegments = []string{
+	"/api/", "/v1/", "/v2/", "/v3/", "/rest/", "/rpc/",
+	"/jsonrpc", "/.well-known/", "/oauth/", "/openapi",
+}
+
+func matchesAPIPath(pathLower string) bool {
+	for _, seg := range apiPathSegments {
+		if strings.Contains(pathLower, seg) {
+			return true
+		}
+	}
+	return false
+}
+
+func isMutatingVerb(method string) bool {
+	switch method {
+	case "POST", "PUT", "PATCH", "DELETE":
+		return true
+	}
+	return false
+}
+
+func containsAny(haystack, needle string) bool {
+	if haystack == "" {
+		return false
+	}
+	return strings.Contains(strings.ToLower(haystack), needle)
+}
+
+func primaryContentType(respCT, reqCT string) string {
+	pick := respCT
+	if pick == "" {
+		pick = reqCT
+	}
+	if pick == "" {
+		return ""
+	}
+	if i := strings.Index(pick, ";"); i >= 0 {
+		pick = pick[:i]
+	}
+	return strings.TrimSpace(strings.ToLower(pick))
+}
+
+func authScheme(authHeader string) string {
+	authHeader = strings.TrimSpace(authHeader)
+	if authHeader == "" {
+		return ""
+	}
+	if i := strings.Index(authHeader, " "); i > 0 {
+		return strings.ToLower(authHeader[:i])
+	}
+	return "unknown"
+}
+
+func paramNames(rawQuery string) []string {
+	if rawQuery == "" {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	var out []string
+	for _, kv := range strings.Split(rawQuery, "&") {
+		if kv == "" {
+			continue
+		}
+		name := kv
+		if i := strings.Index(kv, "="); i >= 0 {
+			name = kv[:i]
+		}
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	return out
+}

--- a/pkg/knowledgebase/extractors/endpoints/endpoints_test.go
+++ b/pkg/knowledgebase/extractors/endpoints/endpoints_test.go
@@ -1,0 +1,129 @@
+package endpoints
+
+import (
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+)
+
+func mustRequest(t *testing.T, method, rawURL string, headers map[string]string) *http.Request {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse URL: %v", err)
+	}
+	req := &http.Request{Method: method, URL: u, Header: http.Header{}}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	return req
+}
+
+func responseWithCT(ct string) *http.Response {
+	h := http.Header{}
+	if ct != "" {
+		h.Set("Content-Type", ct)
+	}
+	return &http.Response{Header: h}
+}
+
+func TestExtract_GraphQLByPath(t *testing.T) {
+	e := New()
+	req := mustRequest(t, "POST", "https://example.com/graphql", map[string]string{
+		"Content-Type": "application/json",
+	})
+	out := e.Extract("", req, responseWithCT("application/json"))
+	if out == nil {
+		t.Fatal("expected entry, got nil")
+	}
+	if out["class"] != "graphql" {
+		t.Errorf("class = %v, want graphql", out["class"])
+	}
+}
+
+func TestExtract_SOAPByHeader(t *testing.T) {
+	e := New()
+	req := mustRequest(t, "POST", "https://example.com/ws/UserService", map[string]string{
+		"Content-Type": "text/xml; charset=utf-8",
+		"SOAPAction":   "GetUser",
+	})
+	out := e.Extract("", req, nil)
+	if out == nil || out["class"] != "soap" {
+		t.Fatalf("class = %v, want soap (out=%#v)", out["class"], out)
+	}
+}
+
+func TestExtract_RESTByJSONMutating(t *testing.T) {
+	e := New()
+	req := mustRequest(t, "POST", "https://api.example.com/users", map[string]string{
+		"Content-Type":  "application/json",
+		"Authorization": "Bearer eyJhbGc",
+	})
+	out := e.Extract("", req, responseWithCT("application/json"))
+	if out == nil || out["class"] != "rest" {
+		t.Fatalf("class = %v, want rest (out=%#v)", out["class"], out)
+	}
+	if out["auth"] != "bearer" {
+		t.Errorf("auth = %v, want bearer", out["auth"])
+	}
+	if out["content_type"] != "application/json" {
+		t.Errorf("content_type = %v, want application/json", out["content_type"])
+	}
+}
+
+func TestExtract_RESTByAPIPath(t *testing.T) {
+	e := New()
+	req := mustRequest(t, "GET", "https://example.com/api/v1/users?q=alice&limit=10", nil)
+	out := e.Extract("", req, responseWithCT("application/json"))
+	if out == nil || out["class"] != "rest" {
+		t.Fatalf("class = %v, want rest (out=%#v)", out["class"], out)
+	}
+	params, _ := out["params"].([]string)
+	want := []string{"q", "limit"}
+	if !reflect.DeepEqual(params, want) {
+		t.Errorf("params = %v, want %v", params, want)
+	}
+}
+
+func TestExtract_XHRJSONGet(t *testing.T) {
+	e := New()
+	req := mustRequest(t, "GET", "https://example.com/feed", nil)
+	out := e.Extract("", req, responseWithCT("application/json; charset=utf-8"))
+	if out == nil || out["class"] != "xhr" {
+		t.Fatalf("class = %v, want xhr (out=%#v)", out["class"], out)
+	}
+}
+
+func TestExtract_FormPost(t *testing.T) {
+	e := New()
+	req := mustRequest(t, "POST", "https://example.com/submit", map[string]string{
+		"Content-Type": "application/x-www-form-urlencoded",
+	})
+	out := e.Extract("", req, nil)
+	if out == nil || out["class"] != "rest" {
+		t.Fatalf("class = %v, want rest (out=%#v)", out["class"], out)
+	}
+}
+
+func TestExtract_PlainHTMLIgnored(t *testing.T) {
+	e := New()
+	req := mustRequest(t, "GET", "https://example.com/about.html", nil)
+	out := e.Extract("", req, responseWithCT("text/html"))
+	if out != nil {
+		t.Errorf("expected nil for plain HTML, got %#v", out)
+	}
+}
+
+func TestExtract_NilRequest(t *testing.T) {
+	e := New()
+	if got := e.Extract("", nil, nil); got != nil {
+		t.Errorf("expected nil for nil request, got %#v", got)
+	}
+}
+
+func TestName(t *testing.T) {
+	if got := New().Name(); got != Name {
+		t.Errorf("Name() = %q, want %q", got, Name)
+	}
+}

--- a/pkg/knowledgebase/extractors/endpoints/endpoints_test.go
+++ b/pkg/knowledgebase/extractors/endpoints/endpoints_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -119,6 +120,134 @@ func TestExtract_NilRequest(t *testing.T) {
 	e := New()
 	if got := e.Extract("", nil, nil); got != nil {
 		t.Errorf("expected nil for nil request, got %#v", got)
+	}
+}
+
+func TestExtract_BasicAuthScheme(t *testing.T) {
+	e := New()
+	req := mustRequest(t, "POST", "https://api.example.com/v1/login", map[string]string{
+		"Content-Type":  "application/json",
+		"Authorization": "Basic dXNlcjpwYXNz",
+	})
+	out := e.Extract("", req, responseWithCT("application/json"))
+	if out == nil {
+		t.Fatal("expected entry, got nil")
+	}
+	if out["auth"] != "basic" {
+		t.Errorf("auth = %v, want basic", out["auth"])
+	}
+}
+
+func TestExtract_AuthSchemeUnknownOmitted(t *testing.T) {
+	e := New()
+	req := mustRequest(t, "POST", "https://api.example.com/v1/login", map[string]string{
+		"Content-Type":  "application/json",
+		"Authorization": "weird-no-space-token",
+	})
+	out := e.Extract("", req, responseWithCT("application/json"))
+	if out == nil {
+		t.Fatal("expected entry, got nil")
+	}
+	if _, ok := out["auth"]; ok {
+		t.Errorf("expected auth field to be omitted for malformed header, got %#v", out["auth"])
+	}
+}
+
+func TestExtract_SOAPByContentTypeOnly(t *testing.T) {
+	e := New()
+	req := mustRequest(t, "POST", "https://example.com/svc", map[string]string{
+		"Content-Type": "application/soap+xml; charset=utf-8",
+	})
+	out := e.Extract("", req, nil)
+	if out == nil || out["class"] != "soap" {
+		t.Fatalf("class = %v, want soap (out=%#v)", out["class"], out)
+	}
+	if out["content_type"] != "application/soap+xml" {
+		t.Errorf("content_type = %v, want application/soap+xml", out["content_type"])
+	}
+}
+
+func TestExtract_CaseInsensitiveContentType(t *testing.T) {
+	e := New()
+	req := mustRequest(t, "POST", "https://api.example.com/v1/users", map[string]string{
+		"Content-Type": "Application/JSON; charset=UTF-8",
+	})
+	out := e.Extract("", req, responseWithCT("Application/JSON"))
+	if out == nil || out["class"] != "rest" {
+		t.Fatalf("class = %v, want rest (out=%#v)", out["class"], out)
+	}
+	if out["content_type"] != "application/json" {
+		t.Errorf("content_type = %v, want application/json", out["content_type"])
+	}
+}
+
+func TestExtract_GraphQLByContentType(t *testing.T) {
+	e := New()
+	req := mustRequest(t, "POST", "https://example.com/query", map[string]string{
+		"Content-Type": "application/graphql",
+	})
+	out := e.Extract("", req, nil)
+	if out == nil || out["class"] != "graphql" {
+		t.Fatalf("class = %v, want graphql (out=%#v)", out["class"], out)
+	}
+}
+
+func TestExtract_GraphQLFalsePositivePath(t *testing.T) {
+	// "/notgraphql/blob" must not be classified as graphql; the request also
+	// lacks any API-shaped content type, so it should be ignored entirely.
+	e := New()
+	req := mustRequest(t, "GET", "https://example.com/notgraphql/blob", map[string]string{
+		"Content-Type": "text/html",
+	})
+	out := e.Extract("", req, responseWithCT("text/html"))
+	if out != nil {
+		t.Errorf("expected nil for /notgraphql/blob, got %#v", out)
+	}
+}
+
+func TestExtract_GraphQLNestedPathSegment(t *testing.T) {
+	e := New()
+	req := mustRequest(t, "POST", "https://example.com/api/graphql", map[string]string{
+		"Content-Type": "application/json",
+	})
+	out := e.Extract("", req, responseWithCT("application/json"))
+	if out == nil || out["class"] != "graphql" {
+		t.Fatalf("class = %v, want graphql (out=%#v)", out["class"], out)
+	}
+}
+
+func TestExtract_URLStripsUserinfoAndFragment(t *testing.T) {
+	e := New()
+	req := mustRequest(t, "POST", "https://user:pass@api.example.com/v1/users?token=abc#frag", map[string]string{
+		"Content-Type": "application/json",
+	})
+	out := e.Extract("", req, responseWithCT("application/json"))
+	if out == nil {
+		t.Fatal("expected entry, got nil")
+	}
+	got, _ := out["url"].(string)
+	if strings.Contains(got, "user:pass") {
+		t.Errorf("url leaks userinfo: %q", got)
+	}
+	if strings.Contains(got, "#frag") {
+		t.Errorf("url leaks fragment: %q", got)
+	}
+	if want := "https://api.example.com/v1/users?token=abc"; got != want {
+		t.Errorf("url = %q, want %q", got, want)
+	}
+}
+
+func TestExtract_DedupParamsCaseSensitive(t *testing.T) {
+	e := New()
+	req := mustRequest(t, "GET", "https://api.example.com/v1/items?Q=1&q=2&Q=3", nil)
+	out := e.Extract("", req, responseWithCT("application/json"))
+	if out == nil {
+		t.Fatal("expected entry, got nil")
+	}
+	params, _ := out["params"].([]string)
+	want := []string{"Q", "q"}
+	if !reflect.DeepEqual(params, want) {
+		t.Errorf("params = %v, want %v", params, want)
 	}
 }
 

--- a/pkg/knowledgebase/extractors/secrets/secrets.go
+++ b/pkg/knowledgebase/extractors/secrets/secrets.go
@@ -6,6 +6,7 @@ package secrets
 
 import (
 	"context"
+	"net/http"
 
 	titus "github.com/praetorian-inc/titus"
 )
@@ -34,7 +35,7 @@ func New(cfg Config) (*Extractor, error) {
 
 func (e *Extractor) Name() string { return Name }
 
-func (e *Extractor) Extract(body string) map[string]any {
+func (e *Extractor) Extract(body string, _ *http.Request, _ *http.Response) map[string]any {
 	if body == "" {
 		return nil
 	}

--- a/pkg/knowledgebase/extractors/secrets/secrets_test.go
+++ b/pkg/knowledgebase/extractors/secrets/secrets_test.go
@@ -17,7 +17,7 @@ func TestExtract_DetectsKnownCredentials(t *testing.T) {
 		const s = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
 	</script>`
 
-	out := e.Extract(body)
+	out := e.Extract(body, nil, nil)
 	if out == nil {
 		t.Fatal("expected findings map, got nil")
 	}
@@ -46,7 +46,7 @@ func TestExtract_EmptyBody(t *testing.T) {
 	}
 	defer func() { _ = e.Close() }()
 
-	if got := e.Extract(""); got != nil {
+	if got := e.Extract("", nil, nil); got != nil {
 		t.Errorf("expected nil for empty body, got %#v", got)
 	}
 }
@@ -58,7 +58,7 @@ func TestExtract_NoSecrets(t *testing.T) {
 	}
 	defer func() { _ = e.Close() }()
 
-	if got := e.Extract("<html><body>hello world</body></html>"); got != nil {
+	if got := e.Extract("<html><body>hello world</body></html>", nil, nil); got != nil {
 		t.Errorf("expected nil for body without secrets, got %#v", got)
 	}
 }

--- a/pkg/types/crawler_options.go
+++ b/pkg/types/crawler_options.go
@@ -3,6 +3,7 @@ package types
 import (
 	"context"
 	"log/slog"
+	"net/http"
 	"os/user"
 	"regexp"
 	"time"
@@ -223,7 +224,9 @@ func (c *CrawlerOptions) ValidatePath(path string) bool {
 // BuildKnowledgeBase assembles the response KnowledgeBase map by merging
 // output from the dit page-type classifier (when enabled) with each registered
 // Extractor. Returns nil when no producer is configured or none produced output.
-func (c *CrawlerOptions) BuildKnowledgeBase(body string) map[string]any {
+// req and resp are forwarded to extractors that classify by request shape
+// (endpoints, headers_audit, etc.); body-only extractors ignore them.
+func (c *CrawlerOptions) BuildKnowledgeBase(body string, req *http.Request, resp *http.Response) map[string]any {
 	if c.DitClassifier == nil && len(c.Extractors) == 0 {
 		return nil
 	}
@@ -237,7 +240,7 @@ func (c *CrawlerOptions) BuildKnowledgeBase(body string) map[string]any {
 		}
 	}
 	for _, e := range c.Extractors {
-		if out := e.Extract(body); out != nil {
+		if out := e.Extract(body, req, resp); out != nil {
 			kb[e.Name()] = out
 		}
 	}

--- a/pkg/types/crawler_options.go
+++ b/pkg/types/crawler_options.go
@@ -11,6 +11,7 @@ import (
 	"github.com/projectdiscovery/fastdialer/fastdialer"
 	"github.com/projectdiscovery/katana/pkg/engine/parser"
 	"github.com/projectdiscovery/katana/pkg/knowledgebase"
+	"github.com/projectdiscovery/katana/pkg/knowledgebase/extractors/endpoints"
 	"github.com/projectdiscovery/katana/pkg/knowledgebase/extractors/secrets"
 	"github.com/projectdiscovery/katana/pkg/output"
 	"github.com/projectdiscovery/katana/pkg/utils/extensions"
@@ -185,6 +186,10 @@ func NewCrawlerOptions(options *Options) (*CrawlerOptions, error) {
 			return nil, errkit.Wrap(err, "could not init secrets extractor")
 		}
 		crawlerOptions.Extractors = append(crawlerOptions.Extractors, secretsExtractor)
+	}
+
+	if options.Endpoints {
+		crawlerOptions.Extractors = append(crawlerOptions.Extractors, endpoints.New())
 	}
 
 	if options.MaxOnclickLinks <= 0 {

--- a/pkg/types/crawler_options.go
+++ b/pkg/types/crawler_options.go
@@ -229,8 +229,11 @@ func (c *CrawlerOptions) ValidatePath(path string) bool {
 // BuildKnowledgeBase assembles the response KnowledgeBase map by merging
 // output from the dit page-type classifier (when enabled) with each registered
 // Extractor. Returns nil when no producer is configured or none produced output.
-// req and resp are forwarded to extractors that classify by request shape
-// (endpoints, headers_audit, etc.); body-only extractors ignore them.
+//
+// body is the fully drained response body (resp.Body has already been
+// consumed by the caller). req and resp are forwarded to extractors that
+// classify by request shape (endpoints, headers_audit, etc.); body-only
+// extractors ignore them. Extractors MUST treat req/resp as read-only.
 func (c *CrawlerOptions) BuildKnowledgeBase(body string, req *http.Request, resp *http.Response) map[string]any {
 	if c.DitClassifier == nil && len(c.Extractors) == 0 {
 		return nil

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -216,6 +216,9 @@ type Options struct {
 	// Validation sends a real request to the credential's provider, which logs
 	// against the credential owner, so it is opt-in.
 	ValidateSecrets bool
+	// Endpoints enables the knowledgebase endpoints extractor (classifies REST,
+	// GraphQL, SOAP, AJAX/XHR requests).
+	Endpoints bool
 	// FilterPageType filters results by page type
 	FilterPageType goflags.StringSlice
 	// AuthCredentials holds username:password for automatic login


### PR DESCRIPTION
## Proposed changes

Closes #1668. Stacked on #1667.

Adds an `endpoints` extractor that classifies each qualifying crawled request as REST / GraphQL / SOAP / AJAX-XHR and emits the entry under `response.knowledgebase.endpoints`.

- new flag `-kb-endpoints` opts in
- per-response entry: `class`, `method`, `url`, `content_type`, optional `auth` (scheme only), optional `params` (names only)
- `Extractor` interface extended to receive `*http.Request` and `*http.Response`; existing secrets extractor updated to match (refactor commit)

### Proof

Unit tests in `pkg/knowledgebase/extractors/endpoints/endpoints_test.go` covering REST (path + JSON), GraphQL (path), SOAP (header), form POST, XHR, HTML-ignored, and nil-request.

End-to-end fixture (drop into any `main.go` and `go run` it):

```go
package main

import (
	"encoding/json"
	"log"
	"net/http"
)

func main() {
	http.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
		w.Header().Set("Content-Type", "text/html")
		_, _ = w.Write([]byte(`<!doctype html><html><body>
<a href="/api/v1/users?q=alice&limit=10">users</a>
<a href="/graphql">graphql</a>
<a href="/ws/UserService">soap</a>
<a href="/about">about</a>
</body></html>`))
	})
	http.HandleFunc("/api/v1/users", func(w http.ResponseWriter, _ *http.Request) {
		w.Header().Set("Content-Type", "application/json")
		_ = json.NewEncoder(w).Encode(map[string]any{"users": []string{"a", "b"}})
	})
	http.HandleFunc("/graphql", func(w http.ResponseWriter, _ *http.Request) {
		w.Header().Set("Content-Type", "application/json")
		_, _ = w.Write([]byte(`{"data":{}}`))
	})
	http.HandleFunc("/ws/UserService", func(w http.ResponseWriter, _ *http.Request) {
		w.Header().Set("Content-Type", "application/soap+xml; charset=utf-8")
		_, _ = w.Write([]byte(`<?xml version="1.0"?><soap:Envelope/>`))
	})
	log.Fatal(http.ListenAndServe("127.0.0.1:8766", nil))
}
```

Run:

```
go run /tmp/fixture.go
go run ./cmd/katana -u http://127.0.0.1:8766/ -kb-endpoints -d 2 -jsonl -silent | jq -c 'select(.response.knowledgebase.endpoints) | {url: .request.endpoint, ep: .response.knowledgebase.endpoints}'
```

Output:
```
{"url":"http://127.0.0.1:8766/ws/UserService","ep":{"class":"soap",...}}
{"url":"http://127.0.0.1:8766/graphql","ep":{"class":"graphql",...}}
{"url":"http://127.0.0.1:8766/api/v1/users?q=alice&limit=10","ep":{"class":"rest","params":["q","limit"],...}}
```

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/katana/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)