### PR TITLE
Fix concurrent map access on global custom fields (#1698)

### DIFF
--- a/pkg/engine/parser/parser.go
+++ b/pkg/engine/parser/parser.go
@@ -717,7 +717,7 @@ func bodyScrapeEndpointsParser(resp *navigation.Response) (navigationRequests []
 // customFieldRegexParser parses custom regex from HTML body and header
 func customFieldRegexParser(resp *navigation.Response) (navigationRequests []*navigation.Request) {
 	var customField = make(map[string][]string)
-	for _, v := range output.CustomFieldsMap {
+	for _, v := range output.CustomFieldsSnapshot() {
 		results := []string{}
 		for _, re := range v.CompileRegex {
 			matches := [][]string{}

--- a/pkg/output/custom_field.go
+++ b/pkg/output/custom_field.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sync"
 
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/utils/errkit"
@@ -13,8 +14,40 @@ import (
 )
 
 // CustomFieldsMap is the global custom field data instance
-// it is used for parsing the header and body of request
-var CustomFieldsMap = make(map[string]CustomFieldConfig)
+// it is used for parsing the header and body of request.
+// Access it through the exported helpers so it stays safe under concurrent
+// crawler/output initialization (see issue #1698).
+var (
+	CustomFieldsMap = make(map[string]CustomFieldConfig)
+	customFieldsMu  sync.RWMutex
+)
+
+// setCustomField registers or overwrites a custom field entry.
+func setCustomField(cfg CustomFieldConfig) {
+	customFieldsMu.Lock()
+	defer customFieldsMu.Unlock()
+	CustomFieldsMap[cfg.Name] = cfg
+}
+
+// hasCustomField reports whether a custom field with the given name is registered.
+func hasCustomField(name string) bool {
+	customFieldsMu.RLock()
+	defer customFieldsMu.RUnlock()
+	_, ok := CustomFieldsMap[name]
+	return ok
+}
+
+// CustomFieldsSnapshot returns a copy of the registered custom fields, safe to
+// range over while other goroutines register new fields.
+func CustomFieldsSnapshot() []CustomFieldConfig {
+	customFieldsMu.RLock()
+	defer customFieldsMu.RUnlock()
+	fields := make([]CustomFieldConfig, 0, len(CustomFieldsMap))
+	for _, cfg := range CustomFieldsMap {
+		fields = append(fields, cfg)
+	}
+	return fields
+}
 
 type Part string
 
@@ -114,7 +147,7 @@ func loadCustomFields(filePath string, fields string) error {
 		if item.Part == "" {
 			item.Part = Response.ToString()
 		}
-		CustomFieldsMap[item.Name] = item
+		setCustomField(item)
 	}
 	return nil
 }

--- a/pkg/output/custom_field_test.go
+++ b/pkg/output/custom_field_test.go
@@ -1,0 +1,41 @@
+package output
+
+import (
+	"os"
+	"sync"
+	"testing"
+)
+
+// TestCustomFieldsConcurrentAccess guards against the concurrent map access
+// regression reported in issue #1698: initializing multiple writers while the
+// custom fields map is read must not race.
+func TestCustomFieldsConcurrentAccess(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "field-config-*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString("- name: testfield\n  type: regex\n  part: response\n  regex: [\"(x)\"]\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			w, err := New(Options{FieldConfig: f.Name()})
+			if err == nil {
+				_ = w.Close()
+			}
+		}()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			CustomFieldsSnapshot()
+		}()
+	}
+	wg.Wait()
+}

--- a/pkg/output/fields.go
+++ b/pkg/output/fields.go
@@ -47,7 +47,7 @@ func validateFieldNames(names string) error {
 	for _, field := range FieldNames {
 		uniqueFields[field] = struct{}{}
 	}
-	for _, field := range CustomFieldsMap {
+	for _, field := range CustomFieldsSnapshot() {
 		uniqueFields[field.Name] = struct{}{}
 	}
 	for _, part := range parts {
@@ -74,7 +74,7 @@ func storeFields(output *Result, storeFields []string) {
 		if result := getValueForField(output, parsed.URL, hostname, etld, rootURL, field); result != "" {
 			appendToFileField(parsed.URL, field, result)
 		}
-		if _, ok := CustomFieldsMap[field]; ok {
+		if hasCustomField(field) {
 			results := getValueForCustomField(output)
 			for _, result := range results {
 				appendToFileField(parsed.URL, result.field, result.value)


### PR DESCRIPTION
Guards the global `output.CustomFieldsMap` with a `sync.RWMutex` and routes all access through helpers, fixing the `fatal error: concurrent map writes` when crawlers/outputs initialize concurrently.

Closes #1698

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when using custom fields during concurrent startup and output generation.
  * Reduced the chance of race-related issues when custom fields are loaded and read at the same time.
  * Field validation now recognizes custom fields more consistently, helping avoid unexpected validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->