### PR TITLE
Headless cannot verify locations with a clean session rewalk

### DIFF
--- a/pkg/engine/headless/browser/session.go
+++ b/pkg/engine/headless/browser/session.go
@@ -1,0 +1,22 @@
+package browser
+
+import (
+	"context"
+
+	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/proto"
+)
+
+// ClearSession wipes cookies and web storage so the next navigation starts clean.
+func ClearSession(ctx context.Context, page *rod.Page) error {
+	if page == nil {
+		return nil
+	}
+	page = page.Context(ctx)
+	_ = proto.NetworkClearBrowserCookies{}.Call(page)
+	_, err := page.Eval(`() => {
+		try { localStorage.clear(); } catch (e) {}
+		try { sessionStorage.clear(); } catch (e) {}
+	}`)
+	return err
+}

--- a/pkg/engine/headless/browser/session_test.go
+++ b/pkg/engine/headless/browser/session_test.go
@@ -1,0 +1,33 @@
+package browser
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/launcher"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClearSessionNilPage(t *testing.T) {
+	t.Parallel()
+	require.NoError(t, ClearSession(context.Background(), nil))
+}
+
+func TestClearSessionOnBlankPage(t *testing.T) {
+	path, found := launcher.LookPath()
+	if !found || path == "" {
+		t.Skip("chrome/chromium not found")
+	}
+	controlURL, err := launcher.New().Bin(path).Leakless(true).Launch()
+	if err != nil {
+		t.Skipf("could not launch browser: %v", err)
+	}
+	b := rod.New().ControlURL(controlURL).MustConnect()
+	t.Cleanup(func() { _ = b.Close() })
+
+	page := b.MustPage("about:blank")
+	t.Cleanup(func() { _ = page.Close() })
+
+	require.NoError(t, ClearSession(context.Background(), page))
+}

--- a/pkg/engine/headless/cartography/classify.go
+++ b/pkg/engine/headless/cartography/classify.go
@@ -1,0 +1,81 @@
+package cartography
+
+import (
+	"github.com/projectdiscovery/katana/pkg/engine/headless/crawler/normalizer/simhash"
+)
+
+// Outcome is the result of comparing rewalk observations to a stored location.
+type Outcome string
+
+const (
+	OutcomeMatch            Outcome = "match"
+	OutcomeAppChange        Outcome = "app_change"
+	OutcomeSessionFork      Outcome = "session_fork"
+	OutcomeNonDeterministic Outcome = "non_deterministic"
+)
+
+// LocationFingerprint is the stable identity of a crawl location for rewalk checks.
+type LocationFingerprint struct {
+	UniqueID string
+	URL      string
+	SimHash  uint64
+}
+
+// DefaultMaxHamming is the max SimHash distance still treated as the same location.
+const DefaultMaxHamming = 3
+
+// SameLocation reports whether two fingerprints describe the same location.
+func SameLocation(a, b LocationFingerprint, maxHamming int) bool {
+	if maxHamming < 0 {
+		maxHamming = DefaultMaxHamming
+	}
+	if a.UniqueID != "" && b.UniqueID != "" && a.UniqueID == b.UniqueID {
+		return true
+	}
+	if a.SimHash == 0 && b.SimHash == 0 {
+		return a.URL != "" && a.URL == b.URL
+	}
+	return int(simhash.Distance(a.SimHash, b.SimHash)) <= maxHamming
+}
+
+// ClassifyRewalks applies Burp-style divergence rules to rewalks of paths that
+// should reach expected:
+//   - all match expected → match
+//   - none match expected, but all agree → app_change
+//   - some match expected, some do not → session_fork
+//   - otherwise → non_deterministic
+func ClassifyRewalks(expected LocationFingerprint, observed []LocationFingerprint, maxHamming int) Outcome {
+	if len(observed) == 0 {
+		return OutcomeNonDeterministic
+	}
+	matchExpected := 0
+	for _, o := range observed {
+		if SameLocation(expected, o, maxHamming) {
+			matchExpected++
+		}
+	}
+	switch {
+	case matchExpected == len(observed):
+		return OutcomeMatch
+	case matchExpected == 0:
+		if allAgree(observed, maxHamming) {
+			return OutcomeAppChange
+		}
+		return OutcomeNonDeterministic
+	default:
+		return OutcomeSessionFork
+	}
+}
+
+func allAgree(fs []LocationFingerprint, maxHamming int) bool {
+	if len(fs) <= 1 {
+		return true
+	}
+	base := fs[0]
+	for i := 1; i < len(fs); i++ {
+		if !SameLocation(base, fs[i], maxHamming) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/engine/headless/cartography/classify_test.go
+++ b/pkg/engine/headless/cartography/classify_test.go
@@ -1,0 +1,65 @@
+package cartography
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSameLocation(t *testing.T) {
+	t.Parallel()
+	a := LocationFingerprint{UniqueID: "x", SimHash: 0b1111}
+	b := LocationFingerprint{UniqueID: "x", SimHash: 0}
+	require.True(t, SameLocation(a, b, 3))
+
+	c := LocationFingerprint{SimHash: 0b1111}
+	d := LocationFingerprint{SimHash: 0b1110} // hamming 1
+	require.True(t, SameLocation(c, d, 3))
+	require.False(t, SameLocation(c, LocationFingerprint{SimHash: 0}, 3))
+}
+
+func TestClassifyRewalks(t *testing.T) {
+	t.Parallel()
+	expected := LocationFingerprint{SimHash: 0b11110000}
+
+	t.Run("all match", func(t *testing.T) {
+		t.Parallel()
+		got := ClassifyRewalks(expected, []LocationFingerprint{
+			{SimHash: 0b11110000},
+			{SimHash: 0b11110001}, // distance 1
+		}, 3)
+		require.Equal(t, OutcomeMatch, got)
+	})
+
+	t.Run("app change", func(t *testing.T) {
+		t.Parallel()
+		got := ClassifyRewalks(expected, []LocationFingerprint{
+			{SimHash: 0b00001111},
+			{SimHash: 0b00001110},
+		}, 3)
+		require.Equal(t, OutcomeAppChange, got)
+	})
+
+	t.Run("session fork", func(t *testing.T) {
+		t.Parallel()
+		got := ClassifyRewalks(expected, []LocationFingerprint{
+			{SimHash: 0b11110000},
+			{SimHash: 0b00001111},
+		}, 3)
+		require.Equal(t, OutcomeSessionFork, got)
+	})
+
+	t.Run("non deterministic", func(t *testing.T) {
+		t.Parallel()
+		got := ClassifyRewalks(expected, []LocationFingerprint{
+			{SimHash: 0b00001111},
+			{SimHash: 0b111100000000}, // far from both expected and first
+		}, 3)
+		require.Equal(t, OutcomeNonDeterministic, got)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, OutcomeNonDeterministic, ClassifyRewalks(expected, nil, 3))
+	})
+}

--- a/pkg/engine/headless/cartography/rewalk.go
+++ b/pkg/engine/headless/cartography/rewalk.go
@@ -1,0 +1,58 @@
+package cartography
+
+import (
+	"context"
+
+	"github.com/projectdiscovery/katana/pkg/engine/headless/types"
+)
+
+// Session clears browser-side state so a rewalk starts from a blank slate.
+type Session interface {
+	Clear(ctx context.Context) error
+}
+
+// Observer replays a path after a clean session and returns what location was reached.
+type Observer interface {
+	Rewalk(ctx context.Context, path *types.Path) (LocationFingerprint, error)
+}
+
+// RewalkReport is one clean-session replay of a path toward expected.
+type RewalkReport struct {
+	Path     *types.Path
+	Expected LocationFingerprint
+	Observed LocationFingerprint
+	Err      error
+}
+
+// Runner clears the session, rewalks each path, and classifies the set of outcomes.
+type Runner struct {
+	Session    Session
+	Observer   Observer
+	MaxHamming int
+}
+
+// Run executes clean-session rewalks for paths that should reach expected.
+func (r *Runner) Run(ctx context.Context, expected LocationFingerprint, paths []*types.Path) (Outcome, []RewalkReport, error) {
+	if r == nil || r.Observer == nil {
+		return OutcomeNonDeterministic, nil, nil
+	}
+	reports := make([]RewalkReport, 0, len(paths))
+	observed := make([]LocationFingerprint, 0, len(paths))
+	for _, p := range paths {
+		if r.Session != nil {
+			if err := r.Session.Clear(ctx); err != nil {
+				return OutcomeNonDeterministic, reports, err
+			}
+		}
+		rep := RewalkReport{Path: p, Expected: expected}
+		got, err := r.Observer.Rewalk(ctx, p)
+		rep.Observed = got
+		rep.Err = err
+		reports = append(reports, rep)
+		if err != nil {
+			continue
+		}
+		observed = append(observed, got)
+	}
+	return ClassifyRewalks(expected, observed, r.MaxHamming), reports, nil
+}

--- a/pkg/engine/headless/cartography/rewalk_test.go
+++ b/pkg/engine/headless/cartography/rewalk_test.go
@@ -1,0 +1,58 @@
+package cartography
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/projectdiscovery/katana/pkg/engine/headless/types"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeSession struct {
+	clears int
+	err    error
+}
+
+func (f *fakeSession) Clear(context.Context) error {
+	f.clears++
+	return f.err
+}
+
+type fakeObserver struct {
+	results []LocationFingerprint
+	err     error
+	calls   int
+}
+
+func (f *fakeObserver) Rewalk(context.Context, *types.Path) (LocationFingerprint, error) {
+	i := f.calls
+	f.calls++
+	if f.err != nil {
+		return LocationFingerprint{}, f.err
+	}
+	if i >= len(f.results) {
+		return LocationFingerprint{}, errors.New("no more results")
+	}
+	return f.results[i], nil
+}
+
+func TestRunnerRun(t *testing.T) {
+	t.Parallel()
+	expected := LocationFingerprint{SimHash: 0b11110000}
+	paths := []*types.Path{
+		{EntryID: "root", TargetID: "a"},
+		{EntryID: "root", TargetID: "a"},
+	}
+	session := &fakeSession{}
+	obs := &fakeObserver{results: []LocationFingerprint{
+		{SimHash: 0b11110000},
+		{SimHash: 0b00001111},
+	}}
+	r := &Runner{Session: session, Observer: obs, MaxHamming: 3}
+	outcome, reports, err := r.Run(context.Background(), expected, paths)
+	require.NoError(t, err)
+	require.Equal(t, OutcomeSessionFork, outcome)
+	require.Equal(t, 2, session.clears)
+	require.Len(t, reports, 2)
+}

--- a/pkg/engine/headless/crawler/crawler.go
+++ b/pkg/engine/headless/crawler/crawler.go
@@ -80,6 +80,9 @@ type Options struct {
 	AuthPassword  string
 	DitClassifier *dit.Classifier
 
+	// RewalkSample is how many discovered paths to clean-session rewalk after the crawl (0 = off).
+	RewalkSample int
+
 	// Hooks installs optional lifecycle callbacks. See Hooks for semantics.
 	// The zero value disables all callbacks.
 	Hooks Hooks
@@ -254,6 +257,7 @@ func (c *Crawler) Crawl(URL string) error {
 		ctx, cancel = context.WithCancel(parentCtx)
 	}
 	defer cancel()
+	defer c.maybeRewalk(context.WithoutCancel(ctx))
 
 	consecutiveFailures := 0
 

--- a/pkg/engine/headless/crawler/rewalk.go
+++ b/pkg/engine/headless/crawler/rewalk.go
@@ -1,0 +1,117 @@
+package crawler
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/projectdiscovery/katana/pkg/engine/headless/browser"
+	"github.com/projectdiscovery/katana/pkg/engine/headless/cartography"
+	"github.com/projectdiscovery/katana/pkg/engine/headless/types"
+)
+
+type pageSession struct {
+	bp *browser.BrowserPage
+}
+
+func (s *pageSession) Clear(ctx context.Context) error {
+	if s == nil || s.bp == nil {
+		return nil
+	}
+	return browser.ClearSession(ctx, s.bp.Page)
+}
+
+type pathObserver struct {
+	c    *Crawler
+	page *browser.BrowserPage
+}
+
+func (o *pathObserver) Rewalk(ctx context.Context, path *types.Path) (cartography.LocationFingerprint, error) {
+	if path == nil {
+		return cartography.LocationFingerprint{}, nil
+	}
+	o.page.Page = o.page.Context(ctx)
+	for _, step := range path.Steps {
+		if step == nil {
+			continue
+		}
+		if err := o.c.executeCrawlStateAction(step, o.page); err != nil {
+			return cartography.LocationFingerprint{}, err
+		}
+	}
+	_, state, err := getPageHash(o.page)
+	if err != nil {
+		return cartography.LocationFingerprint{}, err
+	}
+	return cartography.LocationFingerprint{
+		UniqueID: state.UniqueID,
+		URL:      state.URL,
+		SimHash:  state.SimHash,
+	}, nil
+}
+
+func samplePaths(paths []*types.Path, n int) []*types.Path {
+	if n <= 0 || len(paths) == 0 {
+		return nil
+	}
+	if n >= len(paths) {
+		out := make([]*types.Path, len(paths))
+		copy(out, paths)
+		return out
+	}
+	out := make([]*types.Path, n)
+	copy(out, paths[:n])
+	return out
+}
+
+// maybeRewalk clears the session and replays a sample of discovered paths to
+// classify match / app_change / session_fork / non_deterministic.
+func (c *Crawler) maybeRewalk(ctx context.Context) {
+	if c == nil || c.options.RewalkSample <= 0 || c.crawlGraph == nil || c.launcher == nil {
+		return
+	}
+	paths, err := c.Paths()
+	if err != nil || len(paths) == 0 {
+		return
+	}
+	sample := samplePaths(paths, c.options.RewalkSample)
+	page, err := c.launcher.GetPageFromPool()
+	if err != nil {
+		c.logger.Debug("rewalk skipped: no page", slog.String("error", err.Error()))
+		return
+	}
+	defer c.launcher.PutBrowserToPool(page)
+
+	runner := &cartography.Runner{
+		Session:    &pageSession{bp: page},
+		Observer:   &pathObserver{c: c, page: page},
+		MaxHamming: cartography.DefaultMaxHamming,
+	}
+
+	rewalkCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+
+	for _, p := range sample {
+		ps, err := c.crawlGraph.GetPageState(p.TargetID)
+		if err != nil {
+			continue
+		}
+		expected := cartography.LocationFingerprint{
+			UniqueID: ps.UniqueID,
+			URL:      ps.URL,
+			SimHash:  ps.SimHash,
+		}
+		outcome, _, err := runner.Run(rewalkCtx, expected, []*types.Path{p})
+		if err != nil {
+			c.logger.Debug("rewalk failed",
+				slog.String("target", p.TargetURL),
+				slog.String("error", err.Error()),
+			)
+			continue
+		}
+		c.logger.Info("rewalk complete",
+			slog.String("target", p.TargetURL),
+			slog.String("outcome", string(outcome)),
+		)
+	}
+}

--- a/pkg/engine/headless/crawler/rewalk_test.go
+++ b/pkg/engine/headless/crawler/rewalk_test.go
@@ -1,0 +1,16 @@
+package crawler
+
+import (
+	"testing"
+
+	"github.com/projectdiscovery/katana/pkg/engine/headless/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSamplePaths(t *testing.T) {
+	t.Parallel()
+	paths := []*types.Path{{TargetID: "a"}, {TargetID: "b"}, {TargetID: "c"}}
+	require.Nil(t, samplePaths(paths, 0))
+	require.Len(t, samplePaths(paths, 2), 2)
+	require.Len(t, samplePaths(paths, 10), 3)
+}

--- a/pkg/engine/headless/headless.go
+++ b/pkg/engine/headless/headless.go
@@ -126,6 +126,7 @@ func (h *Headless) Crawl(URL string) error {
 		PageLoadStrategy:  h.options.Options.PageLoadStrategy,
 		ChromeWSUrl:       h.options.Options.ChromeWSUrl,
 		DOMWaitTime:       h.options.Options.DOMWaitTime,
+		RewalkSample:      h.options.Options.RewalkSample,
 		RequestCallback: func(rr *output.Result) {
 			if rr == nil || rr.Request == nil {
 				return

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -191,6 +191,8 @@ type Options struct {
 	// FilterSimilarThreshold is the number of distinct values at a path position
 	// before it is treated as a parameter (default 10, lower = more aggressive)
 	FilterSimilarThreshold int
+	// RewalkSample is how many headless paths to clean-session rewalk after crawl (0 = off)
+	RewalkSample int
 	// Debug
 	Debug bool
 	// TlsImpersonate enables experimental tls ClientHello randomization for standard crawler


### PR DESCRIPTION
Fixes #1716

Stacked on #1715 / headless-path-export.

Adds ClearSession, a rewalk runner that classifies match / app_change / session_fork / non_deterministic, and optional post-crawl sampling via RewalkSample.