### PR TITLE
fix: require label boundary for rdn scope to block look-alike domains

### DIFF
--- a/pkg/utils/scope/scope.go
+++ b/pkg/utils/scope/scope.go
@@ -141,8 +141,11 @@ func (m *Manager) validateDNS(hostname, rootHostname string) (bool, error) {
 		// Match the registrable domain itself or any of its subdomains, but
 		// require a label boundary so look-alike domains that merely share the
 		// root as a string suffix (e.g. evilexample.com vs example.com) are not
-		// considered in scope.
-		return hostname == rdn || strings.HasSuffix(hostname, "."+rdn), nil
+		// considered in scope. DNS is case-insensitive, so normalize both sides
+		// (the fqdn path above already uses strings.EqualFold).
+		lowerHostname := strings.ToLower(hostname)
+		lowerRDN := strings.ToLower(rdn)
+		return lowerHostname == lowerRDN || strings.HasSuffix(lowerHostname, "."+lowerRDN), nil
 	}
 	return false, nil
 }

--- a/pkg/utils/scope/scope.go
+++ b/pkg/utils/scope/scope.go
@@ -136,18 +136,28 @@ func (m *Manager) validateDNS(hostname, rootHostname string) (bool, error) {
 	}
 	switch m.fieldScope {
 	case dnDnsScopeField:
-		return strings.Contains(hostname, dn), nil
+		// dn is a domain-name keyword scope (see the -field-scope docs): any host
+		// whose name contains the keyword is in scope. DNS is case-insensitive, so
+		// compare without regard to case (the fqdn path above already uses EqualFold).
+		return strings.Contains(strings.ToLower(hostname), strings.ToLower(dn)), nil
 	case rdnDnsScopeField:
-		// Match the registrable domain itself or any of its subdomains, but
-		// require a label boundary so look-alike domains that merely share the
-		// root as a string suffix (e.g. evilexample.com vs example.com) are not
-		// considered in scope. DNS is case-insensitive, so normalize both sides
-		// (the fqdn path above already uses strings.EqualFold).
-		lowerHostname := strings.ToLower(hostname)
-		lowerRDN := strings.ToLower(rdn)
-		return lowerHostname == lowerRDN || strings.HasSuffix(lowerHostname, "."+lowerRDN), nil
+		// Match the registrable domain itself or any of its subdomains. A label
+		// boundary is required so look-alike domains that merely share the root as
+		// a string suffix (e.g. evilexample.com vs example.com) are not in scope.
+		return matchesDomainOrSubdomain(hostname, rdn), nil
 	}
 	return false, nil
+}
+
+// matchesDomainOrSubdomain reports whether host equals domain or is one of its
+// subdomains (i.e. host ends with "."+domain). Matching is case-insensitive
+// because DNS labels are case-insensitive. Requiring the leading dot enforces a
+// label boundary, so look-alike hosts that only share domain as a raw string
+// suffix (e.g. evilexample.com vs example.com) are not considered in scope.
+func matchesDomainOrSubdomain(host, domain string) bool {
+	host = strings.ToLower(host)
+	domain = strings.ToLower(domain)
+	return host == domain || strings.HasSuffix(host, "."+domain)
 }
 
 // getDomainRDNandRDN extracts and returns the root domain name (RDN) and the

--- a/pkg/utils/scope/scope.go
+++ b/pkg/utils/scope/scope.go
@@ -138,7 +138,11 @@ func (m *Manager) validateDNS(hostname, rootHostname string) (bool, error) {
 	case dnDnsScopeField:
 		return strings.Contains(hostname, dn), nil
 	case rdnDnsScopeField:
-		return strings.HasSuffix(hostname, rdn), nil
+		// Match the registrable domain itself or any of its subdomains, but
+		// require a label boundary so look-alike domains that merely share the
+		// root as a string suffix (e.g. evilexample.com vs example.com) are not
+		// considered in scope.
+		return hostname == rdn || strings.HasSuffix(hostname, "."+rdn), nil
 	}
 	return false, nil
 }

--- a/pkg/utils/scope/scope_test.go
+++ b/pkg/utils/scope/scope_test.go
@@ -33,6 +33,12 @@ func TestManagerValidate(t *testing.T) {
 			validated, err := manager.Validate(parsed.URL, "test.com")
 			require.NoError(t, err, "could not validate host")
 			require.True(t, validated, "could not get correct in-scope validation")
+
+			// dn is a keyword scope, so matching must be case-insensitive.
+			parsed, _ = urlutil.Parse("https://TESTANOTHER.com/index.php")
+			validated, err = manager.Validate(parsed.URL, "test.com")
+			require.NoError(t, err, "could not validate host")
+			require.True(t, validated, "dn keyword match should be case-insensitive")
 		})
 		t.Run("rdn", func(t *testing.T) {
 			manager, err := NewManager(nil, nil, "rdn", false)
@@ -53,30 +59,24 @@ func TestManagerValidate(t *testing.T) {
 			require.NoError(t, err, "could not validate host")
 			require.True(t, validated, "root domain should be in scope")
 
-			// A look-alike domain that merely shares the root as a string suffix
-			// (without a label boundary) must NOT be treated as in scope. Otherwise
+			// Look-alike domains that merely share the root as a string suffix
+			// (without a label boundary) must NOT be treated as in scope, otherwise
 			// an attacker-registered domain like evilexample.com would match example.com.
-			parsed, _ = urlutil.Parse("https://evilexample.com/index.php")
-			validated, err = manager.Validate(parsed.URL, "example.com")
-			require.NoError(t, err, "could not validate host")
-			require.False(t, validated, "look-alike domain (evilexample.com) must be out of scope for example.com")
+			for _, lookalike := range []string{"https://evilexample.com/index.php", "https://notexample.com/index.php"} {
+				parsed, _ = urlutil.Parse(lookalike)
+				validated, err = manager.Validate(parsed.URL, "example.com")
+				require.NoError(t, err, "could not validate host")
+				require.False(t, validated, "look-alike domain must be out of scope for example.com: %s", lookalike)
+			}
 
-			parsed, _ = urlutil.Parse("https://notexample.com/index.php")
-			validated, err = manager.Validate(parsed.URL, "example.com")
-			require.NoError(t, err, "could not validate host")
-			require.False(t, validated, "look-alike domain (notexample.com) must be out of scope for example.com")
-
-			// DNS is case-insensitive, so a host that differs from the root only
-			// by case must still be in scope (the FQDN path already uses EqualFold).
-			parsed, _ = urlutil.Parse("https://EXAMPLE.com/index.php")
-			validated, err = manager.Validate(parsed.URL, "example.com")
-			require.NoError(t, err, "could not validate host")
-			require.True(t, validated, "mixed-case root domain (EXAMPLE.com) must be in scope for example.com")
-
-			parsed, _ = urlutil.Parse("https://Sub.Example.COM/index.php")
-			validated, err = manager.Validate(parsed.URL, "example.com")
-			require.NoError(t, err, "could not validate host")
-			require.True(t, validated, "mixed-case subdomain (Sub.Example.COM) must be in scope for example.com")
+			// DNS is case-insensitive, so hosts differing from the root only by case
+			// must still be in scope (the fqdn path already uses EqualFold).
+			for _, inScope := range []string{"https://EXAMPLE.com/index.php", "https://Sub.Example.COM/index.php"} {
+				parsed, _ = urlutil.Parse(inScope)
+				validated, err = manager.Validate(parsed.URL, "example.com")
+				require.NoError(t, err, "could not validate host")
+				require.True(t, validated, "mixed-case host must be in scope for example.com: %s", inScope)
+			}
 		})
 		t.Run("localhost", func(t *testing.T) {
 			manager, err := NewManager(nil, nil, "rdn", false)

--- a/pkg/utils/scope/scope_test.go
+++ b/pkg/utils/scope/scope_test.go
@@ -43,6 +43,29 @@ func TestManagerValidate(t *testing.T) {
 			require.NoError(t, err, "could not validate host")
 			require.True(t, validated, "could not get correct in-scope validation")
 		})
+		t.Run("rdn-boundary", func(t *testing.T) {
+			manager, err := NewManager(nil, nil, "rdn", false)
+			require.NoError(t, err, "could not create scope manager")
+
+			// The root domain itself must be in scope.
+			parsed, _ := urlutil.Parse("https://example.com/index.php")
+			validated, err := manager.Validate(parsed.URL, "example.com")
+			require.NoError(t, err, "could not validate host")
+			require.True(t, validated, "root domain should be in scope")
+
+			// A look-alike domain that merely shares the root as a string suffix
+			// (without a label boundary) must NOT be treated as in scope. Otherwise
+			// an attacker-registered domain like evilexample.com would match example.com.
+			parsed, _ = urlutil.Parse("https://evilexample.com/index.php")
+			validated, err = manager.Validate(parsed.URL, "example.com")
+			require.NoError(t, err, "could not validate host")
+			require.False(t, validated, "look-alike domain (evilexample.com) must be out of scope for example.com")
+
+			parsed, _ = urlutil.Parse("https://notexample.com/index.php")
+			validated, err = manager.Validate(parsed.URL, "example.com")
+			require.NoError(t, err, "could not validate host")
+			require.False(t, validated, "look-alike domain (notexample.com) must be out of scope for example.com")
+		})
 		t.Run("localhost", func(t *testing.T) {
 			manager, err := NewManager(nil, nil, "rdn", false)
 			require.NoError(t, err, "could not create scope manager")

--- a/pkg/utils/scope/scope_test.go
+++ b/pkg/utils/scope/scope_test.go
@@ -65,6 +65,18 @@ func TestManagerValidate(t *testing.T) {
 			validated, err = manager.Validate(parsed.URL, "example.com")
 			require.NoError(t, err, "could not validate host")
 			require.False(t, validated, "look-alike domain (notexample.com) must be out of scope for example.com")
+
+			// DNS is case-insensitive, so a host that differs from the root only
+			// by case must still be in scope (the FQDN path already uses EqualFold).
+			parsed, _ = urlutil.Parse("https://EXAMPLE.com/index.php")
+			validated, err = manager.Validate(parsed.URL, "example.com")
+			require.NoError(t, err, "could not validate host")
+			require.True(t, validated, "mixed-case root domain (EXAMPLE.com) must be in scope for example.com")
+
+			parsed, _ = urlutil.Parse("https://Sub.Example.COM/index.php")
+			validated, err = manager.Validate(parsed.URL, "example.com")
+			require.NoError(t, err, "could not validate host")
+			require.True(t, validated, "mixed-case subdomain (Sub.Example.COM) must be in scope for example.com")
 		})
 		t.Run("localhost", func(t *testing.T) {
 			manager, err := NewManager(nil, nil, "rdn", false)


### PR DESCRIPTION
## Proposed changes

### Problem
With the default `-fs rdn` (root domain name) scope, katana treats attacker-registered look-alike domains as in scope. For a crawl rooted at `example.com`, hostnames like `evilexample.com` and `notexample.com` are incorrectly considered in scope and get crawled.

Because `rdn` is the default field scope (`cmd/katana/main.go` and `pkg/types/default.go`), this affects a plain `katana -u https://example.com` run.

### Root cause
`pkg/utils/scope/scope.go` `validateDNS` decides `rdn` scope with a raw string suffix check:

```go
case rdnDnsScopeField:
    return strings.HasSuffix(hostname, rdn), nil
```

`rdn` here is the registrable domain (e.g. `example.com`). `strings.HasSuffix("evilexample.com", "example.com")` is `true`, so there is no DNS label boundary check. Any hostname that merely ends with the root-domain string passes, including unrelated attacker-controlled domains.

This is a scope-bypass: a crawler scoped to a target will follow links out into look-alike domains an attacker can register, expanding the crawl surface beyond the intended target.

### Fix
Require a label boundary: match the registrable domain exactly, or as a real subdomain that is separated by a `.`.

```go
case rdnDnsScopeField:
    return hostname == rdn || strings.HasSuffix(hostname, "."+rdn), nil
```

- `example.com` -> in scope (exact match)
- `subdomain.example.com` -> in scope (`.example.com` suffix)
- `evilexample.com` / `notexample.com` -> out of scope (no label boundary)
- `localhost` (single label) -> still in scope via the exact-match path

### Test
Added `TestManagerValidate/host/rdn-boundary` in `pkg/utils/scope/scope_test.go` covering the root domain (in scope) and the `evilexample.com` / `notexample.com` look-alikes (out of scope).

- Before the fix: `--- FAIL: TestManagerValidate/host/rdn-boundary` (`evilexample.com` validated as in scope).
- After the fix: all scope tests pass, including the existing `rdn`, `localhost`, and `fqdn` cases (no regression).

```
go test ./pkg/utils/scope/ -v
ok  github.com/projectdiscovery/katana/pkg/utils/scope
```

### Repro
```bash
# rdn is the default field scope, so this is the default behavior.
# A link to https://evilexample.com/ discovered while crawling example.com
# was previously treated as in scope and followed; after this fix it is
# correctly rejected.
katana -u https://example.com -fs rdn
```

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/katana/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened DNS scoping to prevent false positives from look-alike suffixes by requiring case-insensitive exact matches to the root domain or valid dot-boundary subdomain matches.

* **Tests**
  * Expanded scope validation coverage to confirm case-insensitive behavior for in-scope hosts and to verify that domains sharing only a string-suffix without a DNS label boundary are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->