### PR TITLE
Recorded flow support

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,8 @@ HEADLESS:
    -dwt, -dom-wait-time int          time in seconds to wait after page load when using domcontentloaded strategy (default 5)
    -csp, -captcha-solver-provider string  captcha solver provider (e.g. capsolver)
    -csk, -captcha-solver-key string       captcha solver provider api key
+   -al, -auto-login string           automatic login with username:password (headless only)
+   -rf, -recorded-flow string        chrome DevTools Recorder JSON (or explicit steps) to replay before crawl (headless only)
 ```
 
 *`-no-sandbox`*
@@ -690,9 +692,13 @@ katana -u https://example.com -kb-endpoints
 
 ## Authenticated Crawling
 
-Authenticated crawling involves including custom headers or cookies in HTTP requests to access protected resources. These headers provide authentication or authorization information, allowing you to crawl authenticated content / endpoint. You can specify headers directly in the command line or provide them as a file with katana to perform authenticated crawling.
+Katana supports authenticated crawling in several ways: static headers/cookies, attaching to an already-logged-in Chrome session, automatic form login (`-auto-login`), and **recorded browser flows** (`-recorded-flow`) for multi-step / SPA / SSO-style logins.
 
-> **Note**: User needs to be manually perform the authentication and export the session cookie / header to file to use with katana.
+### Headers / cookies
+
+Authenticated crawling can include custom headers or cookies in HTTP requests to access protected resources. You can specify headers directly on the command line or provide them as a file.
+
+> **Note**: For the header/cookie approach, perform authentication manually once and export the session cookie / header to use with katana.
 
 *`-headers`*
 ----
@@ -719,6 +725,59 @@ TOKEN=XX
 katana -u https://tesla.com -H cookie.txt
 ```
 
+### Automatic login (`-auto-login`)
+
+In pure headless mode, katana can detect a login form and submit credentials automatically:
+
+```console
+katana -hl -u https://app.example.com -al 'user:password'
+```
+
+This is best for simple username/password forms. For multi-step, SPA, or SSO logins prefer a recorded flow.
+
+### Recorded flow (`-recorded-flow`)
+
+Recorded flows let you export a real browser login from **Chrome DevTools → Recorder** and replay it once **before the crawl starts**. Session cookies stay in the headless browser context for the rest of the crawl.
+
+**1. Record the login in Chrome**
+
+1. Open Chrome DevTools → **Recorder**
+2. Start a new recording and perform the login (navigate, type, click Next, type password, submit, …)
+3. Export the recording as JSON
+
+**2. Replay it with katana**
+
+```console
+katana -hl -u https://app.example.com/dashboard \
+  -rf login.json \
+  -al 'user:password'
+```
+
+Credential literals in the recording are replaced with `{{username}}` / `{{password}}` placeholders and filled from `-al`. If the recording (or an explicit step list) still needs those placeholders, `-al` is required.
+
+Katana also accepts a hand-authored explicit step file:
+
+```json
+{
+  "steps": [
+    {"action": "navigate", "value": "https://app.example.com/login"},
+    {"action": "fill", "selector": "#email", "value": "{{username}}"},
+    {"action": "fill", "selector": "#password", "value": "{{password}}"},
+    {"action": "click", "selector": "#submit"}
+  ]
+}
+```
+
+Supported step actions: `navigate`, `fill`, `click`, `waitvisible`, `wait`, `press`, `submit`.
+
+**How it runs**
+
+1. Katana launches headless Chrome
+2. Replays the recorded flow once (pre-auth)
+3. Starts crawling `-u` with the established session
+4. Skips logout URLs while authenticated
+
+> Recorded flows require **pure headless** (`-hl`). Hybrid (`-hh`) is disabled automatically when `-rf` is set.
 
 There are more options to configure when needed, here is all the config related CLI options - 
 

--- a/README.md
+++ b/README.md
@@ -737,7 +737,7 @@ This is best for simple username/password forms. For multi-step, SPA, or SSO log
 
 ### Recorded flow (`-recorded-flow`)
 
-Recorded flows let you export a real browser login from **Chrome DevTools → Recorder** and replay it once **before the crawl starts**. Session cookies stay in the headless browser context for the rest of the crawl.
+Recorded flows let you export a real browser login from **Chrome DevTools → Recorder** and replay it once **before the crawl starts**. Session cookies and same-origin web storage stay in the headless browser context for the rest of the crawl.
 
 **1. Record the login in Chrome**
 
@@ -768,14 +768,20 @@ Katana also accepts a hand-authored explicit step file:
 }
 ```
 
-Supported step actions: `navigate`, `fill`, `click`, `waitvisible`, `wait`, `press`, `submit`.
+Supported step actions: `navigate`, `fill`, `click`, `doubleclick`, `waitvisible`, `wait`, `press`, `submit`.
 
 **How it runs**
 
 1. Katana launches headless Chrome
-2. Replays the recorded flow once (pre-auth)
-3. Starts crawling `-u` with the established session
-4. Skips logout URLs while authenticated
+2. Captures the anonymous browser state, then replays the recorded flow once
+3. Verifies that a cookie or same-origin web-storage value changed; if not, tries `-auto-login` as a fallback
+4. Starts crawling `-u` with the established session
+5. Skips logout URLs while authenticated
+
+For applications that keep authentication entirely server-side without changing
+cookies or web storage, end an explicit flow with `waitvisible` targeting an
+element that only exists after login. A successful terminal visibility check is
+treated as the flow's explicit authentication assertion.
 
 > Recorded flows require **pure headless** (`-hl`). Hybrid (`-hh`) is disabled automatically when `-rf` is set.
 

--- a/cmd/functional-test/main.go
+++ b/cmd/functional-test/main.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/logrusorgru/aurora"
 	"github.com/pkg/errors"
 	"github.com/projectdiscovery/katana/internal/testutils"
+	"github.com/projectdiscovery/katana/internal/testutils/authlab"
 )
 
 var (
@@ -45,6 +47,51 @@ func runFunctionalTests() error {
 		if testcase.Target == "" {
 			testcase.Target = server.URL
 		}
+		if err := runIndividualTestCase(testcase); err != nil {
+			errored = true
+			fmt.Fprintf(os.Stderr, "%s Test \"%s\" failed: %s\n", failed, testcase.Name, err)
+		} else {
+			fmt.Printf("%s Test \"%s\" passed!\n", success, testcase.Name)
+		}
+	}
+
+	if err := runAuthLabFunctionalTests(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func runAuthLabFunctionalTests() error {
+	lab, err := authlab.Start()
+	if err != nil {
+		return fmt.Errorf("could not start auth lab: %w", err)
+	}
+	defer func() { _ = lab.Close() }()
+
+	fmt.Printf("Auth lab started at %s\n", lab.URL)
+
+	dir, err := os.MkdirTemp("", "katana-rf-*")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	simpleFlow := filepath.Join(dir, "simple.json")
+	if err := os.WriteFile(simpleFlow, []byte(authlab.ChromeRecordingSimple(lab.URL)), 0o600); err != nil {
+		return err
+	}
+	explicitFlow := filepath.Join(dir, "explicit.json")
+	if err := os.WriteFile(explicitFlow, []byte(authlab.ExplicitStepsSimple(lab.URL)), 0o600); err != nil {
+		return err
+	}
+
+	cases := testutils.AuthTestCases(lab.URL, simpleFlow)
+	// Second case reuses the same CompareFunc shape but should run the explicit steps file.
+	if len(cases) >= 2 {
+		cases[1].Args = strings.Replace(cases[1].Args, simpleFlow, explicitFlow, 1)
+	}
+
+	for _, testcase := range cases {
 		if err := runIndividualTestCase(testcase); err != nil {
 			errored = true
 			fmt.Fprintf(os.Stderr, "%s Test \"%s\" failed: %s\n", failed, testcase.Name, err)

--- a/cmd/katana/main.go
+++ b/cmd/katana/main.go
@@ -203,6 +203,7 @@ pipelines offering both headless and non-headless crawling.`)
 		flagSet.StringVarEnv(&options.CaptchaSolverProvider, "captcha-solver-provider", "csp", "", "CAPTCHA_SOLVER_PROVIDER", "captcha solver provider (e.g. capsolver)"),
 		flagSet.StringVarEnv(&options.CaptchaSolverAPIKey, "captcha-solver-key", "csk", "", "CAPTCHA_SOLVER_KEY", "captcha solver provider api key"),
 		flagSet.StringVarEnv(&options.AuthCredentials, "auto-login", "al", "", "AUTH_CREDENTIALS", "automatic login with username:password (headless only)"),
+		flagSet.StringVarP(&options.RecordedFlow, "recorded-flow", "rf", "", "chrome DevTools Recorder JSON (or explicit steps) to replay before crawl (headless only)"),
 	)
 
 	flagSet.CreateGroup("scope", "Scope",

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/gologger/formatter"
+	"github.com/projectdiscovery/katana/pkg/engine/headless/auth"
 	"github.com/projectdiscovery/katana/pkg/types"
 	"github.com/projectdiscovery/katana/pkg/utils"
 	"github.com/projectdiscovery/utils/errkit"
@@ -68,6 +69,37 @@ func validateOptions(options *types.Options) error {
 		if !options.Headless && !options.HeadlessHybrid {
 			options.Headless = true
 			gologger.Info().Msgf("Headless mode enabled automatically for authenticated crawling.")
+		}
+	}
+
+	if options.RecordedFlow != "" {
+		if !fileutil.FileExists(options.RecordedFlow) {
+			return errkit.New("recorded flow file does not exist")
+		}
+		// Recorded flows replay against the pure headless engine only.
+		if options.HeadlessHybrid {
+			options.HeadlessHybrid = false
+			gologger.Warning().Msgf("Recorded flow (-rf) requires pure headless mode; disabling -hh.")
+		}
+		if !options.Headless {
+			options.Headless = true
+			gologger.Info().Msgf("Headless mode enabled automatically for recorded flow.")
+		}
+
+		username, password := "", ""
+		if options.AuthCredentials != "" {
+			parts := strings.SplitN(options.AuthCredentials, ":", 2)
+			username = parts[0]
+			if len(parts) > 1 {
+				password = parts[1]
+			}
+		}
+		steps, err := auth.StepsFromFile(options.RecordedFlow, username, password)
+		if err != nil {
+			return errkit.Wrap(err, "invalid recorded flow")
+		}
+		if auth.NeedsCredentials(steps) && options.AuthCredentials == "" {
+			return errkit.New("recorded flow requires -auto-login username:password for credential placeholders")
 		}
 	}
 

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -49,7 +49,7 @@ func validateOptions(options *types.Options) error {
 	if options.Headless && options.HeadlessHybrid {
 		return errkit.New("flags -hl (headless) and -hh (hybrid) are mutually exclusive")
 	}
-	
+
 	// Warn if -headless or -hh is used with -cwu (Chrome WebSocket URL)
 	// The ChromeWSUrl takes precedence and pure headless engine will be used
 	if options.Headless && options.ChromeWSUrl != "" {
@@ -100,6 +100,13 @@ func validateOptions(options *types.Options) error {
 		}
 		if auth.NeedsCredentials(steps) && options.AuthCredentials == "" {
 			return errkit.New("recorded flow requires -auto-login username:password for credential placeholders")
+		}
+		replaySteps, loginURL := auth.StepsAfterFirstNavigateURL(steps)
+		if loginURL == "" {
+			return errkit.New("recorded flow requires an absolute http(s) navigate step")
+		}
+		if len(replaySteps) == 0 {
+			return errkit.New("recorded flow requires at least one action after its navigate step")
 		}
 	}
 

--- a/internal/runner/options_test.go
+++ b/internal/runner/options_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"os"
 	"testing"
 
 	"github.com/projectdiscovery/katana/pkg/types"
@@ -66,5 +67,64 @@ func TestValidateHeadlessFlags(t *testing.T) {
 		opts.HeadlessNoSandbox = true
 		err := validateOptions(opts)
 		require.NoError(t, err)
+	})
+}
+
+func TestValidateRecordedFlow(t *testing.T) {
+	writeFlow := func(t *testing.T, contents string) string {
+		t.Helper()
+		path := t.TempDir() + "/flow.json"
+		require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+		return path
+	}
+
+	t.Run("missing file is rejected", func(t *testing.T) {
+		opts := newTestOptions()
+		opts.RecordedFlow = "/no/such/recorded-flow.json"
+		err := validateOptions(opts)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "does not exist")
+	})
+
+	t.Run("forces headless and accepts chrome recording with credentials", func(t *testing.T) {
+		flow := `{
+		  "title": "login",
+		  "steps": [
+		    {"type": "navigate", "url": "https://example.com/login"},
+		    {"type": "change", "value": "dave", "selectors": [["#email"]]},
+		    {"type": "change", "value": "secret", "selectors": [["#password"]]},
+		    {"type": "click", "selectors": [["#submit"]]}
+		  ]
+		}`
+		opts := newTestOptions()
+		opts.RecordedFlow = writeFlow(t, flow)
+		opts.AuthCredentials = "dave:secret"
+		err := validateOptions(opts)
+		require.NoError(t, err)
+		require.True(t, opts.Headless, "recorded flow should enable headless")
+	})
+
+	t.Run("requires credentials when placeholders remain", func(t *testing.T) {
+		flow := `{
+		  "steps": [
+		    {"type": "change", "value": "x", "selectors": [["#password"]]}
+		  ]
+		}`
+		opts := newTestOptions()
+		opts.RecordedFlow = writeFlow(t, flow)
+		err := validateOptions(opts)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "auto-login")
+	})
+
+	t.Run("disables hybrid when recorded flow is set", func(t *testing.T) {
+		flow := `{"steps":[{"action":"navigate","value":"https://example.com"}]}`
+		opts := newTestOptions()
+		opts.HeadlessHybrid = true
+		opts.RecordedFlow = writeFlow(t, flow)
+		err := validateOptions(opts)
+		require.NoError(t, err)
+		require.False(t, opts.HeadlessHybrid)
+		require.True(t, opts.Headless)
 	})
 }

--- a/internal/runner/options_test.go
+++ b/internal/runner/options_test.go
@@ -118,7 +118,7 @@ func TestValidateRecordedFlow(t *testing.T) {
 	})
 
 	t.Run("disables hybrid when recorded flow is set", func(t *testing.T) {
-		flow := `{"steps":[{"action":"navigate","value":"https://example.com"}]}`
+		flow := `{"steps":[{"action":"navigate","value":"https://example.com"},{"action":"click","selector":"#submit"}]}`
 		opts := newTestOptions()
 		opts.HeadlessHybrid = true
 		opts.RecordedFlow = writeFlow(t, flow)
@@ -126,5 +126,26 @@ func TestValidateRecordedFlow(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, opts.HeadlessHybrid)
 		require.True(t, opts.Headless)
+	})
+
+	t.Run("requires absolute web navigation", func(t *testing.T) {
+		opts := newTestOptions()
+		opts.RecordedFlow = writeFlow(t, `{"steps":[{"action":"navigate","value":"about:blank"},{"action":"click","selector":"#submit"}]}`)
+		err := validateOptions(opts)
+		require.ErrorContains(t, err, "absolute http(s) navigate step")
+	})
+
+	t.Run("rejects invalid explicit action before launching browser", func(t *testing.T) {
+		opts := newTestOptions()
+		opts.RecordedFlow = writeFlow(t, `{"steps":[{"action":"navigate","value":"https://example.com"},{"action":"evaluate","value":"alert(1)"}]}`)
+		err := validateOptions(opts)
+		require.ErrorContains(t, err, "unknown action")
+	})
+
+	t.Run("requires an action after navigation", func(t *testing.T) {
+		opts := newTestOptions()
+		opts.RecordedFlow = writeFlow(t, `{"steps":[{"action":"navigate","value":"https://example.com"}]}`)
+		err := validateOptions(opts)
+		require.ErrorContains(t, err, "at least one action")
 	})
 }

--- a/internal/testutils/auth_cases.go
+++ b/internal/testutils/auth_cases.go
@@ -1,40 +1,40 @@
 package testutils
 
 import (
+	"path/filepath"
 	"strings"
 
 	"github.com/projectdiscovery/katana/internal/testutils/authlab"
 	"github.com/projectdiscovery/utils/errkit"
 )
 
+func requireGatedPages(_ string, got []string) error {
+	joined := strings.Join(got, "\n")
+	if !strings.Contains(joined, "/app/secret") && !strings.Contains(joined, "/app/settings") {
+		return errkit.Newf("recorded flow crawl should discover gated /app pages, got: %s", joined)
+	}
+	return nil
+}
+
 // AuthTestCases returns functional cases that exercise recorded-flow login
 // against a running authlab instance. flowPath must point at a Chrome Recorder
 // (or explicit steps) JSON file whose navigate URL targets that lab.
 func AuthTestCases(labURL, flowPath string) []TestCase {
 	creds := authlab.Username + ":" + authlab.Password
+	flowPath = filepath.ToSlash(flowPath)
+	baseArgs := "-headless -no-incognito -depth 2 -silent -no-sandbox -rf " + flowPath + " -al " + creds
 	return []TestCase{
 		{
-			Name:   "Recorded Flow Authenticated Crawl",
-			Target: labURL + "/app/dashboard",
-			Args:   "-headless -no-incognito -depth 2 -silent -no-sandbox -rf " + flowPath + " -al " + creds,
-			CompareFunc: func(_ string, got []string) error {
-				joined := strings.Join(got, "\n")
-				if !strings.Contains(joined, "/app/secret") && !strings.Contains(joined, "/app/settings") {
-					return errkit.Newf("recorded flow crawl should discover gated /app pages, got: %s", joined)
-				}
-				return nil
-			},
+			Name:        "Recorded Flow Authenticated Crawl",
+			Target:      labURL + "/app/dashboard",
+			Args:        baseArgs,
+			CompareFunc: requireGatedPages,
 		},
 		{
-			Name:   "Recorded Flow Explicit Steps Crawl",
-			Target: labURL + "/app/dashboard",
-			Args:   "-headless -no-incognito -depth 2 -silent -no-sandbox -rf " + flowPath + " -al " + creds,
-			CompareFunc: func(_ string, got []string) error {
-				if len(got) == 0 {
-					return errkit.New("expected authenticated crawl output")
-				}
-				return nil
-			},
+			Name:        "Recorded Flow Explicit Steps Crawl",
+			Target:      labURL + "/app/dashboard",
+			Args:        baseArgs,
+			CompareFunc: requireGatedPages,
 		},
 	}
 }

--- a/internal/testutils/auth_cases.go
+++ b/internal/testutils/auth_cases.go
@@ -1,0 +1,40 @@
+package testutils
+
+import (
+	"strings"
+
+	"github.com/projectdiscovery/katana/internal/testutils/authlab"
+	"github.com/projectdiscovery/utils/errkit"
+)
+
+// AuthTestCases returns functional cases that exercise recorded-flow login
+// against a running authlab instance. flowPath must point at a Chrome Recorder
+// (or explicit steps) JSON file whose navigate URL targets that lab.
+func AuthTestCases(labURL, flowPath string) []TestCase {
+	creds := authlab.Username + ":" + authlab.Password
+	return []TestCase{
+		{
+			Name:   "Recorded Flow Authenticated Crawl",
+			Target: labURL + "/app/dashboard",
+			Args:   "-headless -no-incognito -depth 2 -silent -no-sandbox -rf " + flowPath + " -al " + creds,
+			CompareFunc: func(_ string, got []string) error {
+				joined := strings.Join(got, "\n")
+				if !strings.Contains(joined, "/app/secret") && !strings.Contains(joined, "/app/settings") {
+					return errkit.Newf("recorded flow crawl should discover gated /app pages, got: %s", joined)
+				}
+				return nil
+			},
+		},
+		{
+			Name:   "Recorded Flow Explicit Steps Crawl",
+			Target: labURL + "/app/dashboard",
+			Args:   "-headless -no-incognito -depth 2 -silent -no-sandbox -rf " + flowPath + " -al " + creds,
+			CompareFunc: func(_ string, got []string) error {
+				if len(got) == 0 {
+					return errkit.New("expected authenticated crawl output")
+				}
+				return nil
+			},
+		},
+	}
+}

--- a/internal/testutils/authlab/lab.go
+++ b/internal/testutils/authlab/lab.go
@@ -1,0 +1,371 @@
+// Package authlab provides a self-hosted mini web app used to exercise
+// Katana recorded-flow / auto-login authentication end-to-end.
+//
+// It exposes three login styles against the same cookie-gated app surface:
+//
+//  1. Classic HTML form POST  (/login)
+//  2. Username-first multi-step (/login/step) — email → next → password
+//  3. JS SPA login              (/login/spa)  — client-side panels + fetch
+//
+// Authenticated pages under /app/* require the session cookie set by a
+// successful login. Tests assert that a recorded flow can unlock those pages
+// for a subsequent crawl.
+package authlab
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"sync/atomic"
+)
+
+const (
+	// Username / Password are the only credentials the lab accepts.
+	Username = "tester@katana.test"
+	Password = "katana-rocks"
+
+	CookieName  = "katana_session"
+	CookieValue = "authenticated"
+
+	// SecretMarker appears only on the cookie-gated /app/secret page.
+	SecretMarker = "KATANA_AUTH_SECRET_OK"
+)
+
+// Lab is a running local auth testbed.
+type Lab struct {
+	URL      string
+	listener net.Listener
+	server   *http.Server
+
+	LoginPosts    atomic.Int64
+	SecretHits    atomic.Int64
+	DashboardHits atomic.Int64
+}
+
+// Start launches the lab on 127.0.0.1 with an ephemeral port.
+func Start() (*Lab, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("authlab: listen: %w", err)
+	}
+	lab := &Lab{
+		URL:      fmt.Sprintf("http://%s", listener.Addr().String()),
+		listener: listener,
+	}
+	mux := http.NewServeMux()
+	lab.register(mux)
+	lab.server = &http.Server{Handler: mux}
+	go func() { _ = lab.server.Serve(listener) }()
+	return lab, nil
+}
+
+// Close shuts the lab down.
+func (l *Lab) Close() error {
+	if l.server != nil {
+		_ = l.server.Close()
+	}
+	if l.listener != nil {
+		return l.listener.Close()
+	}
+	return nil
+}
+
+func (l *Lab) register(mux *http.ServeMux) {
+	mux.HandleFunc("/", l.handleHome)
+	mux.HandleFunc("/about-public", l.handleAboutPublic)
+	mux.HandleFunc("/login", l.handleLogin)
+	mux.HandleFunc("/login/step", l.handleLoginStep)
+	mux.HandleFunc("/login/spa", l.handleLoginSPA)
+	mux.HandleFunc("/api/login", l.handleAPILogin)
+	mux.HandleFunc("/app/dashboard", l.handleDashboard)
+	mux.HandleFunc("/app/secret", l.handleSecret)
+	mux.HandleFunc("/app/settings", l.handleSettings)
+	mux.HandleFunc("/logout", l.handleLogout)
+}
+
+func (l *Lab) authenticated(r *http.Request) bool {
+	c, err := r.Cookie(CookieName)
+	return err == nil && c != nil && c.Value == CookieValue
+}
+
+func (l *Lab) setSession(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     CookieName,
+		Value:    CookieValue,
+		Path:     "/",
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+func (l *Lab) clearSession(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     CookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+	})
+}
+
+func (l *Lab) handleHome(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	authLinks := `<p>You are anonymous. <a href="/login">Login</a> · <a href="/login/step">Step login</a> · <a href="/login/spa">SPA login</a></p>`
+	if l.authenticated(r) {
+		authLinks = `<p>You are authenticated. <a href="/app/dashboard">Dashboard</a> · <a href="/logout">Logout</a></p>`
+	}
+	_, _ = fmt.Fprintf(w, `<!DOCTYPE html>
+<html><head><title>AuthLab Home</title></head>
+<body>
+  <h1>AuthLab</h1>
+  %s
+  <a href="/about-public">Public about</a>
+</body></html>`, authLinks)
+}
+
+func (l *Lab) handleAboutPublic(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = fmt.Fprint(w, `<!DOCTYPE html>
+<html><head><title>About</title></head>
+<body><h1>Public about</h1><a href="/">Home</a></body></html>`)
+}
+
+func (l *Lab) handleLogin(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = fmt.Fprint(w, `<!DOCTYPE html>
+<html><head><title>Login</title></head>
+<body>
+  <h1>Sign in</h1>
+  <form id="login-form" method="POST" action="/login">
+    <label>Email <input id="email" name="email" type="email" aria-label="Email" /></label>
+    <label>Password <input id="password" name="password" type="password" aria-label="Password" /></label>
+    <button id="submit" type="submit" aria-label="Sign in">Sign in</button>
+  </form>
+</body></html>`)
+	case http.MethodPost:
+		l.LoginPosts.Add(1)
+		_ = r.ParseForm()
+		if r.FormValue("email") != Username || r.FormValue("password") != Password {
+			http.Error(w, "invalid credentials", http.StatusUnauthorized)
+			return
+		}
+		l.setSession(w)
+		http.Redirect(w, r, "/app/dashboard", http.StatusFound)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// handleLoginStep serves a username-first flow entirely client-side so a
+// Chrome Recorder captures navigate → fill email → click next → wait password
+// → fill password → click submit.
+func (l *Lab) handleLoginStep(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = fmt.Fprint(w, `<!DOCTYPE html>
+<html><head><title>Step Login</title></head>
+<body>
+  <h1>Step login</h1>
+  <div id="panel-email">
+    <label>Email <input id="email" type="email" aria-label="Email" /></label>
+    <button id="next" type="button" aria-label="Next">Next</button>
+  </div>
+  <div id="panel-password" style="display:none">
+    <label>Password <input id="password" type="password" aria-label="Password" /></label>
+    <button id="submit" type="button" aria-label="Sign in">Sign in</button>
+  </div>
+  <p id="status"></p>
+  <script>
+    let email = "";
+    document.getElementById("next").onclick = () => {
+      email = document.getElementById("email").value;
+      document.getElementById("panel-email").style.display = "none";
+      document.getElementById("panel-password").style.display = "block";
+    };
+    document.getElementById("submit").onclick = async () => {
+      const password = document.getElementById("password").value;
+      const res = await fetch("/api/login", {
+        method: "POST",
+        headers: {"Content-Type": "application/json"},
+        credentials: "same-origin",
+        body: JSON.stringify({email, password})
+      });
+      if (res.ok) { window.location = "/app/dashboard"; }
+      else { document.getElementById("status").textContent = "login failed"; }
+    };
+  </script>
+</body></html>`)
+}
+
+func (l *Lab) handleLoginSPA(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = fmt.Fprint(w, `<!DOCTYPE html>
+<html><head><title>SPA Login</title></head>
+<body>
+  <h1>SPA login</h1>
+  <input id="email" type="email" aria-label="Email" placeholder="email" />
+  <input id="password" type="password" aria-label="Password" placeholder="password" />
+  <button id="submit" type="button" aria-label="Sign in">Sign in</button>
+  <div id="app"></div>
+  <script>
+    document.getElementById("submit").onclick = async () => {
+      const email = document.getElementById("email").value;
+      const password = document.getElementById("password").value;
+      const res = await fetch("/api/login", {
+        method: "POST",
+        headers: {"Content-Type": "application/json"},
+        credentials: "same-origin",
+        body: JSON.stringify({email, password})
+      });
+      if (!res.ok) { document.getElementById("app").textContent = "fail"; return; }
+      window.location = "/app/dashboard";
+    };
+  </script>
+</body></html>`)
+}
+
+func (l *Lab) handleAPILogin(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	l.LoginPosts.Add(1)
+	var body struct {
+		Email    string `json:"email"`
+		Password string `json:"password"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "bad json", http.StatusBadRequest)
+		return
+	}
+	if body.Email != Username || body.Password != Password {
+		http.Error(w, `{"error":"invalid"}`, http.StatusUnauthorized)
+		return
+	}
+	l.setSession(w)
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = fmt.Fprint(w, `{"ok":true}`)
+}
+
+func (l *Lab) requireAuth(w http.ResponseWriter, r *http.Request) bool {
+	if l.authenticated(r) {
+		return true
+	}
+	http.Error(w, "unauthorized", http.StatusUnauthorized)
+	return false
+}
+
+func (l *Lab) handleDashboard(w http.ResponseWriter, r *http.Request) {
+	if !l.requireAuth(w, r) {
+		return
+	}
+	l.DashboardHits.Add(1)
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = fmt.Fprint(w, `<!DOCTYPE html>
+<html><head><title>Dashboard</title></head>
+<body>
+  <h1>Dashboard</h1>
+  <a href="/app/secret">Secret</a>
+  <a href="/app/settings">Settings</a>
+  <a href="/logout">Logout</a>
+</body></html>`)
+}
+
+func (l *Lab) handleSecret(w http.ResponseWriter, r *http.Request) {
+	if !l.requireAuth(w, r) {
+		return
+	}
+	l.SecretHits.Add(1)
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = fmt.Fprintf(w, `<!DOCTYPE html>
+<html><head><title>Secret</title></head>
+<body>
+  <h1>Secret</h1>
+  <p id="marker">%s</p>
+  <a href="/app/dashboard">Back</a>
+</body></html>`, SecretMarker)
+}
+
+func (l *Lab) handleSettings(w http.ResponseWriter, r *http.Request) {
+	if !l.requireAuth(w, r) {
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = fmt.Fprint(w, `<!DOCTYPE html>
+<html><head><title>Settings</title></head>
+<body>
+  <h1>Settings</h1>
+  <a href="/app/dashboard">Back</a>
+</body></html>`)
+}
+
+func (l *Lab) handleLogout(w http.ResponseWriter, r *http.Request) {
+	l.clearSession(w)
+	http.Redirect(w, r, "/", http.StatusFound)
+}
+
+// ChromeRecordingSimple returns a Chrome DevTools Recorder export for the
+// classic /login form.
+func ChromeRecordingSimple(baseURL string) string {
+	baseURL = strings.TrimRight(baseURL, "/")
+	return fmt.Sprintf(`{
+  "title": "authlab simple login",
+  "steps": [
+    {"type": "setViewport", "width": 1280, "height": 720},
+    {"type": "navigate", "url": %q},
+    {"type": "change", "value": %q, "selectors": [["#email"], ["aria/Email"]]},
+    {"type": "change", "value": %q, "selectors": [["#password"], ["aria/Password"]]},
+    {"type": "click", "selectors": [["#submit"], ["aria/Sign in"]]}
+  ]
+}`, baseURL+"/login", Username, Password)
+}
+
+// ChromeRecordingStep returns a Recorder export for the username-first flow.
+func ChromeRecordingStep(baseURL string) string {
+	baseURL = strings.TrimRight(baseURL, "/")
+	return fmt.Sprintf(`{
+  "title": "authlab step login",
+  "steps": [
+    {"type": "navigate", "url": %q},
+    {"type": "change", "value": %q, "selectors": [["#email"]]},
+    {"type": "click", "selectors": [["#next"], ["aria/Next"]]},
+    {"type": "waitForElement", "selectors": [["#password"]]},
+    {"type": "change", "value": %q, "selectors": [["#password"]]},
+    {"type": "click", "selectors": [["#submit"], ["aria/Sign in"]]}
+  ]
+}`, baseURL+"/login/step", Username, Password)
+}
+
+// ChromeRecordingSPA returns a Recorder export for the SPA fetch login.
+func ChromeRecordingSPA(baseURL string) string {
+	baseURL = strings.TrimRight(baseURL, "/")
+	return fmt.Sprintf(`{
+  "title": "authlab spa login",
+  "steps": [
+    {"type": "navigate", "url": %q},
+    {"type": "change", "value": %q, "selectors": [["#email"], ["aria/Email"]]},
+    {"type": "change", "value": %q, "selectors": [["#password"], ["aria/Password"]]},
+    {"type": "click", "selectors": [["#submit"], ["aria/Sign in"]]}
+  ]
+}`, baseURL+"/login/spa", Username, Password)
+}
+
+// ExplicitStepsSimple is a hand-authored step list for the classic login.
+func ExplicitStepsSimple(baseURL string) string {
+	baseURL = strings.TrimRight(baseURL, "/")
+	return fmt.Sprintf(`{
+  "steps": [
+    {"action": "navigate", "value": %q},
+    {"action": "fill", "selector": "#email", "value": "{{username}}"},
+    {"action": "fill", "selector": "#password", "value": "{{password}}"},
+    {"action": "click", "selector": "#submit"}
+  ]
+}`, baseURL+"/login")
+}

--- a/internal/testutils/authlab/lab.go
+++ b/internal/testutils/authlab/lab.go
@@ -64,7 +64,8 @@ func Start() (*Lab, error) {
 // Close shuts the lab down.
 func (l *Lab) Close() error {
 	if l.server != nil {
-		_ = l.server.Close()
+		// Server.Close also closes the underlying listener.
+		return l.server.Close()
 	}
 	if l.listener != nil {
 		return l.listener.Close()

--- a/internal/testutils/authlab/lab.go
+++ b/internal/testutils/authlab/lab.go
@@ -28,6 +28,7 @@ const (
 
 	CookieName  = "katana_session"
 	CookieValue = "authenticated"
+	CSRFCookie  = "katana_csrf"
 
 	// SecretMarker appears only on the cookie-gated /app/secret page.
 	SecretMarker = "KATANA_AUTH_SECRET_OK"
@@ -42,6 +43,7 @@ type Lab struct {
 	LoginPosts    atomic.Int64
 	SecretHits    atomic.Int64
 	DashboardHits atomic.Int64
+	LogoutHits    atomic.Int64
 }
 
 // Start launches the lab on 127.0.0.1 with an ephemeral port.
@@ -140,6 +142,16 @@ func (l *Lab) handleAboutPublic(w http.ResponseWriter, r *http.Request) {
 func (l *Lab) handleLogin(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
+		// Real login pages commonly set an anonymous CSRF/consent cookie. This
+		// ensures recorded-flow verification compares against a post-navigation
+		// baseline instead of treating any cookie as proof of authentication.
+		http.SetCookie(w, &http.Cookie{
+			Name:     CSRFCookie,
+			Value:    "anonymous",
+			Path:     "/",
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
+		})
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		_, _ = fmt.Fprint(w, `<!DOCTYPE html>
 <html><head><title>Login</title></head>
@@ -308,6 +320,7 @@ func (l *Lab) handleSettings(w http.ResponseWriter, r *http.Request) {
 }
 
 func (l *Lab) handleLogout(w http.ResponseWriter, r *http.Request) {
+	l.LogoutHits.Add(1)
 	l.clearSession(w)
 	http.Redirect(w, r, "/", http.StatusFound)
 }

--- a/internal/testutils/authlab/lab_test.go
+++ b/internal/testutils/authlab/lab_test.go
@@ -1,0 +1,87 @@
+package authlab
+
+import (
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLab_GatesSecretAndAcceptsFormLogin(t *testing.T) {
+	lab, err := Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = lab.Close() })
+
+	resp, err := http.Get(lab.URL + "/app/secret")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	_ = resp.Body.Close()
+
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+	client := &http.Client{Jar: jar, CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+
+	form := url.Values{"email": {Username}, "password": {Password}}
+	resp, err = client.PostForm(lab.URL+"/login", form)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusFound, resp.StatusCode)
+	_ = resp.Body.Close()
+
+	client.CheckRedirect = nil
+	resp, err = client.Get(lab.URL + "/app/secret")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Contains(t, string(body), SecretMarker)
+	require.GreaterOrEqual(t, lab.LoginPosts.Load(), int64(1))
+	require.GreaterOrEqual(t, lab.SecretHits.Load(), int64(1))
+}
+
+func TestLab_APILogin(t *testing.T) {
+	lab, err := Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = lab.Close() })
+
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+	client := &http.Client{Jar: jar}
+
+	resp, err := client.Post(lab.URL+"/api/login", "application/json",
+		strings.NewReader(`{"email":"`+Username+`","password":"`+Password+`"}`))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	_ = resp.Body.Close()
+
+	resp, err = client.Get(lab.URL + "/app/dashboard")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestRecordingHelpersProduceValidJSONShape(t *testing.T) {
+	for name, raw := range map[string]string{
+		"simple":   ChromeRecordingSimple("http://127.0.0.1:9"),
+		"step":     ChromeRecordingStep("http://127.0.0.1:9"),
+		"spa":      ChromeRecordingSPA("http://127.0.0.1:9"),
+		"explicit": ExplicitStepsSimple("http://127.0.0.1:9"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			require.Contains(t, raw, "steps")
+			require.Contains(t, raw, "/login")
+			if name == "explicit" {
+				require.Contains(t, raw, "{{username}}")
+				require.Contains(t, raw, "{{password}}")
+			} else {
+				require.Contains(t, raw, Username)
+			}
+		})
+	}
+}

--- a/internal/testutils/integration.go
+++ b/internal/testutils/integration.go
@@ -1,24 +1,45 @@
 package testutils
 
 import (
+	"bytes"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
-func RunKatanaBinaryAndGetResults(target string, katanaBinary string, debug bool, args []string) ([]string, error) {
-	cmd := exec.Command("bash", "-c")
-	cmdLine := fmt.Sprintf(`echo %s | %s `, target, katanaBinary)
-	cmdLine += strings.Join(args, " ")
+// shellQuote quotes s for bash so Windows paths with backslashes and values
+// containing @/: don't get mangled by bash -c.
+func shellQuote(s string) string {
+	s = filepath.ToSlash(s)
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
 
-	cmd.Args = append(cmd.Args, cmdLine)
-	data, err := cmd.Output()
-	if err != nil {
-		return nil, err
+func RunKatanaBinaryAndGetResults(target string, katanaBinary string, debug bool, args []string) ([]string, error) {
+	quotedArgs := make([]string, 0, len(args))
+	for _, a := range args {
+		quotedArgs = append(quotedArgs, shellQuote(a))
 	}
+
+	cmdLine := fmt.Sprintf(`echo %s | %s %s`,
+		shellQuote(target),
+		shellQuote(katanaBinary),
+		strings.Join(quotedArgs, " "),
+	)
+	if debug {
+		fmt.Printf("cmd: %s\n", cmdLine)
+	}
+
+	cmd := exec.Command("bash", "-c", cmdLine)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("katana failed: %w\nstderr:\n%s\nstdout:\n%s", err, stderr.String(), stdout.String())
+	}
+
 	parts := []string{}
-	items := strings.Split(string(data), "\n")
-	for _, i := range items {
+	for _, i := range strings.Split(stdout.String(), "\n") {
 		if i != "" {
 			parts = append(parts, i)
 		}

--- a/internal/testutils/integration.go
+++ b/internal/testutils/integration.go
@@ -4,33 +4,16 @@ import (
 	"bytes"
 	"fmt"
 	"os/exec"
-	"path/filepath"
 	"strings"
 )
 
-// shellQuote quotes s for bash so Windows paths with backslashes and values
-// containing @/: don't get mangled by bash -c.
-func shellQuote(s string) string {
-	s = filepath.ToSlash(s)
-	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
-}
-
 func RunKatanaBinaryAndGetResults(target string, katanaBinary string, debug bool, args []string) ([]string, error) {
-	quotedArgs := make([]string, 0, len(args))
-	for _, a := range args {
-		quotedArgs = append(quotedArgs, shellQuote(a))
-	}
-
-	cmdLine := fmt.Sprintf(`echo %s | %s %s`,
-		shellQuote(target),
-		shellQuote(katanaBinary),
-		strings.Join(quotedArgs, " "),
-	)
 	if debug {
-		fmt.Printf("cmd: %s\n", cmdLine)
+		fmt.Printf("cmd: echo %s | %s %s\n", target, katanaBinary, strings.Join(args, " "))
 	}
 
-	cmd := exec.Command("bash", "-c", cmdLine)
+	cmd := exec.Command(katanaBinary, args...)
+	cmd.Stdin = strings.NewReader(target + "\n")
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/pkg/engine/common/base.go
+++ b/pkg/engine/common/base.go
@@ -121,7 +121,7 @@ func (s *Shared) Enqueue(queue *queue.Queue, navigationRequests ...*navigation.R
 			reqUrl = utils.FingerprintURL(reqUrl, s.PathTrie)
 		}
 
-		if s.Options.Options.AuthCredentials != "" && isLogoutURL(nr.URL) {
+		if (s.Options.Options.AuthCredentials != "" || s.Options.Options.RecordedFlow != "") && isLogoutURL(nr.URL) {
 			continue
 		}
 

--- a/pkg/engine/headless/auth/e2e_test.go
+++ b/pkg/engine/headless/auth/e2e_test.go
@@ -1,0 +1,161 @@
+package auth_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/launcher"
+	"github.com/go-rod/rod/lib/proto"
+	"github.com/projectdiscovery/katana/internal/testutils/authlab"
+	"github.com/projectdiscovery/katana/pkg/engine/headless/auth"
+	"github.com/stretchr/testify/require"
+)
+
+func skipIfNoBrowser(t *testing.T) {
+	t.Helper()
+	path, found := launcher.LookPath()
+	if !found {
+		t.Skip("chrome/chromium not found, skipping recorded-flow e2e")
+	}
+	_ = path
+}
+
+func launchPage(t *testing.T) (*rod.Browser, *rod.Page) {
+	t.Helper()
+	skipIfNoBrowser(t)
+
+	path, _ := launcher.LookPath()
+	u := launcher.New().
+		Bin(path).
+		Headless(true).
+		Leakless(true).
+		Set("no-sandbox", "true").
+		MustLaunch()
+	browser := rod.New().ControlURL(u).MustConnect()
+	t.Cleanup(browser.MustClose)
+
+	page, err := browser.Page(proto.TargetCreateTarget{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = page.Close() })
+	return browser, page
+}
+
+func writeFlow(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "flow.json")
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	return path
+}
+
+func assertSecretReachable(t *testing.T, page *rod.Page, lab *authlab.Lab) {
+	t.Helper()
+	require.NoError(t, page.Navigate(lab.URL+"/app/secret"))
+	require.NoError(t, page.WaitLoad())
+	html, err := page.HTML()
+	require.NoError(t, err)
+	require.Contains(t, html, authlab.SecretMarker, "session from recorded flow should unlock /app/secret")
+	require.GreaterOrEqual(t, lab.SecretHits.Load(), int64(1))
+}
+
+func TestE2E_RecordedFlow_SimpleFormLogin(t *testing.T) {
+	lab, err := authlab.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = lab.Close() })
+
+	_, page := launchPage(t)
+	path := writeFlow(t, authlab.ChromeRecordingSimple(lab.URL))
+
+	steps, err := auth.StepsFromFile(path, authlab.Username, authlab.Password)
+	require.NoError(t, err)
+	require.NotEmpty(t, steps)
+	require.True(t, auth.NeedsCredentials(steps))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	require.NoError(t, auth.RunLoginSteps(ctx, page, steps, authlab.Username, authlab.Password, 5*time.Second))
+	require.GreaterOrEqual(t, lab.LoginPosts.Load(), int64(1))
+	assertSecretReachable(t, page, lab)
+}
+
+func TestE2E_RecordedFlow_UsernameFirst(t *testing.T) {
+	lab, err := authlab.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = lab.Close() })
+
+	_, page := launchPage(t)
+	path := writeFlow(t, authlab.ChromeRecordingStep(lab.URL))
+
+	steps, err := auth.StepsFromFile(path, authlab.Username, authlab.Password)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	require.NoError(t, auth.RunLoginSteps(ctx, page, steps, authlab.Username, authlab.Password, 5*time.Second))
+	assertSecretReachable(t, page, lab)
+}
+
+func TestE2E_RecordedFlow_SPA(t *testing.T) {
+	lab, err := authlab.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = lab.Close() })
+
+	_, page := launchPage(t)
+	path := writeFlow(t, authlab.ChromeRecordingSPA(lab.URL))
+
+	steps, err := auth.StepsFromFile(path, authlab.Username, authlab.Password)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	require.NoError(t, auth.RunLoginSteps(ctx, page, steps, authlab.Username, authlab.Password, 5*time.Second))
+	assertSecretReachable(t, page, lab)
+}
+
+func TestE2E_RecordedFlow_ExplicitSteps(t *testing.T) {
+	lab, err := authlab.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = lab.Close() })
+
+	_, page := launchPage(t)
+	path := writeFlow(t, authlab.ExplicitStepsSimple(lab.URL))
+
+	steps, err := auth.StepsFromFile(path, authlab.Username, authlab.Password)
+	require.NoError(t, err)
+	require.Equal(t, "navigate", steps[0].Action)
+	require.Equal(t, "{{username}}", steps[1].Value)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	require.NoError(t, auth.RunLoginSteps(ctx, page, steps, authlab.Username, authlab.Password, 5*time.Second))
+	assertSecretReachable(t, page, lab)
+}
+
+func TestE2E_RecordedFlow_WrongPasswordDoesNotUnlockSecret(t *testing.T) {
+	lab, err := authlab.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = lab.Close() })
+
+	_, page := launchPage(t)
+	path := writeFlow(t, authlab.ChromeRecordingSimple(lab.URL))
+
+	steps, err := auth.StepsFromFile(path, authlab.Username, authlab.Password)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	// Replay with wrong password — form submit may "succeed" as clicks, but
+	// the session cookie must not be issued.
+	_ = auth.RunLoginSteps(ctx, page, steps, authlab.Username, "wrong-password", 5*time.Second)
+
+	require.NoError(t, page.Navigate(lab.URL+"/app/secret"))
+	_ = page.WaitLoad()
+	html, err := page.HTML()
+	require.NoError(t, err)
+	require.NotContains(t, html, authlab.SecretMarker)
+	require.Equal(t, int64(0), lab.SecretHits.Load())
+}

--- a/pkg/engine/headless/auth/e2e_test.go
+++ b/pkg/engine/headless/auth/e2e_test.go
@@ -17,11 +17,9 @@ import (
 
 func skipIfNoBrowser(t *testing.T) {
 	t.Helper()
-	path, found := launcher.LookPath()
-	if !found {
+	if path, found := launcher.LookPath(); !found || path == "" {
 		t.Skip("chrome/chromium not found, skipping recorded-flow e2e")
 	}
-	_ = path
 }
 
 func launchPage(t *testing.T) (*rod.Browser, *rod.Page) {
@@ -153,7 +151,7 @@ func TestE2E_RecordedFlow_WrongPasswordDoesNotUnlockSecret(t *testing.T) {
 	_ = auth.RunLoginSteps(ctx, page, steps, authlab.Username, "wrong-password", 5*time.Second)
 
 	require.NoError(t, page.Navigate(lab.URL+"/app/secret"))
-	_ = page.WaitLoad()
+	require.NoError(t, page.WaitLoad())
 	html, err := page.HTML()
 	require.NoError(t, err)
 	require.NotContains(t, html, authlab.SecretMarker)

--- a/pkg/engine/headless/auth/e2e_test.go
+++ b/pkg/engine/headless/auth/e2e_test.go
@@ -2,6 +2,9 @@ package auth_test
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -156,4 +159,93 @@ func TestE2E_RecordedFlow_WrongPasswordDoesNotUnlockSecret(t *testing.T) {
 	require.NoError(t, err)
 	require.NotContains(t, html, authlab.SecretMarker)
 	require.Equal(t, int64(0), lab.SecretHits.Load())
+}
+
+func TestE2E_RecordedFlow_LocalStorageSessionIsDetected(t *testing.T) {
+	_, page := launchPage(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = fmt.Fprint(w, `<button id="login" onclick="localStorage.setItem('access_token', 'opaque-token')">Login</button>`)
+	}))
+	t.Cleanup(server.Close)
+
+	require.NoError(t, page.Navigate(server.URL))
+	require.NoError(t, page.WaitLoad())
+	before, err := auth.CaptureSessionState(page)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	require.NoError(t, auth.RunLoginSteps(ctx, page, []auth.LoginStep{
+		{Action: "click", Selector: "#login"},
+	}, "", "", time.Second))
+
+	after, err := auth.CaptureSessionState(page)
+	require.NoError(t, err)
+	require.True(t, auth.SessionStateChanged(before, after),
+		"same-origin localStorage token should verify a cookie-less login")
+}
+
+func TestE2E_RecordedFlow_AllExplicitActions(t *testing.T) {
+	_, page := launchPage(t)
+	lab, err := authlab.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = lab.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	require.NoError(t, auth.RunLoginSteps(ctx, page, []auth.LoginStep{
+		{Action: "navigate", Value: lab.URL + "/login"},
+		{Action: "fill", Selector: "#email", Value: "{{username}}"},
+		{Action: "fill", Selector: "#password", Value: "{{password}}"},
+		{Action: "click", Selector: "#email"},
+		{Action: "doubleclick", Selector: "#email"},
+		{Action: "waitvisible", Selector: "#password"},
+		{Action: "press", Selector: "#password", Value: "tab"},
+		{Action: "wait", Value: "1ms"},
+		{Action: "submit", Selector: "#submit"},
+		{Action: "waitvisible", Selector: "h1"},
+	}, authlab.Username, authlab.Password, 2*time.Second))
+
+	cookies, err := page.Browser().GetCookies()
+	require.NoError(t, err)
+	foundSession := false
+	for _, cookie := range cookies {
+		if cookie.Name == authlab.CookieName && cookie.Value == authlab.CookieValue {
+			foundSession = true
+			break
+		}
+	}
+	require.True(t, foundSession)
+}
+
+func TestE2E_RecordedFlow_WaitHonorsCancellation(t *testing.T) {
+	_, page := launchPage(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	started := time.Now()
+	err := auth.RunLoginSteps(ctx, page, []auth.LoginStep{
+		{Action: "wait", Value: "10s"},
+	}, "", "", time.Second)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Less(t, time.Since(started), time.Second)
+}
+
+func TestE2E_RecordedFlow_NavigateHonorsCancellation(t *testing.T) {
+	_, page := launchPage(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(5 * time.Second)
+		_, _ = fmt.Fprint(w, "late")
+	}))
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	err := auth.RunLoginSteps(ctx, page, []auth.LoginStep{
+		{Action: "navigate", Value: server.URL},
+	}, "", "", 10*time.Second)
+	require.Error(t, err)
+	require.Less(t, time.Since(started), 2*time.Second)
 }

--- a/pkg/engine/headless/auth/recording.go
+++ b/pkg/engine/headless/auth/recording.go
@@ -201,10 +201,20 @@ func parameterizeValue(value, selector, username, password string) string {
 
 func looksLikePasswordSelector(selector string) bool {
 	s := strings.ToLower(selector)
-	return strings.Contains(s, "password") ||
-		strings.Contains(s, "passwd") ||
-		strings.Contains(s, "type=\"password\"") ||
-		strings.Contains(s, "type=password")
+	for _, marker := range []string{
+		"password",
+		"passwd",
+		"pwd",
+		"type=\"password\"",
+		"type=password",
+		"current-password",
+		"new-password",
+	} {
+		if strings.Contains(s, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 // pickSelector prefers native CSS, then XPath, then aria-label CSS, then text XPath.

--- a/pkg/engine/headless/auth/recording.go
+++ b/pkg/engine/headless/auth/recording.go
@@ -1,0 +1,263 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/projectdiscovery/utils/errkit"
+)
+
+// recordingFile is the Chrome DevTools Recorder / @puppeteer/replay export
+// schema. A user records their real login in Chrome (DevTools → Recorder) and
+// exports it as JSON; we compile it down to LoginSteps so multi-step / SSO
+// logins can be authored by recording instead of hand-writing selectors.
+type recordingFile struct {
+	Title string          `json:"title"`
+	Steps []recordingStep `json:"steps"`
+}
+
+// recordingStep is a single recorded user action. Selectors is a list of
+// alternative selector strategies; we pick the most engine-friendly candidate.
+type recordingStep struct {
+	Type       string     `json:"type"`
+	URL        string     `json:"url"`
+	Selectors  [][]string `json:"selectors"`
+	Value      string     `json:"value"`
+	Key        string     `json:"key"`
+	Target     string     `json:"target"`
+	Expression string     `json:"expression"`
+}
+
+// explicitFile is a hand-authored step list (same LoginStep shape as replay).
+type explicitFile struct {
+	Steps []LoginStep `json:"steps"`
+}
+
+// StepsFromFile loads either a Chrome DevTools Recorder export or an explicit
+// { "steps": [ { "action": ... } ] } JSON file.
+func StepsFromFile(path, username, password string) ([]LoginStep, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, errkit.Wrap(err, "recorded-flow: failed to read file")
+	}
+	return StepsFromData(data, username, password)
+}
+
+// StepsFromData converts a recording / explicit-step JSON payload into LoginSteps.
+func StepsFromData(data []byte, username, password string) ([]LoginStep, error) {
+	kind, err := detectStepFileKind(data)
+	if err != nil {
+		return nil, err
+	}
+	switch kind {
+	case stepFileChrome:
+		return StepsFromRecording(data, username, password)
+	case stepFileExplicit:
+		return StepsFromExplicit(data)
+	default:
+		return nil, errkit.New("recorded-flow: unsupported flow file format")
+	}
+}
+
+type stepFileKind int
+
+const (
+	stepFileUnknown stepFileKind = iota
+	stepFileChrome
+	stepFileExplicit
+)
+
+func detectStepFileKind(data []byte) (stepFileKind, error) {
+	var probe struct {
+		Steps []json.RawMessage `json:"steps"`
+	}
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return stepFileUnknown, errkit.Wrap(err, "recorded-flow: invalid json")
+	}
+	if len(probe.Steps) == 0 {
+		return stepFileUnknown, errkit.New("recorded-flow: flow contains no steps")
+	}
+	var first map[string]json.RawMessage
+	if err := json.Unmarshal(probe.Steps[0], &first); err != nil {
+		return stepFileUnknown, errkit.Wrap(err, "recorded-flow: invalid step")
+	}
+	if _, ok := first["type"]; ok {
+		return stepFileChrome, nil
+	}
+	if _, ok := first["action"]; ok {
+		return stepFileExplicit, nil
+	}
+	return stepFileUnknown, errkit.New("recorded-flow: steps must be Chrome Recorder (type) or explicit (action)")
+}
+
+// StepsFromExplicit loads a hand-authored LoginStep list.
+func StepsFromExplicit(data []byte) ([]LoginStep, error) {
+	var file explicitFile
+	if err := json.Unmarshal(data, &file); err != nil {
+		return nil, errkit.Wrap(err, "recorded-flow: invalid explicit steps json")
+	}
+	if len(file.Steps) == 0 {
+		return nil, errkit.New("recorded-flow: explicit steps list is empty")
+	}
+	for i, s := range file.Steps {
+		if strings.TrimSpace(s.Action) == "" {
+			return nil, errkit.Newf("recorded-flow: step %d missing action", i)
+		}
+	}
+	return file.Steps, nil
+}
+
+// StepsFromRecording converts a Chrome DevTools Recorder export into LoginSteps.
+// username/password are used to parameterize captured credential literals into
+// {{username}}/{{password}} placeholders.
+func StepsFromRecording(data []byte, username, password string) ([]LoginStep, error) {
+	var rec recordingFile
+	if err := json.Unmarshal(data, &rec); err != nil {
+		return nil, errkit.Wrap(err, "recorded-flow: invalid recording json")
+	}
+	if len(rec.Steps) == 0 {
+		return nil, errkit.New("recorded-flow: recording contains no steps")
+	}
+
+	var steps []LoginStep
+	for _, rs := range rec.Steps {
+		switch strings.ToLower(strings.TrimSpace(rs.Type)) {
+		case "navigate":
+			if rs.URL != "" {
+				steps = append(steps, LoginStep{Action: "navigate", Value: rs.URL})
+			}
+		case "click", "doubleclick":
+			sel := pickSelector(rs.Selectors)
+			if sel == "" {
+				continue
+			}
+			steps = append(steps, LoginStep{Action: "click", Selector: sel})
+		case "change":
+			sel := pickSelector(rs.Selectors)
+			if sel == "" {
+				continue
+			}
+			steps = append(steps, LoginStep{
+				Action:   "fill",
+				Selector: sel,
+				Value:    parameterizeValue(rs.Value, sel, username, password),
+			})
+		case "keydown":
+			// Character keys are captured by `change`; ignore paired keyUp.
+			if key := normalizeKey(rs.Key); key != "" {
+				steps = append(steps, LoginStep{Action: "press", Value: key, Selector: pickSelector(rs.Selectors)})
+			}
+		case "waitforelement":
+			sel := pickSelector(rs.Selectors)
+			if sel == "" {
+				continue
+			}
+			steps = append(steps, LoginStep{Action: "waitvisible", Selector: sel})
+		case "waitforexpression":
+			// Arbitrary expressions are not evaluated; settle instead.
+			steps = append(steps, LoginStep{Action: "wait"})
+		case "setviewport", "keyup", "scroll", "close", "emulatenetworkconditions", "hover", "":
+			continue
+		default:
+			continue
+		}
+	}
+
+	if len(steps) == 0 {
+		return nil, errkit.New("recorded-flow: recording produced no replayable steps")
+	}
+	return steps, nil
+}
+
+func normalizeKey(key string) string {
+	switch strings.ToLower(strings.TrimSpace(key)) {
+	case "enter", "return", "numpadenter":
+		return "enter"
+	case "tab":
+		return "tab"
+	case "escape", "esc":
+		return "escape"
+	case "space":
+		return "space"
+	default:
+		return ""
+	}
+}
+
+func parameterizeValue(value, selector, username, password string) string {
+	if password != "" && value == password {
+		return "{{password}}"
+	}
+	if username != "" && value == username {
+		return "{{username}}"
+	}
+	if looksLikePasswordSelector(selector) {
+		return "{{password}}"
+	}
+	return value
+}
+
+func looksLikePasswordSelector(selector string) bool {
+	s := strings.ToLower(selector)
+	return strings.Contains(s, "password") ||
+		strings.Contains(s, "passwd") ||
+		strings.Contains(s, "type=\"password\"") ||
+		strings.Contains(s, "type=password")
+}
+
+// pickSelector prefers native CSS, then XPath, then aria-label CSS, then text XPath.
+// Shadow-piercing (pierce/) selectors are skipped.
+func pickSelector(groups [][]string) string {
+	var css, xpath, aria, text string
+	for _, group := range groups {
+		for _, s := range group {
+			s = strings.TrimSpace(s)
+			switch {
+			case s == "":
+				continue
+			case strings.HasPrefix(s, "xpath/"):
+				if xpath == "" {
+					xpath = "xpath=" + strings.TrimPrefix(s, "xpath/")
+				}
+			case strings.HasPrefix(s, "aria/"):
+				if aria == "" {
+					aria = ariaToCSS(strings.TrimPrefix(s, "aria/"))
+				}
+			case strings.HasPrefix(s, "text/"):
+				if text == "" {
+					text = textToXPath(strings.TrimPrefix(s, "text/"))
+				}
+			case strings.HasPrefix(s, "pierce/"):
+				continue
+			default:
+				if css == "" {
+					css = s
+				}
+			}
+		}
+	}
+	for _, candidate := range []string{css, xpath, aria, text} {
+		if candidate != "" {
+			return candidate
+		}
+	}
+	return ""
+}
+
+func ariaToCSS(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" || strings.Contains(name, `"`) {
+		return ""
+	}
+	return fmt.Sprintf(`[aria-label="%s"]`, name)
+}
+
+func textToXPath(t string) string {
+	t = strings.TrimSpace(t)
+	if t == "" || strings.Contains(t, `"`) {
+		return ""
+	}
+	return fmt.Sprintf(`xpath=//*[contains(normalize-space(.), "%s")]`, t)
+}

--- a/pkg/engine/headless/auth/recording.go
+++ b/pkg/engine/headless/auth/recording.go
@@ -209,8 +209,6 @@ func looksLikeUsernameSelector(selector string) bool {
 		"user-name",
 		"email",
 		"e-mail",
-		"login",
-		"account",
 		"autocomplete=\"username\"",
 		"autocomplete=username",
 	} {

--- a/pkg/engine/headless/auth/recording.go
+++ b/pkg/engine/headless/auth/recording.go
@@ -101,10 +101,8 @@ func StepsFromExplicit(data []byte) ([]LoginStep, error) {
 	if len(file.Steps) == 0 {
 		return nil, errkit.New("recorded-flow: explicit steps list is empty")
 	}
-	for i, s := range file.Steps {
-		if strings.TrimSpace(s.Action) == "" {
-			return nil, errkit.Newf("recorded-flow: step %d missing action", i)
-		}
+	if err := ValidateSteps(file.Steps); err != nil {
+		return nil, err
 	}
 	return file.Steps, nil
 }
@@ -122,22 +120,24 @@ func StepsFromRecording(data []byte, username, password string) ([]LoginStep, er
 	}
 
 	var steps []LoginStep
-	for _, rs := range rec.Steps {
-		switch strings.ToLower(strings.TrimSpace(rs.Type)) {
+	for i, rs := range rec.Steps {
+		stepType := strings.ToLower(strings.TrimSpace(rs.Type))
+		switch stepType {
 		case "navigate":
-			if rs.URL != "" {
-				steps = append(steps, LoginStep{Action: "navigate", Value: rs.URL})
+			if strings.TrimSpace(rs.URL) == "" {
+				return nil, errkit.Newf("recorded-flow: recording step %d (navigate) missing URL", i)
 			}
+			steps = append(steps, LoginStep{Action: "navigate", Value: rs.URL})
 		case "click", "doubleclick":
 			sel := pickSelector(rs.Selectors)
 			if sel == "" {
-				continue
+				return nil, errkit.Newf("recorded-flow: recording step %d (%s) has no supported selector", i, stepType)
 			}
-			steps = append(steps, LoginStep{Action: "click", Selector: sel})
+			steps = append(steps, LoginStep{Action: stepType, Selector: sel})
 		case "change":
 			sel := pickSelector(rs.Selectors)
 			if sel == "" {
-				continue
+				return nil, errkit.Newf("recorded-flow: recording step %d (change) has no supported selector", i)
 			}
 			steps = append(steps, LoginStep{
 				Action:   "fill",
@@ -152,16 +152,16 @@ func StepsFromRecording(data []byte, username, password string) ([]LoginStep, er
 		case "waitforelement":
 			sel := pickSelector(rs.Selectors)
 			if sel == "" {
-				continue
+				return nil, errkit.Newf("recorded-flow: recording step %d (waitForElement) has no supported selector", i)
 			}
 			steps = append(steps, LoginStep{Action: "waitvisible", Selector: sel})
 		case "waitforexpression":
 			// Arbitrary expressions are not evaluated; settle instead.
 			steps = append(steps, LoginStep{Action: "wait"})
-		case "setviewport", "keyup", "scroll", "close", "emulatenetworkconditions", "hover", "":
+		case "setviewport", "keyup", "scroll", "close", "emulatenetworkconditions", "hover":
 			continue
 		default:
-			continue
+			return nil, errkit.Newf("recorded-flow: recording step %d has unsupported type %q", i, rs.Type)
 		}
 	}
 
@@ -196,7 +196,29 @@ func parameterizeValue(value, selector, username, password string) string {
 	if looksLikePasswordSelector(selector) {
 		return "{{password}}"
 	}
+	if looksLikeUsernameSelector(selector) {
+		return "{{username}}"
+	}
 	return value
+}
+
+func looksLikeUsernameSelector(selector string) bool {
+	s := strings.ToLower(selector)
+	for _, marker := range []string{
+		"username",
+		"user-name",
+		"email",
+		"e-mail",
+		"login",
+		"account",
+		"autocomplete=\"username\"",
+		"autocomplete=username",
+	} {
+		if strings.Contains(s, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 func looksLikePasswordSelector(selector string) bool {

--- a/pkg/engine/headless/auth/recording_test.go
+++ b/pkg/engine/headless/auth/recording_test.go
@@ -1,0 +1,109 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const chromeRecording = `{
+  "title": "login",
+  "steps": [
+    {"type": "setViewport", "width": 1280, "height": 720},
+    {"type": "navigate", "url": "https://app.example.com/login"},
+    {"type": "change", "value": "dave@example.com", "selectors": [["#email"], ["aria/Email"], ["xpath///*[@id=\"email\"]"]]},
+    {"type": "click", "selectors": [["#next"], ["aria/Next"]]},
+    {"type": "waitForElement", "selectors": [["#password"]]},
+    {"type": "change", "value": "p@ss", "selectors": [["#password"]]},
+    {"type": "keyDown", "key": "Enter"},
+    {"type": "keyUp", "key": "Enter"},
+    {"type": "click", "selectors": [["#submit"]]}
+  ]
+}`
+
+func TestStepsFromRecording_MapsAndParameterizes(t *testing.T) {
+	steps, err := StepsFromRecording([]byte(chromeRecording), "dave@example.com", "p@ss")
+	require.NoError(t, err)
+
+	require.Equal(t, []LoginStep{
+		{Action: "navigate", Value: "https://app.example.com/login"},
+		{Action: "fill", Selector: "#email", Value: "{{username}}"},
+		{Action: "click", Selector: "#next"},
+		{Action: "waitvisible", Selector: "#password"},
+		{Action: "fill", Selector: "#password", Value: "{{password}}"},
+		{Action: "press", Value: "enter"},
+		{Action: "click", Selector: "#submit"},
+	}, steps)
+}
+
+func TestStepsFromRecording_PasswordSelectorMaskedWithoutCredMatch(t *testing.T) {
+	rec := `{"steps": [
+		{"type": "change", "value": "literal-secret", "selectors": [["input[type=password]"]]}
+	]}`
+	steps, err := StepsFromRecording([]byte(rec), "", "")
+	require.NoError(t, err)
+	require.Len(t, steps, 1)
+	require.Equal(t, "{{password}}", steps[0].Value)
+}
+
+func TestStepsFromRecording_SelectorPriority(t *testing.T) {
+	rec := `{"steps": [
+		{"type": "click", "selectors": [["aria/Save"], ["xpath///button[1]"], ["#real"]]},
+		{"type": "click", "selectors": [["pierce/#shadow"], ["xpath///div[2]"]]},
+		{"type": "click", "selectors": [["aria/Submit"]]}
+	]}`
+	steps, err := StepsFromRecording([]byte(rec), "", "")
+	require.NoError(t, err)
+	require.Equal(t, "#real", steps[0].Selector)
+	require.Equal(t, "xpath=//div[2]", steps[1].Selector)
+	require.Equal(t, `[aria-label="Submit"]`, steps[2].Selector)
+}
+
+func TestStepsFromRecording_Errors(t *testing.T) {
+	_, err := StepsFromRecording([]byte(`not json`), "", "")
+	require.Error(t, err)
+
+	_, err = StepsFromRecording([]byte(`{"steps": []}`), "", "")
+	require.Error(t, err)
+
+	_, err = StepsFromRecording([]byte(`{"steps": [{"type":"setViewport"}]}`), "", "")
+	require.Error(t, err)
+}
+
+func TestFirstNavigateURL(t *testing.T) {
+	steps := []LoginStep{
+		{Action: "fill", Selector: "#x"},
+		{Action: "navigate", Value: "https://app.example.com/login"},
+		{Action: "navigate", Value: "https://second"},
+	}
+	require.Equal(t, "https://app.example.com/login", FirstNavigateURL(steps))
+	require.Equal(t, "", FirstNavigateURL([]LoginStep{{Action: "click"}}))
+}
+
+func TestStepsFromData_Explicit(t *testing.T) {
+	raw := `{
+		"steps": [
+			{"action": "navigate", "value": "https://app.example.com/login"},
+			{"action": "fill", "selector": "#email", "value": "{{username}}"},
+			{"action": "fill", "selector": "#password", "value": "{{password}}"},
+			{"action": "click", "selector": "#submit"}
+		]
+	}`
+	steps, err := StepsFromData([]byte(raw), "u", "p")
+	require.NoError(t, err)
+	require.Len(t, steps, 4)
+	require.Equal(t, "fill", steps[1].Action)
+	require.True(t, NeedsCredentials(steps))
+}
+
+func TestStepsFromData_Chrome(t *testing.T) {
+	steps, err := StepsFromData([]byte(chromeRecording), "dave@example.com", "p@ss")
+	require.NoError(t, err)
+	require.NotEmpty(t, steps)
+	require.Equal(t, "navigate", steps[0].Action)
+}
+
+func TestNeedsCredentials(t *testing.T) {
+	require.False(t, NeedsCredentials([]LoginStep{{Action: "click", Selector: "#x"}}))
+	require.True(t, NeedsCredentials([]LoginStep{{Action: "fill", Value: "{{password}}"}}))
+}

--- a/pkg/engine/headless/auth/recording_test.go
+++ b/pkg/engine/headless/auth/recording_test.go
@@ -46,6 +46,17 @@ func TestStepsFromRecording_PasswordSelectorMaskedWithoutCredMatch(t *testing.T)
 	require.Equal(t, "{{password}}", steps[0].Value)
 }
 
+func TestStepsFromRecording_UsernameSelectorUsesConfiguredCredential(t *testing.T) {
+	rec := `{"steps": [
+		{"type": "change", "value": "recorded-old-user", "selectors": [["input[name=email]"]]}
+	]}`
+	steps, err := StepsFromRecording([]byte(rec), "new-user@example.com", "new-password")
+	require.NoError(t, err)
+	require.Equal(t, "{{username}}", steps[0].Value)
+	require.Equal(t, "new-user@example.com",
+		ExpandCredentials(steps[0].Value, "new-user@example.com", "new-password"))
+}
+
 func TestStepsFromRecording_SelectorPriority(t *testing.T) {
 	rec := `{"steps": [
 		{"type": "click", "selectors": [["aria/Save"], ["xpath///button[1]"], ["#real"]]},
@@ -68,16 +79,41 @@ func TestStepsFromRecording_Errors(t *testing.T) {
 
 	_, err = StepsFromRecording([]byte(`{"steps": [{"type":"setViewport"}]}`), "", "")
 	require.Error(t, err)
+
+	_, err = StepsFromRecording([]byte(`{"steps": [{"type":"click","selectors":[]}]}`), "", "")
+	require.ErrorContains(t, err, "no supported selector")
+
+	_, err = StepsFromRecording([]byte(`{"steps": [{"type":"evaluate","expression":"alert(1)"}]}`), "", "")
+	require.ErrorContains(t, err, "unsupported type")
+
+	_, err = StepsFromData([]byte(`{"steps": [
+		{"type":"navigate","url":"https://example.com"},
+		{"action":"click","selector":"#submit"}
+	]}`), "", "")
+	require.ErrorContains(t, err, "unsupported type")
+}
+
+func TestStepsFromRecording_PreservesDoubleClick(t *testing.T) {
+	steps, err := StepsFromRecording([]byte(`{"steps": [
+		{"type":"doubleClick","selectors":[["#continue"]]}
+	]}`), "", "")
+	require.NoError(t, err)
+	require.Equal(t, []LoginStep{{Action: "doubleclick", Selector: "#continue"}}, steps)
 }
 
 func TestFirstNavigateURL(t *testing.T) {
 	steps := []LoginStep{
+		{Action: "navigate", Value: "about:blank"},
 		{Action: "fill", Selector: "#x"},
 		{Action: "navigate", Value: "https://app.example.com/login"},
 		{Action: "navigate", Value: "https://second"},
 	}
 	require.Equal(t, "https://app.example.com/login", FirstNavigateURL(steps))
 	require.Equal(t, "", FirstNavigateURL([]LoginStep{{Action: "click"}}))
+
+	remaining, navigateURL := StepsAfterFirstNavigateURL(steps)
+	require.Equal(t, "https://app.example.com/login", navigateURL)
+	require.Equal(t, []LoginStep{{Action: "navigate", Value: "https://second"}}, remaining)
 }
 
 func TestStepsFromData_Explicit(t *testing.T) {
@@ -106,4 +142,46 @@ func TestStepsFromData_Chrome(t *testing.T) {
 func TestNeedsCredentials(t *testing.T) {
 	require.False(t, NeedsCredentials([]LoginStep{{Action: "click", Selector: "#x"}}))
 	require.True(t, NeedsCredentials([]LoginStep{{Action: "fill", Value: "{{password}}"}}))
+}
+
+func TestValidateSteps(t *testing.T) {
+	valid := []LoginStep{
+		{Action: "navigate", Value: "https://example.com/login"},
+		{Action: "fill", Selector: "#email", Value: "{{username}}"},
+		{Action: "press", Value: "enter"},
+		{Action: "wait", Value: "250ms"},
+		{Action: "submit"},
+	}
+	require.NoError(t, ValidateSteps(valid))
+
+	tests := []struct {
+		name string
+		step LoginStep
+		want string
+	}{
+		{name: "unknown action", step: LoginStep{Action: "eval"}, want: "unknown action"},
+		{name: "missing selector", step: LoginStep{Action: "fill"}, want: "missing selector"},
+		{name: "missing url", step: LoginStep{Action: "navigate"}, want: "missing URL"},
+		{name: "invalid key", step: LoginStep{Action: "press", Value: "delete"}, want: "unsupported key"},
+		{name: "invalid wait", step: LoginStep{Action: "wait", Value: "later"}, want: "invalid duration"},
+		{name: "negative wait", step: LoginStep{Action: "wait", Value: "-1s"}, want: "invalid duration"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.ErrorContains(t, ValidateSteps([]LoginStep{test.step}), test.want)
+		})
+	}
+	require.ErrorContains(t, ValidateSteps(nil), "no steps")
+}
+
+func TestHasTerminalVisibleAssertion(t *testing.T) {
+	require.True(t, HasTerminalVisibleAssertion([]LoginStep{
+		{Action: "click", Selector: "#submit"},
+		{Action: "waitvisible", Selector: "#dashboard"},
+	}))
+	require.False(t, HasTerminalVisibleAssertion([]LoginStep{
+		{Action: "waitvisible", Selector: "#password"},
+		{Action: "click", Selector: "#submit"},
+	}))
+	require.False(t, HasTerminalVisibleAssertion(nil))
 }

--- a/pkg/engine/headless/auth/recording_test.go
+++ b/pkg/engine/headless/auth/recording_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -55,6 +56,22 @@ func TestStepsFromRecording_UsernameSelectorUsesConfiguredCredential(t *testing.
 	require.Equal(t, "{{username}}", steps[0].Value)
 	require.Equal(t, "new-user@example.com",
 		ExpandCredentials(steps[0].Value, "new-user@example.com", "new-password"))
+}
+
+func TestStepsFromRecording_GenericSelectorsKeepRecordedValue(t *testing.T) {
+	for name, selector := range map[string]string{
+		"account number": `input[name="account-number"]`,
+		"login code":     "#login-code",
+	} {
+		t.Run(name, func(t *testing.T) {
+			rec := `{"steps": [
+				{"type": "change", "value": "12345", "selectors": [[` + strconv.Quote(selector) + `]]}
+			]}`
+			steps, err := StepsFromRecording([]byte(rec), "user@example.com", "secret")
+			require.NoError(t, err)
+			require.Equal(t, "12345", steps[0].Value)
+		})
+	}
 }
 
 func TestStepsFromRecording_SelectorPriority(t *testing.T) {

--- a/pkg/engine/headless/auth/replay.go
+++ b/pkg/engine/headless/auth/replay.go
@@ -91,7 +91,17 @@ func RunLoginSteps(ctx context.Context, page *rod.Page, steps []LoginStep, usern
 				return errkit.Wrapf(err, "recorded-flow step %d (press): failed", i)
 			}
 		case "submit":
-			if err := submitForm(page, findVisible(page, `input[type="password"]`), settle); err != nil {
+			fallback := findVisible(page, `input[type="password"]`)
+			if step.Selector != "" {
+				if el := findVisible(page, byName(step.Selector), step.Selector); el != nil {
+					fallback = el
+					_ = el.ScrollIntoView()
+					if err := el.Click(proto.InputMouseButtonLeft, 1); err == nil {
+						break
+					}
+				}
+			}
+			if err := submitForm(page, fallback, settle); err != nil {
 				return errkit.Wrapf(err, "recorded-flow step %d (submit)", i)
 			}
 		default:

--- a/pkg/engine/headless/auth/replay.go
+++ b/pkg/engine/headless/auth/replay.go
@@ -1,0 +1,210 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/input"
+	"github.com/go-rod/rod/lib/proto"
+	"github.com/projectdiscovery/utils/errkit"
+)
+
+// defaultSettle is how long to wait for the page to stabilize between steps.
+const defaultSettle = 5 * time.Second
+
+// RunLoginSteps replays an explicit multi-step login flow against a rod page.
+// Cookies / storage set during replay remain on the browser context for the
+// subsequent crawl. settle bounds waitvisible / inter-step WaitStable; zero
+// uses a 5s default.
+func RunLoginSteps(ctx context.Context, page *rod.Page, steps []LoginStep, username, password string, settle time.Duration) error {
+	if page == nil {
+		return errkit.New("recorded-flow: page is nil")
+	}
+	if len(steps) == 0 {
+		return errkit.New("recorded-flow: no steps to replay")
+	}
+	if settle <= 0 {
+		settle = defaultSettle
+	}
+
+	for i, step := range steps {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		action := strings.ToLower(strings.TrimSpace(step.Action))
+		switch action {
+		case "navigate":
+			if err := page.Navigate(step.Value); err != nil {
+				return errkit.Wrapf(err, "recorded-flow step %d (navigate): failed", i)
+			}
+			_ = page.WaitLoad()
+		case "fill", "input", "type":
+			el := findVisible(page, byName(step.Selector), step.Selector)
+			if el == nil {
+				return errkit.Newf("recorded-flow step %d (fill): element not found: %s", i, step.Selector)
+			}
+			if err := typeInto(el, ExpandCredentials(step.Value, username, password)); err != nil {
+				return errkit.Wrapf(err, "recorded-flow step %d (fill): failed", i)
+			}
+		case "click":
+			el := findVisible(page, step.Selector)
+			if el == nil {
+				return errkit.Newf("recorded-flow step %d (click): element not found: %s", i, step.Selector)
+			}
+			_ = el.ScrollIntoView()
+			if err := el.Click(proto.InputMouseButtonLeft, 1); err != nil {
+				return errkit.Wrapf(err, "recorded-flow step %d (click): failed", i)
+			}
+		case "waitvisible":
+			if err := waitVisible(ctx, page, step.Selector, settle); err != nil {
+				return errkit.Wrapf(err, "recorded-flow step %d (waitvisible)", i)
+			}
+		case "wait":
+			d := settle
+			if step.Value != "" {
+				if pd, perr := time.ParseDuration(step.Value); perr == nil {
+					d = pd
+				}
+			}
+			select {
+			case <-time.After(d):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		case "press":
+			key, kerr := keyFromName(step.Value)
+			if kerr != nil {
+				return errkit.Wrapf(kerr, "recorded-flow step %d (press)", i)
+			}
+			if step.Selector != "" {
+				el := findVisible(page, byName(step.Selector), step.Selector)
+				if el == nil {
+					return errkit.Newf("recorded-flow step %d (press): element not found: %s", i, step.Selector)
+				}
+				if err := el.Type(key); err != nil {
+					return errkit.Wrapf(err, "recorded-flow step %d (press): failed", i)
+				}
+			} else if err := page.Keyboard.Type(key); err != nil {
+				return errkit.Wrapf(err, "recorded-flow step %d (press): failed", i)
+			}
+		case "submit":
+			if err := submitForm(page, findVisible(page, `input[type="password"]`), settle); err != nil {
+				return errkit.Wrapf(err, "recorded-flow step %d (submit)", i)
+			}
+		default:
+			return errkit.Newf("recorded-flow step %d: unknown action %q", i, step.Action)
+		}
+		_ = rod.Try(func() { page.Timeout(settle).MustWaitStable() })
+	}
+	return nil
+}
+
+func keyFromName(name string) (input.Key, error) {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "", "enter", "return":
+		return input.Enter, nil
+	case "tab":
+		return input.Tab, nil
+	case "escape", "esc":
+		return input.Escape, nil
+	case "space":
+		return input.Space, nil
+	default:
+		return 0, errkit.Newf("unsupported key %q (supported: enter, tab, escape, space)", name)
+	}
+}
+
+func waitVisible(ctx context.Context, page *rod.Page, selector string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if findVisible(page, selector) != nil {
+			return nil
+		}
+		select {
+		case <-time.After(150 * time.Millisecond):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return errkit.Newf("timeout waiting for element to become visible: %s", selector)
+}
+
+func submitForm(page *rod.Page, fallbackField *rod.Element, settle time.Duration) error {
+	clickTimeout := settle
+	if clickTimeout <= 0 {
+		clickTimeout = 5 * time.Second
+	}
+	if btn := findVisible(page, `button[type="submit"]`, `input[type="submit"]`, `button:not([type])`, `[role="button"]`); btn != nil {
+		clickErr := rod.Try(func() {
+			b := btn.Timeout(clickTimeout)
+			b.MustWaitInteractable()
+			_ = b.ScrollIntoView()
+			b.MustClick()
+		})
+		if clickErr == nil {
+			return nil
+		}
+		if fallbackField == nil {
+			return errkit.Wrapf(clickErr, "recorded-flow: submit button never became interactable")
+		}
+	}
+	if fallbackField != nil {
+		if err := fallbackField.Type(input.Enter); err != nil {
+			return errkit.Wrap(err, "recorded-flow: failed to submit form")
+		}
+		return nil
+	}
+	return errkit.New("recorded-flow: no submit control found and no field to submit")
+}
+
+func byName(name string) string {
+	if name == "" || strings.HasPrefix(name, "xpath=") || strings.HasPrefix(name, "//") || strings.HasPrefix(name, "(//") {
+		return ""
+	}
+	// Avoid wrapping an already-qualified CSS selector as input[name=...].
+	if strings.ContainsAny(name, "#[.[:") {
+		return ""
+	}
+	return fmt.Sprintf(`input[name=%q]`, name)
+}
+
+func findVisible(page *rod.Page, selectors ...string) *rod.Element {
+	for _, sel := range selectors {
+		if sel == "" {
+			continue
+		}
+		els, err := queryElements(page, sel)
+		if err != nil {
+			continue
+		}
+		for _, el := range els {
+			if vis, verr := el.Visible(); verr == nil && vis {
+				return el
+			}
+		}
+	}
+	return nil
+}
+
+func queryElements(page *rod.Page, sel string) (rod.Elements, error) {
+	switch {
+	case strings.HasPrefix(sel, "xpath="):
+		return page.ElementsX(strings.TrimPrefix(sel, "xpath="))
+	case strings.HasPrefix(sel, "//"), strings.HasPrefix(sel, "(//"):
+		return page.ElementsX(sel)
+	default:
+		return page.Elements(sel)
+	}
+}
+
+func typeInto(el *rod.Element, text string) error {
+	_ = el.ScrollIntoView()
+	if err := el.Focus(); err != nil {
+		return err
+	}
+	_ = el.SelectAllText()
+	return el.Input(text)
+}

--- a/pkg/engine/headless/auth/replay.go
+++ b/pkg/engine/headless/auth/replay.go
@@ -34,15 +34,22 @@ func RunLoginSteps(ctx context.Context, page *rod.Page, steps []LoginStep, usern
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		stepPage := page.Context(ctx).Timeout(settle)
+		// Bind rod operations to ctx so cancellation is honored mid-step. The
+		// settle budget bounds waits only: element interaction on a loaded CI
+		// machine can take longer than a wait is allowed to.
+		stepPage := page.Context(ctx)
 		action := strings.ToLower(strings.TrimSpace(step.Action))
 		switch action {
 		case "navigate":
 			if err := stepPage.Navigate(step.Value); err != nil {
 				return errkit.Wrapf(err, "recorded-flow step %d (navigate): failed", i)
 			}
-			if err := stepPage.WaitLoad(); err != nil {
-				return errkit.Wrapf(err, "recorded-flow step %d (navigate): page did not load", i)
+			if err := stepPage.Timeout(settle).WaitLoad(); err != nil {
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return ctxErr
+				}
+				// A page that never fires load can still be interactable, so
+				// the following steps decide whether the flow really broke.
 			}
 		case "fill", "input", "type":
 			el := findVisible(stepPage, byName(step.Selector), step.Selector)
@@ -114,7 +121,7 @@ func RunLoginSteps(ctx context.Context, page *rod.Page, steps []LoginStep, usern
 		default:
 			return errkit.Newf("recorded-flow step %d: unknown action %q", i, step.Action)
 		}
-		_ = rod.Try(func() { stepPage.MustWaitStable() })
+		_ = rod.Try(func() { stepPage.Timeout(settle).MustWaitStable() })
 	}
 	return nil
 }

--- a/pkg/engine/headless/auth/replay.go
+++ b/pkg/engine/headless/auth/replay.go
@@ -23,8 +23,8 @@ func RunLoginSteps(ctx context.Context, page *rod.Page, steps []LoginStep, usern
 	if page == nil {
 		return errkit.New("recorded-flow: page is nil")
 	}
-	if len(steps) == 0 {
-		return errkit.New("recorded-flow: no steps to replay")
+	if err := ValidateSteps(steps); err != nil {
+		return err
 	}
 	if settle <= 0 {
 		settle = defaultSettle
@@ -34,32 +34,39 @@ func RunLoginSteps(ctx context.Context, page *rod.Page, steps []LoginStep, usern
 		if err := ctx.Err(); err != nil {
 			return err
 		}
+		stepPage := page.Context(ctx).Timeout(settle)
 		action := strings.ToLower(strings.TrimSpace(step.Action))
 		switch action {
 		case "navigate":
-			if err := page.Navigate(step.Value); err != nil {
+			if err := stepPage.Navigate(step.Value); err != nil {
 				return errkit.Wrapf(err, "recorded-flow step %d (navigate): failed", i)
 			}
-			_ = page.WaitLoad()
+			if err := stepPage.WaitLoad(); err != nil {
+				return errkit.Wrapf(err, "recorded-flow step %d (navigate): page did not load", i)
+			}
 		case "fill", "input", "type":
-			el := findVisible(page, byName(step.Selector), step.Selector)
+			el := findVisible(stepPage, byName(step.Selector), step.Selector)
 			if el == nil {
 				return errkit.Newf("recorded-flow step %d (fill): element not found: %s", i, step.Selector)
 			}
 			if err := typeInto(el, ExpandCredentials(step.Value, username, password)); err != nil {
 				return errkit.Wrapf(err, "recorded-flow step %d (fill): failed", i)
 			}
-		case "click":
-			el := findVisible(page, step.Selector)
+		case "click", "doubleclick":
+			el := findVisible(stepPage, step.Selector)
 			if el == nil {
-				return errkit.Newf("recorded-flow step %d (click): element not found: %s", i, step.Selector)
+				return errkit.Newf("recorded-flow step %d (%s): element not found: %s", i, action, step.Selector)
 			}
 			_ = el.ScrollIntoView()
-			if err := el.Click(proto.InputMouseButtonLeft, 1); err != nil {
-				return errkit.Wrapf(err, "recorded-flow step %d (click): failed", i)
+			clickCount := 1
+			if action == "doubleclick" {
+				clickCount = 2
+			}
+			if err := el.Click(proto.InputMouseButtonLeft, clickCount); err != nil {
+				return errkit.Wrapf(err, "recorded-flow step %d (%s): failed", i, action)
 			}
 		case "waitvisible":
-			if err := waitVisible(ctx, page, step.Selector, settle); err != nil {
+			if err := waitVisible(ctx, stepPage, step.Selector, settle); err != nil {
 				return errkit.Wrapf(err, "recorded-flow step %d (waitvisible)", i)
 			}
 		case "wait":
@@ -80,20 +87,20 @@ func RunLoginSteps(ctx context.Context, page *rod.Page, steps []LoginStep, usern
 				return errkit.Wrapf(kerr, "recorded-flow step %d (press)", i)
 			}
 			if step.Selector != "" {
-				el := findVisible(page, byName(step.Selector), step.Selector)
+				el := findVisible(stepPage, byName(step.Selector), step.Selector)
 				if el == nil {
 					return errkit.Newf("recorded-flow step %d (press): element not found: %s", i, step.Selector)
 				}
 				if err := el.Type(key); err != nil {
 					return errkit.Wrapf(err, "recorded-flow step %d (press): failed", i)
 				}
-			} else if err := page.Keyboard.Type(key); err != nil {
+			} else if err := stepPage.Keyboard.Type(key); err != nil {
 				return errkit.Wrapf(err, "recorded-flow step %d (press): failed", i)
 			}
 		case "submit":
-			fallback := findVisible(page, `input[type="password"]`)
+			fallback := findVisible(stepPage, `input[type="password"]`)
 			if step.Selector != "" {
-				if el := findVisible(page, byName(step.Selector), step.Selector); el != nil {
+				if el := findVisible(stepPage, byName(step.Selector), step.Selector); el != nil {
 					fallback = el
 					_ = el.ScrollIntoView()
 					if err := el.Click(proto.InputMouseButtonLeft, 1); err == nil {
@@ -101,13 +108,13 @@ func RunLoginSteps(ctx context.Context, page *rod.Page, steps []LoginStep, usern
 					}
 				}
 			}
-			if err := submitForm(page, fallback, settle); err != nil {
+			if err := submitForm(stepPage, fallback, settle); err != nil {
 				return errkit.Wrapf(err, "recorded-flow step %d (submit)", i)
 			}
 		default:
 			return errkit.Newf("recorded-flow step %d: unknown action %q", i, step.Action)
 		}
-		_ = rod.Try(func() { page.Timeout(settle).MustWaitStable() })
+		_ = rod.Try(func() { stepPage.MustWaitStable() })
 	}
 	return nil
 }

--- a/pkg/engine/headless/auth/session.go
+++ b/pkg/engine/headless/auth/session.go
@@ -22,6 +22,9 @@ type SessionState struct {
 	Origin         string
 	LocalStorage   string
 	SessionStorage string
+	// StorageCaptured distinguishes empty storage from a failed read, so a
+	// failed read is never mistaken for storage having changed.
+	StorageCaptured bool
 }
 
 // CaptureCookieState snapshots cookie values without exposing them to logs.
@@ -81,6 +84,7 @@ func CaptureSessionState(page *rod.Page) (SessionState, error) {
 		if json.Unmarshal([]byte(raw), &storage) == nil {
 			state.LocalStorage = string(storage.Local)
 			state.SessionStorage = string(storage.Session)
+			state.StorageCaptured = true
 		}
 	}
 	return state, nil
@@ -93,5 +97,6 @@ func SessionStateChanged(before, after SessionState) bool {
 	}
 	return before.Origin != "" &&
 		before.Origin == after.Origin &&
+		before.StorageCaptured && after.StorageCaptured &&
 		(before.LocalStorage != after.LocalStorage || before.SessionStorage != after.SessionStorage)
 }

--- a/pkg/engine/headless/auth/session.go
+++ b/pkg/engine/headless/auth/session.go
@@ -1,0 +1,97 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/go-rod/rod"
+	"github.com/projectdiscovery/utils/errkit"
+)
+
+// CookieState is a browser-wide snapshot used to verify that a login changed
+// authentication state. Cookies are browser-wide because SSO flows can finish
+// on a different origin from the application login page.
+type CookieState map[string]string
+
+// SessionState captures the browser state commonly used to persist web
+// authentication. Storage is compared only while the flow remains on the same
+// origin; cookies are browser-wide and cover cross-origin SSO redirects.
+type SessionState struct {
+	Cookies        CookieState
+	Origin         string
+	LocalStorage   string
+	SessionStorage string
+}
+
+// CaptureCookieState snapshots cookie values without exposing them to logs.
+func CaptureCookieState(page *rod.Page) (CookieState, error) {
+	if page == nil {
+		return nil, errkit.New("recorded-flow: page is nil")
+	}
+	cookies, err := page.Browser().GetCookies()
+	if err != nil {
+		return nil, errkit.Wrap(err, "recorded-flow: failed to inspect session cookies")
+	}
+	state := make(CookieState, len(cookies))
+	for _, cookie := range cookies {
+		if cookie == nil {
+			continue
+		}
+		key := fmt.Sprintf("%s\x00%s\x00%s", cookie.Domain, cookie.Path, cookie.Name)
+		state[key] = cookie.Value
+	}
+	return state, nil
+}
+
+// CookieStateChanged reports whether a cookie was added or its value changed.
+// Deletions alone do not prove authentication.
+func CookieStateChanged(before, after CookieState) bool {
+	for key, value := range after {
+		if previous, ok := before[key]; !ok || previous != value {
+			return true
+		}
+	}
+	return false
+}
+
+// CaptureSessionState snapshots cookies plus same-origin web storage.
+func CaptureSessionState(page *rod.Page) (SessionState, error) {
+	cookies, err := CaptureCookieState(page)
+	if err != nil {
+		return SessionState{}, err
+	}
+	state := SessionState{Cookies: cookies}
+	if info, infoErr := page.Info(); infoErr == nil {
+		if parsed, parseErr := url.Parse(info.URL); parseErr == nil {
+			state.Origin = parsed.Scheme + "://" + parsed.Host
+		}
+	}
+	// Storage can be unavailable on opaque/security-restricted origins. Cookie
+	// verification remains useful, so an evaluation error is not fatal.
+	if value, evalErr := page.Eval(`() => JSON.stringify({
+		local: Object.entries(localStorage).sort(),
+		session: Object.entries(sessionStorage).sort()
+	})`); evalErr == nil && value != nil {
+		var storage struct {
+			Local   json.RawMessage `json:"local"`
+			Session json.RawMessage `json:"session"`
+		}
+		raw := value.Value.Str()
+		if json.Unmarshal([]byte(raw), &storage) == nil {
+			state.LocalStorage = string(storage.Local)
+			state.SessionStorage = string(storage.Session)
+		}
+	}
+	return state, nil
+}
+
+// SessionStateChanged reports evidence that replay established browser auth.
+func SessionStateChanged(before, after SessionState) bool {
+	if CookieStateChanged(before.Cookies, after.Cookies) {
+		return true
+	}
+	return before.Origin != "" &&
+		before.Origin == after.Origin &&
+		(before.LocalStorage != after.LocalStorage || before.SessionStorage != after.SessionStorage)
+}

--- a/pkg/engine/headless/auth/session_test.go
+++ b/pkg/engine/headless/auth/session_test.go
@@ -1,0 +1,74 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCookieStateChanged(t *testing.T) {
+	t.Run("added cookie proves a session change", func(t *testing.T) {
+		require.True(t, CookieStateChanged(
+			CookieState{"csrf": "before"},
+			CookieState{"csrf": "before", "session": "authenticated"},
+		))
+	})
+
+	t.Run("changed cookie proves a session change", func(t *testing.T) {
+		require.True(t, CookieStateChanged(
+			CookieState{"session": "anonymous"},
+			CookieState{"session": "authenticated"},
+		))
+	})
+
+	t.Run("unchanged anonymous cookie is not authentication", func(t *testing.T) {
+		require.False(t, CookieStateChanged(
+			CookieState{"csrf": "same"},
+			CookieState{"csrf": "same"},
+		))
+	})
+
+	t.Run("unchanged preexisting session is not replay proof", func(t *testing.T) {
+		require.False(t, CookieStateChanged(
+			CookieState{"session": "already-present"},
+			CookieState{"session": "already-present"},
+		))
+	})
+
+	t.Run("cookie deletion alone is not authentication", func(t *testing.T) {
+		require.False(t, CookieStateChanged(
+			CookieState{"csrf": "before"},
+			CookieState{},
+		))
+	})
+}
+
+func TestSessionStateChanged(t *testing.T) {
+	t.Run("same-origin local storage supports token login", func(t *testing.T) {
+		require.True(t, SessionStateChanged(
+			SessionState{Origin: "https://app.example", LocalStorage: "[]"},
+			SessionState{Origin: "https://app.example", LocalStorage: `[["token","opaque"]]`},
+		))
+	})
+
+	t.Run("same-origin session storage supports token login", func(t *testing.T) {
+		require.True(t, SessionStateChanged(
+			SessionState{Origin: "https://app.example", SessionStorage: "[]"},
+			SessionState{Origin: "https://app.example", SessionStorage: `[["token","opaque"]]`},
+		))
+	})
+
+	t.Run("cross-origin storage is not proof", func(t *testing.T) {
+		require.False(t, SessionStateChanged(
+			SessionState{Origin: "https://idp.example", LocalStorage: "[]"},
+			SessionState{Origin: "https://app.example", LocalStorage: `[["theme","dark"]]`},
+		))
+	})
+
+	t.Run("cookie proof works across origins", func(t *testing.T) {
+		require.True(t, SessionStateChanged(
+			SessionState{Origin: "https://idp.example", Cookies: CookieState{}},
+			SessionState{Origin: "https://app.example", Cookies: CookieState{"app-session": "ok"}},
+		))
+	})
+}

--- a/pkg/engine/headless/auth/session_test.go
+++ b/pkg/engine/headless/auth/session_test.go
@@ -46,22 +46,29 @@ func TestCookieStateChanged(t *testing.T) {
 func TestSessionStateChanged(t *testing.T) {
 	t.Run("same-origin local storage supports token login", func(t *testing.T) {
 		require.True(t, SessionStateChanged(
-			SessionState{Origin: "https://app.example", LocalStorage: "[]"},
-			SessionState{Origin: "https://app.example", LocalStorage: `[["token","opaque"]]`},
+			SessionState{Origin: "https://app.example", LocalStorage: "[]", StorageCaptured: true},
+			SessionState{Origin: "https://app.example", LocalStorage: `[["token","opaque"]]`, StorageCaptured: true},
 		))
 	})
 
 	t.Run("same-origin session storage supports token login", func(t *testing.T) {
 		require.True(t, SessionStateChanged(
-			SessionState{Origin: "https://app.example", SessionStorage: "[]"},
-			SessionState{Origin: "https://app.example", SessionStorage: `[["token","opaque"]]`},
+			SessionState{Origin: "https://app.example", SessionStorage: "[]", StorageCaptured: true},
+			SessionState{Origin: "https://app.example", SessionStorage: `[["token","opaque"]]`, StorageCaptured: true},
 		))
 	})
 
 	t.Run("cross-origin storage is not proof", func(t *testing.T) {
 		require.False(t, SessionStateChanged(
-			SessionState{Origin: "https://idp.example", LocalStorage: "[]"},
-			SessionState{Origin: "https://app.example", LocalStorage: `[["theme","dark"]]`},
+			SessionState{Origin: "https://idp.example", LocalStorage: "[]", StorageCaptured: true},
+			SessionState{Origin: "https://app.example", LocalStorage: `[["theme","dark"]]`, StorageCaptured: true},
+		))
+	})
+
+	t.Run("failed storage read is not a storage change", func(t *testing.T) {
+		require.False(t, SessionStateChanged(
+			SessionState{Origin: "https://app.example", LocalStorage: "[]", StorageCaptured: true},
+			SessionState{Origin: "https://app.example"},
 		))
 	})
 

--- a/pkg/engine/headless/auth/step.go
+++ b/pkg/engine/headless/auth/step.go
@@ -1,0 +1,45 @@
+package auth
+
+import "strings"
+
+// LoginStep is a single action in a multi-step headless login flow.
+// In Value, the placeholders {{username}} and {{password}} are substituted with
+// the configured credentials so secrets stay out of the step list / recording.
+type LoginStep struct {
+	// Action is one of: navigate, fill, click, waitvisible, wait, press, submit.
+	Action string `json:"action" yaml:"action"`
+	// Selector is a CSS selector (or xpath=… expression) the action targets.
+	// Unused by navigate/wait.
+	Selector string `json:"selector" yaml:"selector"`
+	// Value is the action argument: a URL (navigate), text to type (fill), a key
+	// name such as "enter"/"tab" (press), or a duration like "2s" (wait).
+	Value string `json:"value" yaml:"value"`
+}
+
+// FirstNavigateURL returns the URL of the first navigate step, or "".
+func FirstNavigateURL(steps []LoginStep) string {
+	for _, s := range steps {
+		if strings.EqualFold(s.Action, "navigate") && s.Value != "" {
+			return s.Value
+		}
+	}
+	return ""
+}
+
+// NeedsCredentials reports whether any step value still contains an unresolved
+// credential placeholder that must be supplied via -auto-login.
+func NeedsCredentials(steps []LoginStep) bool {
+	for _, s := range steps {
+		if strings.Contains(s.Value, "{{username}}") || strings.Contains(s.Value, "{{password}}") {
+			return true
+		}
+	}
+	return false
+}
+
+// ExpandCredentials substitutes {{username}}/{{password}} placeholders.
+func ExpandCredentials(value, username, password string) string {
+	value = strings.ReplaceAll(value, "{{username}}", username)
+	value = strings.ReplaceAll(value, "{{password}}", password)
+	return value
+}

--- a/pkg/engine/headless/auth/step.go
+++ b/pkg/engine/headless/auth/step.go
@@ -1,12 +1,19 @@
 package auth
 
-import "strings"
+import (
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/projectdiscovery/utils/errkit"
+)
 
 // LoginStep is a single action in a multi-step headless login flow.
 // In Value, the placeholders {{username}} and {{password}} are substituted with
 // the configured credentials so secrets stay out of the step list / recording.
 type LoginStep struct {
-	// Action is one of: navigate, fill, click, waitvisible, wait, press, submit.
+	// Action is one of: navigate, fill, click, doubleclick, waitvisible, wait,
+	// press, submit.
 	Action string `json:"action" yaml:"action"`
 	// Selector is a CSS selector (or xpath=… expression) the action targets.
 	// Unused by navigate/wait.
@@ -16,14 +23,81 @@ type LoginStep struct {
 	Value string `json:"value" yaml:"value"`
 }
 
-// FirstNavigateURL returns the URL of the first navigate step, or "".
+// FirstNavigateURL returns the first absolute HTTP(S) navigate URL, or "".
+// Recorder exports can contain an initial about:blank navigation, which is not
+// a useful anonymous-session baseline.
 func FirstNavigateURL(steps []LoginStep) string {
-	for _, s := range steps {
-		if strings.EqualFold(s.Action, "navigate") && s.Value != "" {
-			return s.Value
+	_, navigateURL := stepsAfterFirstNavigateURL(steps)
+	return navigateURL
+}
+
+// StepsAfterFirstNavigateURL returns the replayable suffix after the first
+// absolute HTTP(S) navigation. The caller can navigate once, capture the
+// anonymous cookie baseline, and avoid loading the login page a second time.
+func StepsAfterFirstNavigateURL(steps []LoginStep) ([]LoginStep, string) {
+	return stepsAfterFirstNavigateURL(steps)
+}
+
+func stepsAfterFirstNavigateURL(steps []LoginStep) ([]LoginStep, string) {
+	for i, s := range steps {
+		if !strings.EqualFold(s.Action, "navigate") {
+			continue
+		}
+		parsed, err := url.Parse(strings.TrimSpace(s.Value))
+		if err == nil && parsed.Host != "" && (parsed.Scheme == "http" || parsed.Scheme == "https") {
+			return steps[i+1:], parsed.String()
 		}
 	}
-	return ""
+	return nil, ""
+}
+
+// HasTerminalVisibleAssertion reports whether the flow ends by asserting an
+// authenticated-only element. This is an explicit success signal for
+// applications whose server-side session does not mutate browser state.
+func HasTerminalVisibleAssertion(steps []LoginStep) bool {
+	if len(steps) == 0 {
+		return false
+	}
+	last := steps[len(steps)-1]
+	return strings.EqualFold(strings.TrimSpace(last.Action), "waitvisible") &&
+		strings.TrimSpace(last.Selector) != ""
+}
+
+// ValidateSteps rejects flows that cannot be replayed deterministically.
+func ValidateSteps(steps []LoginStep) error {
+	if len(steps) == 0 {
+		return errkit.New("recorded-flow: no steps to replay")
+	}
+	for i, step := range steps {
+		action := strings.ToLower(strings.TrimSpace(step.Action))
+		switch action {
+		case "navigate":
+			if strings.TrimSpace(step.Value) == "" {
+				return errkit.Newf("recorded-flow: step %d (navigate) missing URL", i)
+			}
+		case "fill", "input", "type", "click", "doubleclick", "waitvisible":
+			if strings.TrimSpace(step.Selector) == "" {
+				return errkit.Newf("recorded-flow: step %d (%s) missing selector", i, action)
+			}
+		case "press":
+			if _, err := keyFromName(step.Value); err != nil {
+				return errkit.Wrapf(err, "recorded-flow: step %d (press)", i)
+			}
+		case "wait":
+			if step.Value != "" {
+				duration, err := time.ParseDuration(step.Value)
+				if err != nil || duration < 0 {
+					return errkit.Newf("recorded-flow: step %d (wait) has invalid duration %q", i, step.Value)
+				}
+			}
+		case "submit":
+			// Selector is optional: replay falls back to a submit control or
+			// Enter on the visible password field.
+		default:
+			return errkit.Newf("recorded-flow: step %d has unknown action %q", i, step.Action)
+		}
+	}
+	return nil
 }
 
 // NeedsCredentials reports whether any step value still contains an unresolved

--- a/pkg/engine/headless/crawler/crawler.go
+++ b/pkg/engine/headless/crawler/crawler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/happyhackingspace/dit"
 	"github.com/pkg/errors"
 	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/katana/pkg/engine/headless/auth"
 	"github.com/projectdiscovery/katana/pkg/engine/headless/browser"
 	"github.com/projectdiscovery/katana/pkg/engine/headless/captcha"
 	"github.com/projectdiscovery/katana/pkg/engine/headless/crawler/diagnostics"
@@ -78,6 +79,9 @@ type Options struct {
 	AuthUsername  string
 	AuthPassword  string
 	DitClassifier *dit.Classifier
+	// AuthSteps, when non-empty, are replayed once against the browser context
+	// before the crawl queue starts (recorded / multi-step login).
+	AuthSteps []auth.LoginStep
 
 	// Hooks installs optional lifecycle callbacks. See Hooks for semantics.
 	// The zero value disables all callbacks.
@@ -224,6 +228,16 @@ func (c *Crawler) Crawl(URL string) error {
 		ctx, cancel = context.WithCancel(parentCtx)
 	}
 	defer cancel()
+
+	// Replay a recorded / explicit auth flow once up-front so the shared browser
+	// context holds session cookies for the rest of the crawl. Opportunistic
+	// -auto-login (tryAutoLogin) remains available as a fallback when no steps
+	// are configured.
+	if len(c.options.AuthSteps) > 0 {
+		if err := c.runRecordedAuthFlow(ctx); err != nil {
+			return err
+		}
+	}
 
 	consecutiveFailures := 0
 
@@ -551,6 +565,34 @@ func (c *Crawler) dispatchCrawlAction(action *types.Action, page *browser.Browse
 		return fmt.Errorf("unknown action type: %v", action.Type)
 	}
 
+	return nil
+}
+
+func (c *Crawler) runRecordedAuthFlow(ctx context.Context) error {
+	page, err := c.launcher.GetPageFromPool()
+	if err != nil {
+		return err
+	}
+	defer c.launcher.PutBrowserToPool(page)
+
+	page.Page = page.Context(ctx)
+
+	loginURL := auth.FirstNavigateURL(c.options.AuthSteps)
+	c.logger.Info("Replaying recorded auth flow",
+		slog.Int("steps", len(c.options.AuthSteps)),
+		slog.String("url", loginURL),
+	)
+
+	settle := c.options.PageMaxTimeout
+	if settle <= 0 {
+		settle = 30 * time.Second
+	}
+	if err := auth.RunLoginSteps(ctx, page.Page, c.options.AuthSteps, c.options.AuthUsername, c.options.AuthPassword, settle); err != nil {
+		return errors.Wrap(err, "recorded auth flow failed")
+	}
+
+	c.loggedIn = true
+	c.logger.Info("Recorded auth flow completed")
 	return nil
 }
 

--- a/pkg/engine/headless/crawler/crawler.go
+++ b/pkg/engine/headless/crawler/crawler.go
@@ -210,12 +210,22 @@ func (c *Crawler) Crawl(URL string) error {
 		return err
 	}
 
-	// Create a master context that will automatically cancel all page operations
-	// once the per-URL crawl deadline is reached.
 	parentCtx := c.options.Context
 	if parentCtx == nil {
 		parentCtx = context.Background()
 	}
+
+	// Authentication is setup, not crawling: MaxCrawlDuration starts only after
+	// a session is established so a slow SSO flow cannot consume the crawl's
+	// entire time budget. The caller's context still bounds both phases.
+	if len(c.options.AuthSteps) > 0 {
+		if err := c.runRecordedAuthFlow(parentCtx); err != nil {
+			return err
+		}
+	}
+
+	// Create a master context that will automatically cancel all page operations
+	// once the per-URL crawl deadline is reached.
 	var (
 		ctx           context.Context
 		cancel        context.CancelFunc
@@ -228,16 +238,6 @@ func (c *Crawler) Crawl(URL string) error {
 		ctx, cancel = context.WithCancel(parentCtx)
 	}
 	defer cancel()
-
-	// Replay a recorded / explicit auth flow once up-front so the shared browser
-	// context holds session cookies for the rest of the crawl. Opportunistic
-	// -auto-login (tryAutoLogin) remains available as a fallback when no steps
-	// are configured.
-	if len(c.options.AuthSteps) > 0 {
-		if err := c.runRecordedAuthFlow(ctx); err != nil {
-			return err
-		}
-	}
 
 	consecutiveFailures := 0
 
@@ -577,9 +577,15 @@ func (c *Crawler) runRecordedAuthFlow(ctx context.Context) error {
 
 	page.Page = page.Context(ctx)
 
-	loginURL := auth.FirstNavigateURL(c.options.AuthSteps)
+	replaySteps, loginURL := auth.StepsAfterFirstNavigateURL(c.options.AuthSteps)
+	if loginURL == "" {
+		return errors.New("recorded auth flow must contain a navigate step")
+	}
+	if len(replaySteps) == 0 {
+		return errors.New("recorded auth flow contains no actions after its navigate step")
+	}
 	c.logger.Info("Replaying recorded auth flow",
-		slog.Int("steps", len(c.options.AuthSteps)),
+		slog.Int("steps", len(replaySteps)),
 		slog.String("url", loginURL),
 	)
 
@@ -587,13 +593,53 @@ func (c *Crawler) runRecordedAuthFlow(ctx context.Context) error {
 	if settle <= 0 {
 		settle = 30 * time.Second
 	}
-	if err := auth.RunLoginSteps(ctx, page.Page, c.options.AuthSteps, c.options.AuthUsername, c.options.AuthPassword, settle); err != nil {
+
+	// Establish the anonymous baseline after loading the login page. Taking the
+	// snapshot before navigation would mistake CSRF/consent cookies created by
+	// the login page for proof that authentication succeeded.
+	if err := page.Navigate(loginURL); err != nil {
+		return errors.Wrap(err, "recorded auth flow could not open login page")
+	}
+	_ = page.WaitLoad()
+	before, err := auth.CaptureSessionState(page.Page)
+	if err != nil {
+		return err
+	}
+
+	if err := auth.RunLoginSteps(ctx, page.Page, replaySteps, c.options.AuthUsername, c.options.AuthPassword, settle); err != nil {
 		return errors.Wrap(err, "recorded auth flow failed")
 	}
 
-	c.loggedIn = true
-	c.logger.Info("Recorded auth flow completed")
-	return nil
+	after, err := auth.CaptureSessionState(page.Page)
+	if err != nil {
+		return err
+	}
+	if auth.SessionStateChanged(before, after) || auth.HasTerminalVisibleAssertion(replaySteps) {
+		c.loggedIn = true
+		c.logger.Info("Recorded auth flow established an authenticated session")
+		return nil
+	}
+
+	// A replay can execute every click successfully while the application
+	// rejects stale captured credentials. Try the classifier-based login on the
+	// page that rejected the recording before giving up.
+	c.logger.Warn("Recorded auth flow completed without establishing a session; trying auto-login fallback")
+	if c.options.AuthUsername != "" && c.options.DitClassifier != nil {
+		if html, htmlErr := page.HTML(); htmlErr == nil && c.tryAutoLogin(page, html) {
+			_ = page.WaitPageLoadHeurisitics()
+			fallback, cookieErr := auth.CaptureSessionState(page.Page)
+			if cookieErr != nil {
+				return cookieErr
+			}
+			if auth.SessionStateChanged(before, fallback) {
+				c.loggedIn = true
+				c.logger.Info("Auto-login fallback established an authenticated session")
+				return nil
+			}
+		}
+	}
+
+	return errors.New("recorded auth flow did not establish authenticated browser state")
 }
 
 func (c *Crawler) tryAutoLogin(page *browser.BrowserPage, html string) bool {

--- a/pkg/engine/headless/headless.go
+++ b/pkg/engine/headless/headless.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/lmittmann/tint"
 	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/katana/pkg/engine/headless/auth"
 	"github.com/projectdiscovery/katana/pkg/engine/headless/browser"
 	"github.com/projectdiscovery/katana/pkg/engine/headless/captcha"
 	_ "github.com/projectdiscovery/katana/pkg/engine/headless/captcha/capsolver"
@@ -197,6 +198,14 @@ func (h *Headless) Crawl(URL string) error {
 		if len(parts) > 1 {
 			crawlOpts.AuthPassword = parts[1]
 		}
+	}
+
+	if path := h.options.Options.RecordedFlow; path != "" {
+		steps, err := auth.StepsFromFile(path, crawlOpts.AuthUsername, crawlOpts.AuthPassword)
+		if err != nil {
+			return err
+		}
+		crawlOpts.AuthSteps = steps
 	}
 
 	if provider := h.options.Options.CaptchaSolverProvider; provider != "" {

--- a/pkg/engine/headless/recorded_flow_e2e_test.go
+++ b/pkg/engine/headless/recorded_flow_e2e_test.go
@@ -113,18 +113,21 @@ func TestE2E_Crawl_WithoutAuth_CannotReachSecret(t *testing.T) {
 	t.Cleanup(func() { _ = lab.Close() })
 
 	collector := &resultCollector{}
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	// Bound the crawl with MaxCrawlDuration so CI (cold Chrome cache / slow
+	// runners) exits cleanly instead of relying on the parent context deadline.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
 	c, err := crawler.New(crawler.Options{
-		Context:         ctx,
-		MaxBrowsers:     1,
-		MaxDepth:        2,
-		PageMaxTimeout:  30 * time.Second,
-		NoSandbox:       true,
-		RequestCallback: collector.callback,
-		Logger:          slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
-		ScopeValidator:  func(u string) bool { return strings.HasPrefix(u, lab.URL) },
+		Context:          ctx,
+		MaxBrowsers:      1,
+		MaxDepth:         1,
+		MaxCrawlDuration: 30 * time.Second,
+		PageMaxTimeout:   15 * time.Second,
+		NoSandbox:        true,
+		RequestCallback:  collector.callback,
+		Logger:           slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
+		ScopeValidator:   func(u string) bool { return strings.HasPrefix(u, lab.URL) },
 	})
 	require.NoError(t, err)
 	t.Cleanup(c.Close)
@@ -132,8 +135,10 @@ func TestE2E_Crawl_WithoutAuth_CannotReachSecret(t *testing.T) {
 	// Start from the public home — without a recorded flow the crawler should
 	// never successfully fetch the gated secret page content.
 	require.NoError(t, c.Crawl(lab.URL+"/"))
+	urls := collector.list()
+	require.NotEmpty(t, urls, "crawl must produce some public-page traffic")
 	require.Equal(t, int64(0), lab.SecretHits.Load(), "unauthenticated crawl must not hit /app/secret")
-	require.False(t, containsURL(collector.list(), "/app/secret"))
+	require.False(t, containsURL(urls, "/app/secret"))
 }
 
 func TestE2E_Crawl_UsernameFirstRecordedFlow(t *testing.T) {

--- a/pkg/engine/headless/recorded_flow_e2e_test.go
+++ b/pkg/engine/headless/recorded_flow_e2e_test.go
@@ -131,7 +131,7 @@ func TestE2E_Crawl_WithoutAuth_CannotReachSecret(t *testing.T) {
 
 	// Start from the public home — without a recorded flow the crawler should
 	// never successfully fetch the gated secret page content.
-	_ = c.Crawl(lab.URL + "/")
+	require.NoError(t, c.Crawl(lab.URL+"/"))
 	require.Equal(t, int64(0), lab.SecretHits.Load(), "unauthenticated crawl must not hit /app/secret")
 	require.False(t, containsURL(collector.list(), "/app/secret"))
 }

--- a/pkg/engine/headless/recorded_flow_e2e_test.go
+++ b/pkg/engine/headless/recorded_flow_e2e_test.go
@@ -1,0 +1,173 @@
+package headless_test
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-rod/rod/lib/launcher"
+	"github.com/projectdiscovery/katana/internal/testutils/authlab"
+	"github.com/projectdiscovery/katana/pkg/engine/headless/auth"
+	"github.com/projectdiscovery/katana/pkg/engine/headless/crawler"
+	"github.com/projectdiscovery/katana/pkg/output"
+	"github.com/stretchr/testify/require"
+)
+
+func skipIfNoBrowser(t *testing.T) {
+	t.Helper()
+	if path, found := launcher.LookPath(); !found || path == "" {
+		t.Skip("chrome/chromium not found, skipping recorded-flow crawl e2e")
+	}
+}
+
+func writeTempFlow(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "flow.json")
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	return path
+}
+
+type resultCollector struct {
+	mu   sync.Mutex
+	urls []string
+}
+
+func (c *resultCollector) callback(rr *output.Result) {
+	if rr == nil || rr.Request == nil {
+		return
+	}
+	c.mu.Lock()
+	c.urls = append(c.urls, rr.Request.URL)
+	c.mu.Unlock()
+}
+
+func (c *resultCollector) list() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]string, len(c.urls))
+	copy(out, c.urls)
+	return out
+}
+
+func containsURL(urls []string, substr string) bool {
+	for _, u := range urls {
+		if strings.Contains(u, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestE2E_Crawl_WithRecordedFlow_DiscoversGatedPages(t *testing.T) {
+	skipIfNoBrowser(t)
+
+	lab, err := authlab.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = lab.Close() })
+
+	flowPath := writeTempFlow(t, authlab.ChromeRecordingSimple(lab.URL))
+	steps, err := auth.StepsFromFile(flowPath, authlab.Username, authlab.Password)
+	require.NoError(t, err)
+
+	collector := &resultCollector{}
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	c, err := crawler.New(crawler.Options{
+		Context:         ctx,
+		MaxBrowsers:     1,
+		MaxDepth:        2,
+		PageMaxTimeout:  30 * time.Second,
+		NoSandbox:       true,
+		AuthUsername:    authlab.Username,
+		AuthPassword:    authlab.Password,
+		AuthSteps:       steps,
+		RequestCallback: collector.callback,
+		Logger:          slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
+		ScopeValidator:  func(u string) bool { return strings.HasPrefix(u, lab.URL) },
+	})
+	require.NoError(t, err)
+	t.Cleanup(c.Close)
+
+	require.NoError(t, c.Crawl(lab.URL+"/app/dashboard"))
+
+	urls := collector.list()
+	require.True(t, containsURL(urls, "/app/dashboard") || lab.DashboardHits.Load() > 0,
+		"expected dashboard visit, urls=%v", urls)
+	require.True(t, containsURL(urls, "/app/secret") || lab.SecretHits.Load() > 0,
+		"recorded flow should unlock gated /app/secret during crawl, urls=%v secretHits=%d",
+		urls, lab.SecretHits.Load())
+	require.GreaterOrEqual(t, lab.LoginPosts.Load(), int64(1), "login must have been submitted")
+}
+
+func TestE2E_Crawl_WithoutAuth_CannotReachSecret(t *testing.T) {
+	skipIfNoBrowser(t)
+
+	lab, err := authlab.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = lab.Close() })
+
+	collector := &resultCollector{}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	c, err := crawler.New(crawler.Options{
+		Context:         ctx,
+		MaxBrowsers:     1,
+		MaxDepth:        2,
+		PageMaxTimeout:  30 * time.Second,
+		NoSandbox:       true,
+		RequestCallback: collector.callback,
+		Logger:          slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
+		ScopeValidator:  func(u string) bool { return strings.HasPrefix(u, lab.URL) },
+	})
+	require.NoError(t, err)
+	t.Cleanup(c.Close)
+
+	// Start from the public home — without a recorded flow the crawler should
+	// never successfully fetch the gated secret page content.
+	_ = c.Crawl(lab.URL + "/")
+	require.Equal(t, int64(0), lab.SecretHits.Load(), "unauthenticated crawl must not hit /app/secret")
+	require.False(t, containsURL(collector.list(), "/app/secret"))
+}
+
+func TestE2E_Crawl_UsernameFirstRecordedFlow(t *testing.T) {
+	skipIfNoBrowser(t)
+
+	lab, err := authlab.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = lab.Close() })
+
+	steps, err := auth.StepsFromData([]byte(authlab.ChromeRecordingStep(lab.URL)), authlab.Username, authlab.Password)
+	require.NoError(t, err)
+
+	collector := &resultCollector{}
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	c, err := crawler.New(crawler.Options{
+		Context:         ctx,
+		MaxBrowsers:     1,
+		MaxDepth:        2,
+		PageMaxTimeout:  30 * time.Second,
+		NoSandbox:       true,
+		AuthUsername:    authlab.Username,
+		AuthPassword:    authlab.Password,
+		AuthSteps:       steps,
+		RequestCallback: collector.callback,
+		Logger:          slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
+		ScopeValidator:  func(u string) bool { return strings.HasPrefix(u, lab.URL) },
+	})
+	require.NoError(t, err)
+	t.Cleanup(c.Close)
+
+	require.NoError(t, c.Crawl(lab.URL+"/app/dashboard"))
+	require.GreaterOrEqual(t, lab.LoginPosts.Load(), int64(1))
+	require.True(t, containsURL(collector.list(), "/app/secret") || lab.SecretHits.Load() > 0,
+		"username-first recorded flow should unlock secret pages")
+}

--- a/pkg/engine/headless/recorded_flow_e2e_test.go
+++ b/pkg/engine/headless/recorded_flow_e2e_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/go-rod/rod/lib/launcher"
+	"github.com/happyhackingspace/dit"
 	"github.com/projectdiscovery/katana/internal/testutils/authlab"
 	"github.com/projectdiscovery/katana/pkg/engine/headless/auth"
 	"github.com/projectdiscovery/katana/pkg/engine/headless/crawler"
@@ -103,6 +104,7 @@ func TestE2E_Crawl_WithRecordedFlow_DiscoversGatedPages(t *testing.T) {
 		"recorded flow should unlock gated /app/secret during crawl, urls=%v secretHits=%d",
 		urls, lab.SecretHits.Load())
 	require.GreaterOrEqual(t, lab.LoginPosts.Load(), int64(1), "login must have been submitted")
+	require.Equal(t, int64(0), lab.LogoutHits.Load(), "authenticated crawl must skip logout links")
 }
 
 func TestE2E_Crawl_WithoutAuth_CannotReachSecret(t *testing.T) {
@@ -175,4 +177,170 @@ func TestE2E_Crawl_UsernameFirstRecordedFlow(t *testing.T) {
 	require.GreaterOrEqual(t, lab.LoginPosts.Load(), int64(1))
 	require.True(t, containsURL(collector.list(), "/app/secret") || lab.SecretHits.Load() > 0,
 		"username-first recorded flow should unlock secret pages")
+	require.Equal(t, int64(0), lab.LogoutHits.Load(), "authenticated crawl must skip logout links")
+}
+
+func TestE2E_Crawl_RecordedFlowWithoutSessionFails(t *testing.T) {
+	skipIfNoBrowser(t)
+
+	lab, err := authlab.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = lab.Close() })
+
+	// Every step succeeds, but clicking a field is not a login. This is the
+	// stale-recording false positive that used to set loggedIn unconditionally.
+	steps := []auth.LoginStep{
+		{Action: "navigate", Value: lab.URL + "/login"},
+		{Action: "click", Selector: "#email"},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	c, err := crawler.New(crawler.Options{
+		Context:        ctx,
+		MaxBrowsers:    1,
+		MaxDepth:       1,
+		PageMaxTimeout: 15 * time.Second,
+		NoSandbox:      true,
+		AuthSteps:      steps,
+		Logger:         slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
+		ScopeValidator: func(u string) bool { return strings.HasPrefix(u, lab.URL) },
+	})
+	require.NoError(t, err)
+	t.Cleanup(c.Close)
+
+	err = c.Crawl(lab.URL + "/app/dashboard")
+	require.ErrorContains(t, err, "did not establish authenticated browser state")
+	require.Equal(t, int64(0), lab.DashboardHits.Load())
+}
+
+func TestE2E_Crawl_RecordedFlowRejectsWrongCredentials(t *testing.T) {
+	skipIfNoBrowser(t)
+
+	lab, err := authlab.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = lab.Close() })
+	steps, err := auth.StepsFromData(
+		[]byte(authlab.ChromeRecordingSimple(lab.URL)),
+		authlab.Username,
+		authlab.Password,
+	)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	c, err := crawler.New(crawler.Options{
+		Context:        ctx,
+		MaxBrowsers:    1,
+		MaxDepth:       1,
+		PageMaxTimeout: 15 * time.Second,
+		NoSandbox:      true,
+		AuthUsername:   authlab.Username,
+		AuthPassword:   "wrong-password",
+		AuthSteps:      steps,
+		Logger:         slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
+		ScopeValidator: func(u string) bool { return strings.HasPrefix(u, lab.URL) },
+	})
+	require.NoError(t, err)
+	t.Cleanup(c.Close)
+
+	require.ErrorContains(t, c.Crawl(lab.URL+"/app/dashboard"), "did not establish authenticated browser state")
+	require.GreaterOrEqual(t, lab.LoginPosts.Load(), int64(1))
+	require.Equal(t, int64(0), lab.DashboardHits.Load())
+	require.Equal(t, int64(0), lab.SecretHits.Load())
+}
+
+func TestE2E_Crawl_StaleRecordedFlowFallsBackToAutoLogin(t *testing.T) {
+	skipIfNoBrowser(t)
+
+	lab, err := authlab.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = lab.Close() })
+	classifier, err := dit.New()
+	require.NoError(t, err)
+
+	// The recording is stale but leaves the login form available. Correct
+	// configured credentials must still be tried by the auto-login fallback.
+	steps := []auth.LoginStep{
+		{Action: "navigate", Value: lab.URL + "/login"},
+		{Action: "click", Selector: "#email"},
+	}
+	collector := &resultCollector{}
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	c, err := crawler.New(crawler.Options{
+		Context:         ctx,
+		MaxBrowsers:     1,
+		MaxDepth:        2,
+		PageMaxTimeout:  15 * time.Second,
+		NoSandbox:       true,
+		AuthUsername:    authlab.Username,
+		AuthPassword:    authlab.Password,
+		AuthSteps:       steps,
+		DitClassifier:   classifier,
+		RequestCallback: collector.callback,
+		Logger:          slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
+		ScopeValidator:  func(u string) bool { return strings.HasPrefix(u, lab.URL) },
+	})
+	require.NoError(t, err)
+	t.Cleanup(c.Close)
+
+	require.NoError(t, c.Crawl(lab.URL+"/app/dashboard"))
+	require.GreaterOrEqual(t, lab.LoginPosts.Load(), int64(1))
+	require.True(t, containsURL(collector.list(), "/app/secret") || lab.SecretHits.Load() > 0,
+		"auto-login fallback should unlock secret pages")
+}
+
+func TestE2E_Crawl_RecordedFlowRequiresNavigate(t *testing.T) {
+	skipIfNoBrowser(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	c, err := crawler.New(crawler.Options{
+		Context:     ctx,
+		MaxBrowsers: 1,
+		NoSandbox:   true,
+		AuthSteps:   []auth.LoginStep{{Action: "click", Selector: "#submit"}},
+	})
+	require.NoError(t, err)
+	t.Cleanup(c.Close)
+
+	require.ErrorContains(t, c.Crawl("https://example.com"), "must contain a navigate step")
+}
+
+func TestE2E_Crawl_AuthDoesNotConsumeCrawlDuration(t *testing.T) {
+	skipIfNoBrowser(t)
+
+	lab, err := authlab.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = lab.Close() })
+	steps := []auth.LoginStep{
+		{Action: "navigate", Value: lab.URL + "/login"},
+		{Action: "wait", Value: "3s"},
+		{Action: "fill", Selector: "#email", Value: "{{username}}"},
+		{Action: "fill", Selector: "#password", Value: "{{password}}"},
+		{Action: "click", Selector: "#submit"},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	c, err := crawler.New(crawler.Options{
+		Context:          ctx,
+		MaxBrowsers:      1,
+		MaxDepth:         1,
+		MaxCrawlDuration: 2 * time.Second,
+		PageMaxTimeout:   10 * time.Second,
+		NoSandbox:        true,
+		AuthUsername:     authlab.Username,
+		AuthPassword:     authlab.Password,
+		AuthSteps:        steps,
+		Logger:           slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
+		ScopeValidator:   func(u string) bool { return strings.HasPrefix(u, lab.URL) },
+	})
+	require.NoError(t, err)
+	t.Cleanup(c.Close)
+
+	require.NoError(t, c.Crawl(lab.URL+"/app/dashboard"))
+	require.GreaterOrEqual(t, lab.DashboardHits.Load(), int64(1),
+		"crawl duration must begin after the three-second auth flow")
 }

--- a/pkg/engine/headless/recorded_flow_e2e_test.go
+++ b/pkg/engine/headless/recorded_flow_e2e_test.go
@@ -341,6 +341,8 @@ func TestE2E_Crawl_AuthDoesNotConsumeCrawlDuration(t *testing.T) {
 	t.Cleanup(c.Close)
 
 	require.NoError(t, c.Crawl(lab.URL+"/app/dashboard"))
-	require.GreaterOrEqual(t, lab.DashboardHits.Load(), int64(1),
+	// The login redirect accounts for the first hit, so a second one proves the
+	// crawl deadline started after the three-second auth flow.
+	require.GreaterOrEqual(t, lab.DashboardHits.Load(), int64(2),
 		"crawl duration must begin after the three-second auth flow")
 }

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -223,6 +223,9 @@ type Options struct {
 	FilterPageType goflags.StringSlice
 	// AuthCredentials holds username:password for automatic login
 	AuthCredentials string
+	// RecordedFlow is the path to a Chrome DevTools Recorder JSON (or an explicit
+	// LoginStep list) replayed once in headless mode before crawling starts.
+	RecordedFlow string
 	// MaxDomainPages is the maximum number of pages to crawl per domain (0 = unlimited)
 	MaxDomainPages int
 }


### PR DESCRIPTION
Closes #1629

Adds `-rf` / `-recorded-flow` to replay Chrome DevTools Recorder (or explicit step) logins once before headless crawl. Includes AuthLab e2e + docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a headless-only `--recorded-flow` / `-rf` option for replaying Chrome DevTools Recorder or explicit authentication steps before crawling.
  * Added support for multi-step login flows, credential placeholders, session verification, and automatic-login fallback.
* **Bug Fixes**
  * Improved logout URL skipping when authenticated crawling is enabled.
  * Added validation and clearer errors for invalid or incomplete recorded flows.
* **Documentation**
  * Expanded authenticated crawling guidance, including `-auto-login` and `-recorded-flow`.
* **Tests**
  * Added comprehensive authentication workflow and end-to-end coverage.
* **Chores**
  * Improved test command quoting and failure diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->