### PR TITLE
Headless crawl paths are not exportable

### DIFF
--- a/pkg/engine/headless/crawler/crawler.go
+++ b/pkg/engine/headless/crawler/crawler.go
@@ -173,11 +173,19 @@ func (c *Crawler) GetCrawlGraph() *graph.CrawlGraph {
 	return c.crawlGraph
 }
 
+// Paths returns replayable paths from the entrypoint to every discovered location.
+func (c *Crawler) Paths() ([]*types.Path, error) {
+	if c == nil || c.crawlGraph == nil {
+		return nil, nil
+	}
+	return c.crawlGraph.AllPathsFromRoot()
+}
+
 func (c *Crawler) writePathsExport() error {
 	if c.crawlGraph == nil || c.options.DiagnosticsDir == "" {
 		return nil
 	}
-	paths, err := c.crawlGraph.AllPathsFromRoot()
+	paths, err := c.Paths()
 	if err != nil {
 		return err
 	}

--- a/pkg/engine/headless/crawler/crawler.go
+++ b/pkg/engine/headless/crawler/crawler.go
@@ -2,6 +2,7 @@ package crawler
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
@@ -172,6 +173,24 @@ func (c *Crawler) GetCrawlGraph() *graph.CrawlGraph {
 	return c.crawlGraph
 }
 
+func (c *Crawler) writePathsExport() error {
+	if c.crawlGraph == nil || c.options.DiagnosticsDir == "" {
+		return nil
+	}
+	paths, err := c.crawlGraph.AllPathsFromRoot()
+	if err != nil {
+		return err
+	}
+	if paths == nil {
+		paths = []*types.Path{}
+	}
+	data, err := json.MarshalIndent(paths, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(c.options.DiagnosticsDir, "paths.json"), data, 0644)
+}
+
 func (c *Crawler) Crawl(URL string) error {
 	defer func() {
 		if c.diagnostics == nil {
@@ -180,6 +199,9 @@ func (c *Crawler) Crawl(URL string) error {
 		err := c.crawlGraph.DrawGraph(filepath.Join(c.options.DiagnosticsDir, "crawl-graph.dot"))
 		if err != nil {
 			c.logger.Error("Failed to draw crawl graph", slog.String("error", err.Error()))
+		}
+		if err := c.writePathsExport(); err != nil {
+			c.logger.Error("Failed to write paths export", slog.String("error", err.Error()))
 		}
 	}()
 

--- a/pkg/engine/headless/crawler/paths_test.go
+++ b/pkg/engine/headless/crawler/paths_test.go
@@ -1,0 +1,32 @@
+package crawler
+
+import (
+	"testing"
+
+	"github.com/projectdiscovery/katana/pkg/engine/headless/graph"
+	"github.com/projectdiscovery/katana/pkg/engine/headless/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPathsFromGraph(t *testing.T) {
+	t.Parallel()
+	c := &Crawler{crawlGraph: graph.NewCrawlGraph()}
+	require.NoError(t, c.crawlGraph.AddPageState(types.PageState{UniqueID: "root", URL: "about:blank"}))
+	require.NoError(t, c.crawlGraph.AddPageState(types.PageState{
+		UniqueID:         "home",
+		OriginID:         "root",
+		URL:              "https://example.com/",
+		NavigationAction: &types.Action{Type: types.ActionTypeLoadURL, Input: "https://example.com/", OriginID: "root"},
+	}))
+
+	paths, err := c.Paths()
+	require.NoError(t, err)
+	require.Len(t, paths, 1)
+	require.Equal(t, "home", paths[0].TargetID)
+	require.Equal(t, 1, paths[0].Len())
+
+	empty := &Crawler{}
+	paths, err = empty.Paths()
+	require.NoError(t, err)
+	require.Nil(t, paths)
+}

--- a/pkg/engine/headless/graph/graph.go
+++ b/pkg/engine/headless/graph/graph.go
@@ -130,6 +130,90 @@ func (g *CrawlGraph) ShortestPath(sourceState, targetState string) ([]*types.Act
 	return actionsSlice, nil
 }
 
+// RootID returns the crawl entrypoint vertex (IsRoot, about:blank, or indegree 0).
+func (g *CrawlGraph) RootID() (string, error) {
+	vertices := g.GetVertices()
+	if len(vertices) == 0 {
+		return "", errors.New("crawl graph is empty")
+	}
+	for _, id := range vertices {
+		ps, err := g.GetPageState(id)
+		if err != nil {
+			continue
+		}
+		if ps.IsRoot || ps.URL == "about:blank" {
+			return id, nil
+		}
+	}
+	pred, err := g.graph.PredecessorMap()
+	if err != nil {
+		return "", errors.Wrap(err, "could not get predecessor map")
+	}
+	for _, id := range vertices {
+		if len(pred[id]) == 0 {
+			return id, nil
+		}
+	}
+	return vertices[0], nil
+}
+
+// PathFromRoot builds a Path of actions from the entrypoint to targetID.
+func (g *CrawlGraph) PathFromRoot(targetID string) (*types.Path, error) {
+	entryID, err := g.RootID()
+	if err != nil {
+		return nil, err
+	}
+	target, err := g.GetPageState(targetID)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get target page state")
+	}
+	if entryID == targetID {
+		return &types.Path{
+			EntryID:   entryID,
+			TargetID:  targetID,
+			TargetURL: target.URL,
+			Steps:     nil,
+		}, nil
+	}
+	steps, err := g.ShortestPath(entryID, targetID)
+	if err != nil {
+		return nil, err
+	}
+	return &types.Path{
+		EntryID:   entryID,
+		TargetID:  targetID,
+		TargetURL: target.URL,
+		Steps:     steps,
+	}, nil
+}
+
+// AllPathsFromRoot returns a path from the entrypoint to every non-entry vertex.
+func (g *CrawlGraph) AllPathsFromRoot() ([]*types.Path, error) {
+	entryID, err := g.RootID()
+	if err != nil {
+		return nil, err
+	}
+	var paths []*types.Path
+	for _, id := range g.GetVertices() {
+		if id == entryID {
+			continue
+		}
+		ps, err := g.GetPageState(id)
+		if err != nil {
+			continue
+		}
+		if ps.URL == "about:blank" {
+			continue
+		}
+		p, err := g.PathFromRoot(id)
+		if err != nil {
+			continue
+		}
+		paths = append(paths, p)
+	}
+	return paths, nil
+}
+
 func (g *CrawlGraph) DrawGraph(file string) error {
 	f, err := os.Create(file)
 	if err != nil {

--- a/pkg/engine/headless/graph/graph_test.go
+++ b/pkg/engine/headless/graph/graph_test.go
@@ -1,0 +1,57 @@
+package graph
+
+import (
+	"testing"
+
+	"github.com/projectdiscovery/katana/pkg/engine/headless/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPathFromRoot(t *testing.T) {
+	t.Parallel()
+	g := NewCrawlGraph()
+
+	root := types.PageState{UniqueID: "root", URL: "about:blank", Depth: 0}
+	require.NoError(t, g.AddPageState(root))
+
+	homeAction := &types.Action{Type: types.ActionTypeLoadURL, Input: "https://example.com/", OriginID: "root", Depth: 1}
+	home := types.PageState{
+		UniqueID:         "home",
+		OriginID:         "root",
+		URL:              "https://example.com/",
+		Depth:            1,
+		NavigationAction: homeAction,
+	}
+	require.NoError(t, g.AddPageState(home))
+
+	click := &types.Action{Type: types.ActionTypeLeftClick, OriginID: "home", Depth: 2, Element: &types.HTMLElement{TagName: "a", ID: "next"}}
+	next := types.PageState{
+		UniqueID:         "next",
+		OriginID:         "home",
+		URL:              "https://example.com/next",
+		Depth:            2,
+		NavigationAction: click,
+	}
+	require.NoError(t, g.AddPageState(next))
+
+	rootID, err := g.RootID()
+	require.NoError(t, err)
+	require.Equal(t, "root", rootID)
+
+	p, err := g.PathFromRoot("next")
+	require.NoError(t, err)
+	require.Equal(t, "root", p.EntryID)
+	require.Equal(t, "next", p.TargetID)
+	require.Equal(t, "https://example.com/next", p.TargetURL)
+	require.Len(t, p.Steps, 2)
+	require.Equal(t, types.ActionTypeLoadURL, p.Steps[0].Type)
+	require.Equal(t, types.ActionTypeLeftClick, p.Steps[1].Type)
+
+	self, err := g.PathFromRoot("root")
+	require.NoError(t, err)
+	require.Equal(t, 0, self.Len())
+
+	all, err := g.AllPathsFromRoot()
+	require.NoError(t, err)
+	require.Len(t, all, 2)
+}

--- a/pkg/engine/headless/types/path.go
+++ b/pkg/engine/headless/types/path.go
@@ -1,0 +1,58 @@
+package types
+
+import (
+	"encoding/json"
+)
+
+// Path is an ordered sequence of actions from the crawl entrypoint to a location.
+// It is the unit Burp-style cartography rewalks and audits replay.
+type Path struct {
+	EntryID   string    `json:"entry_id"`
+	TargetID  string    `json:"target_id"`
+	TargetURL string    `json:"target_url,omitempty"`
+	Steps     []*Action `json:"steps,omitempty"`
+}
+
+// Len returns the number of navigation steps.
+func (p *Path) Len() int {
+	if p == nil {
+		return 0
+	}
+	return len(p.Steps)
+}
+
+// Clone returns a shallow copy with a new Steps slice (actions are shared).
+func (p *Path) Clone() *Path {
+	if p == nil {
+		return nil
+	}
+	out := &Path{
+		EntryID:   p.EntryID,
+		TargetID:  p.TargetID,
+		TargetURL: p.TargetURL,
+	}
+	if len(p.Steps) > 0 {
+		out.Steps = make([]*Action, len(p.Steps))
+		copy(out.Steps, p.Steps)
+	}
+	return out
+}
+
+// MarshalJSON ensures nil Steps serialize as [] not null.
+func (p *Path) MarshalJSON() ([]byte, error) {
+	steps := p.Steps
+	if steps == nil {
+		steps = []*Action{}
+	}
+	return json.Marshal(struct {
+		EntryID   string    `json:"entry_id"`
+		TargetID  string    `json:"target_id"`
+		TargetURL string    `json:"target_url,omitempty"`
+		Steps     []*Action `json:"steps"`
+	}{
+		EntryID:   p.EntryID,
+		TargetID:  p.TargetID,
+		TargetURL: p.TargetURL,
+		Steps:     steps,
+	})
+}

--- a/pkg/engine/headless/types/path_test.go
+++ b/pkg/engine/headless/types/path_test.go
@@ -1,0 +1,39 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPathLenAndClone(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, 0, (*Path)(nil).Len())
+
+	p := &Path{
+		EntryID:  "root",
+		TargetID: "leaf",
+		Steps: []*Action{
+			{Type: ActionTypeLoadURL, Input: "https://example.com"},
+			{Type: ActionTypeLeftClick},
+		},
+	}
+	require.Equal(t, 2, p.Len())
+
+	c := p.Clone()
+	require.Equal(t, p.EntryID, c.EntryID)
+	require.Equal(t, p.TargetID, c.TargetID)
+	require.Len(t, c.Steps, 2)
+	c.Steps = append(c.Steps, &Action{Type: ActionTypeWait})
+	require.Equal(t, 2, p.Len())
+	require.Equal(t, 3, c.Len())
+}
+
+func TestPathMarshalEmptySteps(t *testing.T) {
+	t.Parallel()
+	p := &Path{EntryID: "a", TargetID: "b"}
+	raw, err := json.Marshal(p)
+	require.NoError(t, err)
+	require.Contains(t, string(raw), `"steps":[]`)
+}


### PR DESCRIPTION
Fixes #1715

Pure headless builds a crawl graph but does not expose a replayable path from the entrypoint to each location. This adds a Path type, PathFromRoot / AllPathsFromRoot, Paths() on the crawler, and paths.json when diagnostics are on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added crawl path discovery, including entrypoints, targets, navigation steps, and path lengths.
  * Added access to all replayable paths generated during a crawl.
  * Added optional JSON export of discovered paths to the diagnostics output as `paths.json`.
  * Added consistent path cloning and serialization, including empty step lists.

* **Tests**
  * Added coverage for path discovery, traversal, cloning, lengths, and JSON output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->