### PR TITLE
Headless treats volatile links as new doors every time

### DIFF
--- a/pkg/engine/headless/cartography/link_identity.go
+++ b/pkg/engine/headless/cartography/link_identity.go
@@ -1,0 +1,183 @@
+package cartography
+
+import (
+	"net/url"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/projectdiscovery/katana/pkg/engine/headless/types"
+)
+
+// LinkFeatures are the stable-ish attributes used to recognize a door across revisits.
+type LinkFeatures struct {
+	Tag        string
+	ID         string
+	CSSPath    string
+	Text       string
+	PathOnly   string // URL path without query/fragment
+	QueryKeys  []string
+	ActionType types.ActionType
+}
+
+// LinkIdentity tracks which features remain stable for a logical door.
+type LinkIdentity struct {
+	mu       sync.Mutex
+	core     LinkFeatures
+	visits   int
+	unstable map[string]int // feature name -> times it changed
+}
+
+// Observe updates core features: values that change are marked unstable and cleared from core.
+func (l *LinkIdentity) Observe(f LinkFeatures) {
+	if l == nil {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.visits++
+	if l.unstable == nil {
+		l.unstable = make(map[string]int)
+	}
+	if l.visits == 1 {
+		l.core = normalizeFeatures(f)
+		return
+	}
+	cur := normalizeFeatures(f)
+	l.dropIfChanged("tag", l.core.Tag, cur.Tag, func() { l.core.Tag = "" })
+	l.dropIfChanged("id", l.core.ID, cur.ID, func() { l.core.ID = "" })
+	l.dropIfChanged("css", l.core.CSSPath, cur.CSSPath, func() { l.core.CSSPath = "" })
+	l.dropIfChanged("text", l.core.Text, cur.Text, func() { l.core.Text = "" })
+	l.dropIfChanged("path", l.core.PathOnly, cur.PathOnly, func() { l.core.PathOnly = "" })
+	if !sameStringSet(l.core.QueryKeys, cur.QueryKeys) {
+		l.unstable["query_keys"]++
+		l.core.QueryKeys = nil
+	}
+	if l.core.ActionType != "" && cur.ActionType != "" && l.core.ActionType != cur.ActionType {
+		l.unstable["action_type"]++
+		l.core.ActionType = ""
+	}
+}
+
+func (l *LinkIdentity) dropIfChanged(name, old, neu string, clear func()) {
+	if old == "" || neu == "" {
+		return
+	}
+	if old != neu {
+		l.unstable[name]++
+		clear()
+	}
+}
+
+// Core returns a snapshot of features still considered stable.
+func (l *LinkIdentity) Core() LinkFeatures {
+	if l == nil {
+		return LinkFeatures{}
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := l.core
+	if len(l.core.QueryKeys) > 0 {
+		out.QueryKeys = append([]string(nil), l.core.QueryKeys...)
+	}
+	return out
+}
+
+// Visits returns how many observations were recorded.
+func (l *LinkIdentity) Visits() int {
+	if l == nil {
+		return 0
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.visits
+}
+
+// Matches reports whether f agrees with remaining core features.
+// Empty fields on f are ignored so partial observations can still match.
+func (l *LinkIdentity) Matches(f LinkFeatures) bool {
+	core := l.Core()
+	f = normalizeFeatures(f)
+	if core.Tag != "" && f.Tag != "" && core.Tag != f.Tag {
+		return false
+	}
+	if core.ID != "" && f.ID != "" && core.ID != f.ID {
+		return false
+	}
+	if core.CSSPath != "" && f.CSSPath != "" && core.CSSPath != f.CSSPath {
+		return false
+	}
+	if core.Text != "" && f.Text != "" && core.Text != f.Text {
+		return false
+	}
+	if core.PathOnly != "" && f.PathOnly != "" && core.PathOnly != f.PathOnly {
+		return false
+	}
+	if len(core.QueryKeys) > 0 && len(f.QueryKeys) > 0 && !sameStringSet(core.QueryKeys, f.QueryKeys) {
+		return false
+	}
+	if core.ActionType != "" && f.ActionType != "" && core.ActionType != f.ActionType {
+		return false
+	}
+	return true
+}
+
+// FeaturesFromAction extracts link features from a crawl action.
+func FeaturesFromAction(a *types.Action) LinkFeatures {
+	if a == nil {
+		return LinkFeatures{}
+	}
+	f := LinkFeatures{ActionType: a.Type}
+	if a.Element != nil {
+		f.Tag = a.Element.TagName
+		f.ID = a.Element.ID
+		f.CSSPath = a.Element.CSSSelector
+		f.Text = strings.TrimSpace(a.Element.TextContent)
+		if href := a.Element.Attributes["href"]; href != "" {
+			f.PathOnly, f.QueryKeys = splitURLFeatures(href)
+		}
+	}
+	if a.Type == types.ActionTypeLoadURL && a.Input != "" {
+		f.PathOnly, f.QueryKeys = splitURLFeatures(a.Input)
+	}
+	return normalizeFeatures(f)
+}
+
+func splitURLFeatures(raw string) (pathOnly string, queryKeys []string) {
+	u, err := url.Parse(raw)
+	if err != nil || u == nil {
+		return raw, nil
+	}
+	pathOnly = u.Path
+	for k := range u.Query() {
+		queryKeys = append(queryKeys, k)
+	}
+	sort.Strings(queryKeys)
+	return pathOnly, queryKeys
+}
+
+func normalizeFeatures(f LinkFeatures) LinkFeatures {
+	f.Tag = strings.ToLower(strings.TrimSpace(f.Tag))
+	f.ID = strings.TrimSpace(f.ID)
+	f.CSSPath = strings.TrimSpace(f.CSSPath)
+	f.Text = strings.Join(strings.Fields(f.Text), " ")
+	f.PathOnly = strings.TrimSpace(f.PathOnly)
+	if len(f.QueryKeys) > 0 {
+		keys := append([]string(nil), f.QueryKeys...)
+		sort.Strings(keys)
+		f.QueryKeys = keys
+	}
+	return f
+}
+
+func sameStringSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/engine/headless/cartography/link_identity.go
+++ b/pkg/engine/headless/cartography/link_identity.go
@@ -94,32 +94,48 @@ func (l *LinkIdentity) Visits() int {
 }
 
 // Matches reports whether f agrees with remaining core features.
-// Empty fields on f are ignored so partial observations can still match.
+// Empty fields on f are ignored so partial observations can still match, but a
+// match requires positive agreement on at least one discriminating feature:
+// otherwise a fully churned (empty-core) identity would match every candidate
+// and silently swallow the rest of the crawl.
 func (l *LinkIdentity) Matches(f LinkFeatures) bool {
 	core := l.Core()
 	f = normalizeFeatures(f)
-	if core.Tag != "" && f.Tag != "" && core.Tag != f.Tag {
+
+	agreed := false
+	// strong compares a discriminating feature: a contradiction fails the match
+	// and positive agreement satisfies the "at least one real signal" rule.
+	strong := func(a, b string) bool {
+		if a == "" || b == "" {
+			return true
+		}
+		if a != b {
+			return false
+		}
+		agreed = true
+		return true
+	}
+	// weak features (tag, action type) are shared by whole classes of elements
+	// (every <a>, every form). They can only reject a match, never confirm one.
+	weak := func(a, b string) bool {
+		return a == "" || b == "" || a == b
+	}
+	if !strong(core.ID, f.ID) ||
+		!strong(core.CSSPath, f.CSSPath) ||
+		!strong(core.Text, f.Text) ||
+		!strong(core.PathOnly, f.PathOnly) {
 		return false
 	}
-	if core.ID != "" && f.ID != "" && core.ID != f.ID {
+	if len(core.QueryKeys) > 0 && len(f.QueryKeys) > 0 {
+		if !sameStringSet(core.QueryKeys, f.QueryKeys) {
+			return false
+		}
+		agreed = true
+	}
+	if !weak(core.Tag, f.Tag) || !weak(string(core.ActionType), string(f.ActionType)) {
 		return false
 	}
-	if core.CSSPath != "" && f.CSSPath != "" && core.CSSPath != f.CSSPath {
-		return false
-	}
-	if core.Text != "" && f.Text != "" && core.Text != f.Text {
-		return false
-	}
-	if core.PathOnly != "" && f.PathOnly != "" && core.PathOnly != f.PathOnly {
-		return false
-	}
-	if len(core.QueryKeys) > 0 && len(f.QueryKeys) > 0 && !sameStringSet(core.QueryKeys, f.QueryKeys) {
-		return false
-	}
-	if core.ActionType != "" && f.ActionType != "" && core.ActionType != f.ActionType {
-		return false
-	}
-	return true
+	return agreed
 }
 
 // FeaturesFromAction extracts link features from a crawl action.
@@ -146,7 +162,9 @@ func FeaturesFromAction(a *types.Action) LinkFeatures {
 func splitURLFeatures(raw string) (pathOnly string, queryKeys []string) {
 	u, err := url.Parse(raw)
 	if err != nil || u == nil {
-		return raw, nil
+		// A malformed href has no meaningful path; returning the raw string
+		// would plant a bogus PathOnly feature that never matches anything.
+		return "", nil
 	}
 	pathOnly = u.Path
 	for k := range u.Query() {

--- a/pkg/engine/headless/cartography/link_identity_test.go
+++ b/pkg/engine/headless/cartography/link_identity_test.go
@@ -1,0 +1,62 @@
+package cartography
+
+import (
+	"testing"
+
+	"github.com/projectdiscovery/katana/pkg/engine/headless/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLinkIdentityDropsVolatileQuery(t *testing.T) {
+	t.Parallel()
+	id := &LinkIdentity{}
+	id.Observe(FeaturesFromAction(&types.Action{
+		Type: types.ActionTypeLeftClick,
+		Element: &types.HTMLElement{
+			TagName:     "a",
+			ID:          "buy",
+			CSSSelector: "a#buy",
+			TextContent: "Buy",
+			Attributes:  map[string]string{"href": "/product?id=1&token=aaa"},
+		},
+	}))
+	id.Observe(FeaturesFromAction(&types.Action{
+		Type: types.ActionTypeLeftClick,
+		Element: &types.HTMLElement{
+			TagName:     "a",
+			ID:          "buy",
+			CSSSelector: "a#buy",
+			TextContent: "Buy",
+			Attributes:  map[string]string{"href": "/product?id=2&token=bbb"},
+		},
+	}))
+
+	core := id.Core()
+	require.Equal(t, 2, id.Visits())
+	require.Equal(t, "a", core.Tag)
+	require.Equal(t, "buy", core.ID)
+	require.Equal(t, "/product", core.PathOnly)
+	// query key set changed (id/token values change identity of key set still same keys - wait, keys are id,token both times)
+	// Path stayed; query keys same set [id, token] - should remain
+	require.Equal(t, []string{"id", "token"}, core.QueryKeys)
+
+	// Path changes → path dropped
+	id.Observe(FeaturesFromAction(&types.Action{
+		Type: types.ActionTypeLeftClick,
+		Element: &types.HTMLElement{
+			TagName:    "a",
+			ID:         "buy",
+			Attributes: map[string]string{"href": "/other?id=3&token=ccc"},
+		},
+	}))
+	core = id.Core()
+	require.Empty(t, core.PathOnly)
+	require.True(t, id.Matches(FeaturesFromAction(&types.Action{
+		Type: types.ActionTypeLeftClick,
+		Element: &types.HTMLElement{
+			TagName:    "a",
+			ID:         "buy",
+			Attributes: map[string]string{"href": "/whatever?id=9&token=zzz"},
+		},
+	})))
+}

--- a/pkg/engine/headless/crawler/crawler.go
+++ b/pkg/engine/headless/crawler/crawler.go
@@ -22,6 +22,7 @@ import (
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/katana/pkg/engine/headless/browser"
 	"github.com/projectdiscovery/katana/pkg/engine/headless/captcha"
+	"github.com/projectdiscovery/katana/pkg/engine/headless/cartography"
 	"github.com/projectdiscovery/katana/pkg/engine/headless/crawler/diagnostics"
 	"github.com/projectdiscovery/katana/pkg/engine/headless/crawler/normalizer"
 	"github.com/projectdiscovery/katana/pkg/engine/headless/crawler/normalizer/simhash"
@@ -31,15 +32,16 @@ import (
 )
 
 type Crawler struct {
-	logger        *slog.Logger
-	launcher      *browser.Launcher
-	options       Options
-	crawlQueue    queue.Queue[*types.Action]
-	crawlGraph    *graph.CrawlGraph
-	simhashOracle *simhash.Oracle
-	uniqueActions map[string]struct{}
-	diagnostics   diagnostics.Writer
-	loggedIn      bool
+	logger         *slog.Logger
+	launcher       *browser.Launcher
+	options        Options
+	crawlQueue     queue.Queue[*types.Action]
+	crawlGraph     *graph.CrawlGraph
+	simhashOracle  *simhash.Oracle
+	uniqueActions  map[string]struct{}
+	linkIdentities []*cartography.LinkIdentity
+	diagnostics    diagnostics.Writer
+	loggedIn       bool
 }
 
 type Options struct {
@@ -82,6 +84,9 @@ type Options struct {
 
 	// RewalkSample is how many discovered paths to clean-session rewalk after the crawl (0 = off).
 	RewalkSample int
+
+	// LinkIdentity enables volatile-door dedupe across revisits (default on when budget > 0).
+	LinkIdentityBudget int
 
 	// Hooks installs optional lifecycle callbacks. See Hooks for semantics.
 	// The zero value disables all callbacks.
@@ -488,6 +493,12 @@ func (c *Crawler) crawlFn(ctx context.Context, action *types.Action, page *brows
 		if nav.Element != nil && isLogoutPage(nav.Element) {
 			c.logger.Debug("Skipping Found logout page",
 				slog.String("url", nav.Element.Attributes["href"]),
+			)
+			continue
+		}
+		if !c.acceptLinkIdentity(nav) {
+			c.logger.Debug("Skipping navigation as link identity budget exhausted",
+				slog.Any("navigation", nav),
 			)
 			continue
 		}

--- a/pkg/engine/headless/crawler/link_identity.go
+++ b/pkg/engine/headless/crawler/link_identity.go
@@ -1,0 +1,28 @@
+package crawler
+
+import (
+	"github.com/projectdiscovery/katana/pkg/engine/headless/cartography"
+	"github.com/projectdiscovery/katana/pkg/engine/headless/types"
+)
+
+func (c *Crawler) acceptLinkIdentity(nav *types.Action) bool {
+	budget := c.options.LinkIdentityBudget
+	if budget < 0 {
+		return true // disabled
+	}
+	if budget == 0 {
+		budget = 1
+	}
+	f := cartography.FeaturesFromAction(nav)
+	for _, id := range c.linkIdentities {
+		if !id.Matches(f) {
+			continue
+		}
+		id.Observe(f)
+		return id.Visits() <= budget
+	}
+	id := &cartography.LinkIdentity{}
+	id.Observe(f)
+	c.linkIdentities = append(c.linkIdentities, id)
+	return true
+}

--- a/pkg/engine/headless/crawler/link_identity_test.go
+++ b/pkg/engine/headless/crawler/link_identity_test.go
@@ -1,0 +1,34 @@
+package crawler
+
+import (
+	"testing"
+
+	"github.com/projectdiscovery/katana/pkg/engine/headless/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAcceptLinkIdentityBudget(t *testing.T) {
+	t.Parallel()
+	c := &Crawler{options: Options{LinkIdentityBudget: 1}}
+	nav := &types.Action{
+		Type: types.ActionTypeLeftClick,
+		Element: &types.HTMLElement{
+			TagName:    "a",
+			ID:         "buy",
+			Attributes: map[string]string{"href": "/p?id=1&token=a"},
+		},
+	}
+	require.True(t, c.acceptLinkIdentity(nav))
+	nav2 := &types.Action{
+		Type: types.ActionTypeLeftClick,
+		Element: &types.HTMLElement{
+			TagName:    "a",
+			ID:         "buy",
+			Attributes: map[string]string{"href": "/p?id=2&token=b"},
+		},
+	}
+	require.False(t, c.acceptLinkIdentity(nav2))
+
+	disabled := &Crawler{options: Options{LinkIdentityBudget: -1}}
+	require.True(t, disabled.acceptLinkIdentity(nav2))
+}

--- a/pkg/engine/headless/headless.go
+++ b/pkg/engine/headless/headless.go
@@ -125,8 +125,9 @@ func (h *Headless) Crawl(URL string) error {
 		AutomaticFormFill: h.options.Options.AutomaticFormFill,
 		PageLoadStrategy:  h.options.Options.PageLoadStrategy,
 		ChromeWSUrl:       h.options.Options.ChromeWSUrl,
-		DOMWaitTime:       h.options.Options.DOMWaitTime,
-		RewalkSample:      h.options.Options.RewalkSample,
+		DOMWaitTime:        h.options.Options.DOMWaitTime,
+		RewalkSample:       h.options.Options.RewalkSample,
+		LinkIdentityBudget: h.options.Options.LinkIdentityBudget,
 		RequestCallback: func(rr *output.Result) {
 			if rr == nil || rr.Request == nil {
 				return

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -193,6 +193,8 @@ type Options struct {
 	FilterSimilarThreshold int
 	// RewalkSample is how many headless paths to clean-session rewalk after crawl (0 = off)
 	RewalkSample int
+	// LinkIdentityBudget is how many near-duplicate doors to enqueue (-1 disables, default 1)
+	LinkIdentityBudget int
 	// Debug
 	Debug bool
 	// TlsImpersonate enables experimental tls ClientHello randomization for standard crawler


### PR DESCRIPTION
Fixes #1717

Stacked on headless-clean-rewalk.

Tracks stable door features across revisits, drops fields that churn, and skips enqueue once LinkIdentityBudget is hit.