### PR TITLE
Fix race condition

### DIFF
--- a/pkg/engine/parser/parser.go
+++ b/pkg/engine/parser/parser.go
@@ -718,8 +718,8 @@ func bodyScrapeEndpointsParser(resp *navigation.Response) (navigationRequests []
 func customFieldRegexParser(resp *navigation.Response) (navigationRequests []*navigation.Request) {
 	var customField = make(map[string][]string)
 
-	CustomFieldsMapMutex.Lock()
-	defer CustomFieldsMapMutex.Unlock()
+	output.CustomFieldsMapMutex.Lock()
+	defer output.CustomFieldsMapMutex.Unlock()
 
 	for _, v := range output.CustomFieldsMap {
 		results := []string{}

--- a/pkg/engine/parser/parser.go
+++ b/pkg/engine/parser/parser.go
@@ -717,6 +717,10 @@ func bodyScrapeEndpointsParser(resp *navigation.Response) (navigationRequests []
 // customFieldRegexParser parses custom regex from HTML body and header
 func customFieldRegexParser(resp *navigation.Response) (navigationRequests []*navigation.Request) {
 	var customField = make(map[string][]string)
+
+	CustomFieldsMapMutex.Lock()
+	defer CustomFieldsMapMutex.Unlock()
+
 	for _, v := range output.CustomFieldsMap {
 		results := []string{}
 		for _, re := range v.CompileRegex {

--- a/pkg/engine/parser/parser_test.go
+++ b/pkg/engine/parser/parser_test.go
@@ -414,94 +414,54 @@ func TestScriptParsers(t *testing.T) {
 	})
 }
 
-func TestRegexBodyParsers(t *testing.T) {
+func TestCustomFieldRegexParser_BasicMatch(t *testing.T) {
 	parsed, _ := urlutil.Parse("https://security-crawl-maze.app/contact")
 
-	t.Run("regexbody", func(t *testing.T) {
-		output.CustomFieldsMapMutex.Lock()
-		output.CustomFieldsMap = make(map[string]output.CustomFieldConfig)
-		output.CustomFieldsMapMutex.Unlock()
+	output.CustomFieldsMapMutex.Lock()
+	output.CustomFieldsMap = map[string]output.CustomFieldConfig{}
+	output.CustomFieldsMapMutex.Unlock()
 
-		resp := &navigation.Response{
-			Resp:  &http.Response{Request: &http.Request{URL: parsed.URL}},
-			Depth: 0,
-			Body:  "some content contact@example.com",
-		}
-
-		output.CustomFieldsMapMutex.Lock()
-		output.CustomFieldsMap["email"] = output.CustomFieldConfig{
-			Name:         "email",
-			Type:         "regex",
-			Part:         "body",
-			CompileRegex: []*regexp.Regexp{regexp.MustCompile(`([a-zA-Z0-9._-]+@[a-zA-Z0-9._-]+\.[a-zA-Z0-9_-]+)`)},
-		}
-		output.CustomFieldsMapMutex.Unlock()
-
-		navigationRequests := customFieldRegexParser(resp)
-		var requireFields = map[string][]string{"email": {"contact@example.com"}}
-		require.Equal(t, requireFields, navigationRequests[0].CustomFields, "could not get correct url")
-	})
-
-	t.Run("regexheader", func(t *testing.T) {
-		output.CustomFieldsMapMutex.Lock()
-		output.CustomFieldsMap = make(map[string]output.CustomFieldConfig)
-		output.CustomFieldsMapMutex.Unlock()
-
-		resp := &navigation.Response{
-			Resp: &http.Response{Request: &http.Request{URL: parsed.URL},
-				Header: http.Header{
-					"server": []string{"ECS (dcb/7F84)"},
-				},
+	resp := &navigation.Response{
+		Resp: &http.Response{
+			Request: &http.Request{
+				URL: parsed.URL,
 			},
-		}
-
-		output.CustomFieldsMapMutex.Lock()
-		output.CustomFieldsMap["server"] = output.CustomFieldConfig{
-			Name:         "server",
-			Type:         "regex",
-			Part:         "header",
-			CompileRegex: []*regexp.Regexp{regexp.MustCompile(`server: ECS`)},
-		}
-		output.CustomFieldsMapMutex.Unlock()
-
-		navigationRequests := customFieldRegexParser(resp)
-		var requireFields = map[string][]string{"server": {"server: ECS"}}
-		require.Equal(t, requireFields, navigationRequests[0].CustomFields, "could not get correct url")
-	})
-
-	t.Run("regexresponse", func(t *testing.T) {
-		output.CustomFieldsMapMutex.Lock()
-		output.CustomFieldsMap = make(map[string]output.CustomFieldConfig)
-		output.CustomFieldsMapMutex.Unlock()
-
-		resp := &navigation.Response{
-			Resp: &http.Response{Request: &http.Request{URL: parsed.URL},
-				Header: http.Header{
-					"server": []string{"ECS (dcb/7F84)"},
-				},
+			Header: http.Header{
+				"server": []string{"ECS (dcb/7F84)"},
 			},
-			Body: "some content contact@example.com",
-		}
+		},
+		Depth: 0,
+		Body:  "please contact contact@example.com or admin@example.com",
+	}
 
-		output.CustomFieldsMapMutex.Lock()
-		output.CustomFieldsMap["server"] = output.CustomFieldConfig{
-			Name:         "server",
-			Type:         "regex",
-			Part:         "response",
-			CompileRegex: []*regexp.Regexp{regexp.MustCompile(`ECS`)},
-		}
-		output.CustomFieldsMap["email"] = output.CustomFieldConfig{
-			Name:         "email",
-			Type:         "regex",
-			Part:         "response",
-			CompileRegex: []*regexp.Regexp{regexp.MustCompile(`([a-zA-Z0-9._-]+@[a-zA-Z0-9._-]+\.[a-zA-Z0-9_-]+)`)},
-		}
-		output.CustomFieldsMapMutex.Unlock()
+	output.CustomFieldsMapMutex.Lock()
+	output.CustomFieldsMap["email"] = output.CustomFieldConfig{
+		Name: "email",
+		Type: "regex",
+		Part: "response",
+		CompileRegex: []*regexp.Regexp{
+			regexp.MustCompile(`([a-zA-Z0-9._-]+@[a-zA-Z0-9._-]+\.[a-zA-Z0-9_-]+)`),
+		},
+	}
 
-		navigationRequests := customFieldRegexParser(resp)
-		var requireFields = map[string][]string{"server": {"ECS"}, "email": {"contact@example.com"}}
-		require.Equal(t, requireFields, navigationRequests[0].CustomFields, "could not get correct url")
-	})
+	output.CustomFieldsMap["server"] = output.CustomFieldConfig{
+		Name: "server",
+		Type: "regex",
+		Part: "response",
+		CompileRegex: []*regexp.Regexp{
+			regexp.MustCompile(`ECS`),
+		},
+	}
+	output.CustomFieldsMapMutex.Unlock()
+
+	navigationRequests := customFieldRegexParser(resp)
+
+	require.Len(t, navigationRequests, 1)
+
+	require.Equal(t, map[string][]string{
+		"email":  {"contact@example.com", "admin@example.com"},
+		"server": {"ECS"},
+	}, navigationRequests[0].CustomFields)
 }
 
 func TestHtmxBodyParser(t *testing.T) {

--- a/pkg/engine/parser/parser_test.go
+++ b/pkg/engine/parser/parser_test.go
@@ -418,9 +418,9 @@ func TestRegexBodyParsers(t *testing.T) {
 	parsed, _ := urlutil.Parse("https://security-crawl-maze.app/contact")
 
 	t.Run("regexbody", func(t *testing.T) {
-		output.customFieldsMu.Lock()
+		output.CustomFieldsMapMutex.Lock()
 		output.CustomFieldsMap = make(map[string]output.CustomFieldConfig)
-		output.customFieldsMu.Unlock()
+		output.CustomFieldsMapMutex.Unlock()
 
 		resp := &navigation.Response{
 			Resp:  &http.Response{Request: &http.Request{URL: parsed.URL}},
@@ -428,14 +428,14 @@ func TestRegexBodyParsers(t *testing.T) {
 			Body:  "some content contact@example.com",
 		}
 
-		output.customFieldsMu.Lock()
+		output.CustomFieldsMapMutex.Lock()
 		output.CustomFieldsMap["email"] = output.CustomFieldConfig{
 			Name:         "email",
 			Type:         "regex",
 			Part:         "body",
 			CompileRegex: []*regexp.Regexp{regexp.MustCompile(`([a-zA-Z0-9._-]+@[a-zA-Z0-9._-]+\.[a-zA-Z0-9_-]+)`)},
 		}
-		output.customFieldsMu.Unlock()
+		output.CustomFieldsMapMutex.Unlock()
 
 		navigationRequests := customFieldRegexParser(resp)
 		var requireFields = map[string][]string{"email": {"contact@example.com"}}
@@ -443,9 +443,9 @@ func TestRegexBodyParsers(t *testing.T) {
 	})
 
 	t.Run("regexheader", func(t *testing.T) {
-		output.customFieldsMu.Lock()
+		output.CustomFieldsMapMutex.Lock()
 		output.CustomFieldsMap = make(map[string]output.CustomFieldConfig)
-		output.customFieldsMu.Unlock()
+		output.CustomFieldsMapMutex.Unlock()
 
 		resp := &navigation.Response{
 			Resp: &http.Response{Request: &http.Request{URL: parsed.URL},
@@ -455,14 +455,14 @@ func TestRegexBodyParsers(t *testing.T) {
 			},
 		}
 
-		output.customFieldsMu.Lock()
+		output.CustomFieldsMapMutex.Lock()
 		output.CustomFieldsMap["server"] = output.CustomFieldConfig{
 			Name:         "server",
 			Type:         "regex",
 			Part:         "header",
 			CompileRegex: []*regexp.Regexp{regexp.MustCompile(`server: ECS`)},
 		}
-		output.customFieldsMu.Unlock()
+		output.CustomFieldsMapMutex.Unlock()
 
 		navigationRequests := customFieldRegexParser(resp)
 		var requireFields = map[string][]string{"server": {"server: ECS"}}
@@ -470,9 +470,9 @@ func TestRegexBodyParsers(t *testing.T) {
 	})
 
 	t.Run("regexresponse", func(t *testing.T) {
-		output.customFieldsMu.Lock()
+		output.CustomFieldsMapMutex.Lock()
 		output.CustomFieldsMap = make(map[string]output.CustomFieldConfig)
-		output.customFieldsMu.Unlock()
+		output.CustomFieldsMapMutex.Unlock()
 
 		resp := &navigation.Response{
 			Resp: &http.Response{Request: &http.Request{URL: parsed.URL},
@@ -483,7 +483,7 @@ func TestRegexBodyParsers(t *testing.T) {
 			Body: "some content contact@example.com",
 		}
 
-		output.customFieldsMu.Lock()
+		output.CustomFieldsMapMutex.Lock()
 		output.CustomFieldsMap["server"] = output.CustomFieldConfig{
 			Name:         "server",
 			Type:         "regex",
@@ -496,7 +496,7 @@ func TestRegexBodyParsers(t *testing.T) {
 			Part:         "response",
 			CompileRegex: []*regexp.Regexp{regexp.MustCompile(`([a-zA-Z0-9._-]+@[a-zA-Z0-9._-]+\.[a-zA-Z0-9_-]+)`)},
 		}
-		output.customFieldsMu.Unlock()
+		output.CustomFieldsMapMutex.Unlock()
 
 		navigationRequests := customFieldRegexParser(resp)
 		var requireFields = map[string][]string{"server": {"ECS"}, "email": {"contact@example.com"}}

--- a/pkg/engine/parser/parser_test.go
+++ b/pkg/engine/parser/parser_test.go
@@ -416,28 +416,37 @@ func TestScriptParsers(t *testing.T) {
 
 func TestRegexBodyParsers(t *testing.T) {
 	parsed, _ := urlutil.Parse("https://security-crawl-maze.app/contact")
+
 	t.Run("regexbody", func(t *testing.T) {
+		output.customFieldsMu.Lock()
 		output.CustomFieldsMap = make(map[string]output.CustomFieldConfig)
+		output.customFieldsMu.Unlock()
+
 		resp := &navigation.Response{
 			Resp:  &http.Response{Request: &http.Request{URL: parsed.URL}},
 			Depth: 0,
 			Body:  "some content contact@example.com",
 		}
 
-		// set required regex
+		output.customFieldsMu.Lock()
 		output.CustomFieldsMap["email"] = output.CustomFieldConfig{
 			Name:         "email",
 			Type:         "regex",
 			Part:         "body",
 			CompileRegex: []*regexp.Regexp{regexp.MustCompile(`([a-zA-Z0-9._-]+@[a-zA-Z0-9._-]+\.[a-zA-Z0-9_-]+)`)},
 		}
+		output.customFieldsMu.Unlock()
 
 		navigationRequests := customFieldRegexParser(resp)
 		var requireFields = map[string][]string{"email": {"contact@example.com"}}
 		require.Equal(t, requireFields, navigationRequests[0].CustomFields, "could not get correct url")
 	})
+
 	t.Run("regexheader", func(t *testing.T) {
+		output.customFieldsMu.Lock()
 		output.CustomFieldsMap = make(map[string]output.CustomFieldConfig)
+		output.customFieldsMu.Unlock()
+
 		resp := &navigation.Response{
 			Resp: &http.Response{Request: &http.Request{URL: parsed.URL},
 				Header: http.Header{
@@ -446,13 +455,14 @@ func TestRegexBodyParsers(t *testing.T) {
 			},
 		}
 
-		// set required regex
+		output.customFieldsMu.Lock()
 		output.CustomFieldsMap["server"] = output.CustomFieldConfig{
 			Name:         "server",
 			Type:         "regex",
 			Part:         "header",
 			CompileRegex: []*regexp.Regexp{regexp.MustCompile(`server: ECS`)},
 		}
+		output.customFieldsMu.Unlock()
 
 		navigationRequests := customFieldRegexParser(resp)
 		var requireFields = map[string][]string{"server": {"server: ECS"}}
@@ -460,7 +470,10 @@ func TestRegexBodyParsers(t *testing.T) {
 	})
 
 	t.Run("regexresponse", func(t *testing.T) {
+		output.customFieldsMu.Lock()
 		output.CustomFieldsMap = make(map[string]output.CustomFieldConfig)
+		output.customFieldsMu.Unlock()
+
 		resp := &navigation.Response{
 			Resp: &http.Response{Request: &http.Request{URL: parsed.URL},
 				Header: http.Header{
@@ -470,7 +483,7 @@ func TestRegexBodyParsers(t *testing.T) {
 			Body: "some content contact@example.com",
 		}
 
-		// set required regex
+		output.customFieldsMu.Lock()
 		output.CustomFieldsMap["server"] = output.CustomFieldConfig{
 			Name:         "server",
 			Type:         "regex",
@@ -483,6 +496,7 @@ func TestRegexBodyParsers(t *testing.T) {
 			Part:         "response",
 			CompileRegex: []*regexp.Regexp{regexp.MustCompile(`([a-zA-Z0-9._-]+@[a-zA-Z0-9._-]+\.[a-zA-Z0-9_-]+)`)},
 		}
+		output.customFieldsMu.Unlock()
 
 		navigationRequests := customFieldRegexParser(resp)
 		var requireFields = map[string][]string{"server": {"ECS"}, "email": {"contact@example.com"}}

--- a/pkg/output/custom_field.go
+++ b/pkg/output/custom_field.go
@@ -15,6 +15,7 @@ import (
 
 // CustomFieldsMap is the global custom field data instance
 // it is used for parsing the header and body of request
+// CustomFieldsMap may be used concurrently, hence the need for an RWMutex
 var (
 	CustomFieldsMap      = make(map[string]CustomFieldConfig)
 	CustomFieldsMapMutex sync.RWMutex

--- a/pkg/output/custom_field.go
+++ b/pkg/output/custom_field.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sync"
 
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/utils/errkit"
@@ -14,7 +15,10 @@ import (
 
 // CustomFieldsMap is the global custom field data instance
 // it is used for parsing the header and body of request
-var CustomFieldsMap = make(map[string]CustomFieldConfig)
+var (
+	CustomFieldsMap      = make(map[string]CustomFieldConfig)
+	CustomFieldsMapMutex sync.RWMutex
+)
 
 type Part string
 
@@ -86,6 +90,9 @@ func parseCustomFieldName(filePath string) error {
 }
 
 func loadCustomFields(filePath string, fields string) error {
+	CustomFieldsMapMutex.Lock()
+	defer CustomFieldsMapMutex.Unlock()
+
 	var err error
 
 	file, err := os.Open(filePath)


### PR DESCRIPTION
## Proposed changes

I've added a mutex (`output.CustomFieldsMapMutex`) that is now protecting `output.CustomFieldsMap` as it may be used concurrently when katana is embedded as Go library. This fixes issue #1698 error that caused program to crash when more than one crawler/output is initialized concurrently.

### Proof

I've ran the test from issue that I have fixed: #1698 and modified `TestCustomFieldRegexParser_BasicMatch` to also use mutex that is now protecting the `output.CustomFieldsMap`. All tests passed

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/katana/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when loading and using custom-field matching, reducing the risk of concurrent access issues.
  * Custom-field extraction now handles multiple fields more reliably during parsing.
* **Tests**
  * Updated automated coverage for custom-field regex matching with both body and header data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->