### PR TITLE
Headless has no distinct crawl identities

### DIFF
--- a/cmd/katana/main.go
+++ b/cmd/katana/main.go
@@ -183,6 +183,7 @@ func readFlags() (*goflags.FlagSet, error) {
 		flagSet.StringVarEnv(&options.CaptchaSolverProvider, "captcha-solver-provider", "csp", "", "CAPTCHA_SOLVER_PROVIDER", "captcha solver provider (e.g. capsolver)"),
 		flagSet.StringVarEnv(&options.CaptchaSolverAPIKey, "captcha-solver-key", "csk", "", "CAPTCHA_SOLVER_KEY", "captcha solver provider api key"),
 		flagSet.StringVarEnv(&options.AuthCredentials, "auto-login", "al", "", "AUTH_CREDENTIALS", "automatic login with username:password (headless only)"),
+		flagSet.IntVarP(&options.HeadlessAgents, "headless-agents", "ha", 1, "number of isolated headless browser identities to run (forced to 1 with -cdd/-cwu)"),
 	)
 
 	// Scope group

--- a/pkg/engine/headless/agents.go
+++ b/pkg/engine/headless/agents.go
@@ -1,0 +1,67 @@
+package headless
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/katana/pkg/engine/headless/cartography"
+	"github.com/projectdiscovery/katana/pkg/types"
+)
+
+func buildAgentPool(opts *types.Options) *cartography.AgentPool {
+	if opts == nil {
+		return cartography.NewAgentPool()
+	}
+	if opts.ChromeDataDir != "" || opts.ChromeWSUrl != "" {
+		return cartography.NewAgentPool(&cartography.Agent{
+			ID:      "default",
+			Role:    "anon",
+			DataDir: opts.ChromeDataDir,
+		})
+	}
+	n := opts.HeadlessAgents
+	if n <= 0 {
+		n = 1
+	}
+	agents := make([]*cartography.Agent, 0, n)
+	for i := 0; i < n; i++ {
+		a := &cartography.Agent{
+			ID:   fmt.Sprintf("agent-%d", i),
+			Role: "anon",
+		}
+		if opts.AuthCredentials != "" && i == 0 {
+			a.Credentials = opts.AuthCredentials
+			a.Role = "auth"
+		}
+		agents = append(agents, a)
+	}
+	pool := cartography.NewAgentPool(agents...)
+	if cartography.DetectSingleLoginConflict(pool.All()) {
+		gologger.Warning().Msg("headless agents share credentials; prefer distinct accounts")
+	}
+	return pool
+}
+
+func ensureAgentDataDir(agent *cartography.Agent) (cleanup func(), err error) {
+	cleanup = func() {}
+	if agent == nil || agent.DataDir != "" {
+		return cleanup, nil
+	}
+	dir, err := os.MkdirTemp("", fmt.Sprintf("katana-agent-%s-*", agent.ID))
+	if err != nil {
+		return cleanup, err
+	}
+	agent.DataDir = dir
+	return func() { _ = os.RemoveAll(dir) }, nil
+}
+
+func splitCredentials(creds string) (user, pass string) {
+	parts := strings.SplitN(creds, ":", 2)
+	user = parts[0]
+	if len(parts) > 1 {
+		pass = parts[1]
+	}
+	return user, pass
+}

--- a/pkg/engine/headless/agents.go
+++ b/pkg/engine/headless/agents.go
@@ -38,8 +38,11 @@ func buildAgentPool(opts *types.Options) *cartography.AgentPool {
 		agents = append(agents, a)
 	}
 	pool := cartography.NewAgentPool(agents...)
-	if cartography.DetectSingleLoginConflict(pool.All()) {
-		gologger.Warning().Msg("headless agents share credentials; prefer distinct accounts")
+	// A single -auto-login credential authenticates only the first agent; the
+	// rest crawl anonymously. Warn so the user knows N-1 identities are anon and
+	// can supply distinct accounts if they wanted multiple authenticated crawls.
+	if opts.AuthCredentials != "" && n > 1 {
+		gologger.Warning().Msgf("only 1 of %d headless agents is authenticated; the rest crawl anonymously (provide distinct accounts for multiple authenticated identities)", n)
 	}
 	return pool
 }

--- a/pkg/engine/headless/agents_test.go
+++ b/pkg/engine/headless/agents_test.go
@@ -1,0 +1,27 @@
+package headless
+
+import (
+	"testing"
+
+	"github.com/projectdiscovery/katana/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildAgentPool(t *testing.T) {
+	t.Parallel()
+	p := buildAgentPool(&types.Options{HeadlessAgents: 2})
+	require.Equal(t, 2, p.Len())
+
+	p = buildAgentPool(&types.Options{ChromeDataDir: "/tmp/x", HeadlessAgents: 5})
+	require.Equal(t, 1, p.Len())
+	a, ok := p.Get("default")
+	require.True(t, ok)
+	require.Equal(t, "/tmp/x", a.DataDir)
+}
+
+func TestSplitCredentials(t *testing.T) {
+	t.Parallel()
+	u, p := splitCredentials("alice:s3cret")
+	require.Equal(t, "alice", u)
+	require.Equal(t, "s3cret", p)
+}

--- a/pkg/engine/headless/cartography/agents.go
+++ b/pkg/engine/headless/cartography/agents.go
@@ -1,0 +1,95 @@
+package cartography
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Agent is a crawl identity with its own cookie/storage jar.
+// Unlike hybrid -c browser workers (throughput), agents model distinct users/roles.
+type Agent struct {
+	ID          string
+	Role        string // e.g. anon, user, admin
+	Credentials string // optional username:password or recorded-flow ref
+	DataDir     string // chrome user-data-dir for jar isolation
+}
+
+// AgentPool holds named identities for multi-agent cartography.
+type AgentPool struct {
+	mu     sync.Mutex
+	agents []*Agent
+}
+
+// NewAgentPool creates a pool. If agents is empty, a single anon agent is used.
+func NewAgentPool(agents ...*Agent) *AgentPool {
+	p := &AgentPool{}
+	if len(agents) == 0 {
+		p.agents = []*Agent{{ID: "anon", Role: "anon"}}
+		return p
+	}
+	for i, a := range agents {
+		if a == nil {
+			continue
+		}
+		cp := *a
+		if cp.ID == "" {
+			cp.ID = fmt.Sprintf("agent-%d", i)
+		}
+		if cp.Role == "" {
+			cp.Role = "anon"
+		}
+		p.agents = append(p.agents, &cp)
+	}
+	if len(p.agents) == 0 {
+		p.agents = []*Agent{{ID: "anon", Role: "anon"}}
+	}
+	return p
+}
+
+// All returns a snapshot of agents.
+func (p *AgentPool) All() []*Agent {
+	if p == nil {
+		return nil
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]*Agent, len(p.agents))
+	copy(out, p.agents)
+	return out
+}
+
+// Len returns the number of agents.
+func (p *AgentPool) Len() int {
+	if p == nil {
+		return 0
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.agents)
+}
+
+// Get returns an agent by ID.
+func (p *AgentPool) Get(id string) (*Agent, bool) {
+	for _, a := range p.All() {
+		if a.ID == id {
+			return a, true
+		}
+	}
+	return nil, false
+}
+
+// DetectSingleLoginConflict reports whether two authenticated agents share credentials.
+// Burp uses this signal to avoid concurrent logins for the same account.
+func DetectSingleLoginConflict(agents []*Agent) bool {
+	seen := map[string]struct{}{}
+	for _, a := range agents {
+		if a == nil || a.Credentials == "" {
+			continue
+		}
+		if _, ok := seen[a.Credentials]; ok {
+			return true
+		}
+		seen[a.Credentials] = struct{}{}
+	}
+	return false
+}

--- a/pkg/engine/headless/cartography/agents_test.go
+++ b/pkg/engine/headless/cartography/agents_test.go
@@ -1,0 +1,41 @@
+package cartography
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgentPoolDefaults(t *testing.T) {
+	t.Parallel()
+	p := NewAgentPool()
+	require.Equal(t, 1, p.Len())
+	a, ok := p.Get("anon")
+	require.True(t, ok)
+	require.Equal(t, "anon", a.Role)
+
+	p2 := NewAgentPool(
+		&Agent{Role: "user", Credentials: "u:p", DataDir: "/tmp/u"},
+		&Agent{ID: "admin", Role: "admin", Credentials: "a:p"},
+	)
+	require.Equal(t, 2, p2.Len())
+	first := p2.All()[0]
+	require.Equal(t, "agent-0", first.ID)
+	require.Equal(t, "user", first.Role)
+}
+
+func TestDetectSingleLoginConflict(t *testing.T) {
+	t.Parallel()
+	require.False(t, DetectSingleLoginConflict([]*Agent{
+		{ID: "a", Credentials: "u:p"},
+		{ID: "b", Credentials: "u2:p"},
+	}))
+	require.True(t, DetectSingleLoginConflict([]*Agent{
+		{ID: "a", Credentials: "u:p"},
+		{ID: "b", Credentials: "u:p"},
+	}))
+	require.False(t, DetectSingleLoginConflict([]*Agent{
+		{ID: "a"},
+		{ID: "b", Credentials: "u:p"},
+	}))
+}

--- a/pkg/engine/headless/headless.go
+++ b/pkg/engine/headless/headless.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/lmittmann/tint"
@@ -13,6 +12,7 @@ import (
 	"github.com/projectdiscovery/katana/pkg/engine/headless/browser"
 	"github.com/projectdiscovery/katana/pkg/engine/headless/captcha"
 	_ "github.com/projectdiscovery/katana/pkg/engine/headless/captcha/capsolver"
+	"github.com/projectdiscovery/katana/pkg/engine/headless/cartography"
 	"github.com/projectdiscovery/katana/pkg/engine/headless/crawler"
 	"github.com/projectdiscovery/katana/pkg/engine/parser"
 	"github.com/projectdiscovery/katana/pkg/output"
@@ -106,25 +106,47 @@ func (h *Headless) Crawl(URL string) error {
 		}
 	}()
 
+	pool := buildAgentPool(h.options.Options)
+	var firstErr error
+	for _, agent := range pool.All() {
+		cleanup, err := ensureAgentDataDir(agent)
+		if err != nil {
+			return err
+		}
+		err = h.crawlWithAgent(URL, agent)
+		cleanup()
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func (h *Headless) crawlWithAgent(URL string, agent *cartography.Agent) error {
 	scopeValidator := validateScopeFunc(h, URL)
 
+	userDataDir := h.options.Options.ChromeDataDir
+	if agent != nil && agent.DataDir != "" {
+		userDataDir = agent.DataDir
+	}
+
 	crawlOpts := crawler.Options{
-		Context:           h.options.Options.Context,
-		ChromiumPath:      h.options.Options.SystemChromePath,
-		MaxDepth:          h.options.Options.MaxDepth,
-		ShowBrowser:       h.options.Options.ShowBrowser,
-		MaxCrawlDuration:  h.options.Options.CrawlDuration,
-		MaxFailureCount:   h.options.Options.MaxFailureCount,
-		NoSandbox:         h.options.Options.HeadlessNoSandbox,
-		NoIncognito:       h.options.Options.HeadlessNoIncognito,
-		UserDataDir:       h.options.Options.ChromeDataDir,
-		Proxy:             h.options.Options.Proxy,
-		MaxBrowsers:       1,
-		PageMaxTimeout:    30 * time.Second,
-		ScopeValidator:    scopeValidator,
-		AutomaticFormFill: h.options.Options.AutomaticFormFill,
-		PageLoadStrategy:  h.options.Options.PageLoadStrategy,
-		ChromeWSUrl:       h.options.Options.ChromeWSUrl,
+		Context:            h.options.Options.Context,
+		ChromiumPath:       h.options.Options.SystemChromePath,
+		MaxDepth:           h.options.Options.MaxDepth,
+		ShowBrowser:        h.options.Options.ShowBrowser,
+		MaxCrawlDuration:   h.options.Options.CrawlDuration,
+		MaxFailureCount:    h.options.Options.MaxFailureCount,
+		NoSandbox:          h.options.Options.HeadlessNoSandbox,
+		NoIncognito:        h.options.Options.HeadlessNoIncognito,
+		UserDataDir:        userDataDir,
+		Proxy:              h.options.Options.Proxy,
+		MaxBrowsers:        1,
+		PageMaxTimeout:     30 * time.Second,
+		ScopeValidator:     scopeValidator,
+		AutomaticFormFill:  h.options.Options.AutomaticFormFill,
+		PageLoadStrategy:   h.options.Options.PageLoadStrategy,
+		ChromeWSUrl:        h.options.Options.ChromeWSUrl,
 		DOMWaitTime:        h.options.Options.DOMWaitTime,
 		RewalkSample:       h.options.Options.RewalkSample,
 		LinkIdentityBudget: h.options.Options.LinkIdentityBudget,
@@ -136,15 +158,8 @@ func (h *Headless) Crawl(URL string) error {
 				return
 			}
 
-			// Register the real (intercepted) request URL before parsing the
-			// response body for additional discoveries. This ensures that real
-			// results with full response data always take priority over
-			// synthetic Request-only entries produced by performAdditionalAnalysis.
 			isUnique := h.isUniqueURL(rr.Request.URL)
 
-			// Always run additional analysis regardless of uniqueness so we
-			// don't miss URL discoveries embedded in a response body that the
-			// browser happened to fetch more than once.
 			navigationRequests := h.performAdditionalAnalysis(rr)
 			for _, req := range navigationRequests {
 				if err := h.options.OutputWriter.Write(req); err != nil {
@@ -193,12 +208,12 @@ func (h *Headless) Crawl(URL string) error {
 		Hooks:               h.hooks,
 	}
 
-	if creds := h.options.Options.AuthCredentials; creds != "" {
-		parts := strings.SplitN(creds, ":", 2)
-		crawlOpts.AuthUsername = parts[0]
-		if len(parts) > 1 {
-			crawlOpts.AuthPassword = parts[1]
-		}
+	creds := h.options.Options.AuthCredentials
+	if agent != nil && agent.Credentials != "" {
+		creds = agent.Credentials
+	}
+	if creds != "" {
+		crawlOpts.AuthUsername, crawlOpts.AuthPassword = splitCredentials(creds)
 	}
 
 	if provider := h.options.Options.CaptchaSolverProvider; provider != "" {
@@ -211,7 +226,12 @@ func (h *Headless) Crawl(URL string) error {
 		}
 	}
 
-	// TODO: Make the crawling multi-threaded. Right now concurrency is hardcoded to 1.
+	if agent != nil {
+		h.logger.Info("headless agent starting",
+			slog.String("agent", agent.ID),
+			slog.String("role", agent.Role),
+		)
+	}
 
 	headlessCrawler, err := crawler.New(crawlOpts)
 	if err != nil {
@@ -219,10 +239,7 @@ func (h *Headless) Crawl(URL string) error {
 	}
 	defer headlessCrawler.Close()
 
-	if err = headlessCrawler.Crawl(URL); err != nil {
-		return err
-	}
-	return nil
+	return headlessCrawler.Crawl(URL)
 }
 
 func (h *Headless) Close() error {

--- a/pkg/engine/headless/headless.go
+++ b/pkg/engine/headless/headless.go
@@ -107,16 +107,26 @@ func (h *Headless) Crawl(URL string) error {
 	}()
 
 	pool := buildAgentPool(h.options.Options)
+	// A remote browser (-cwu) ignores user-data-dir, so per-agent temp jars are
+	// pointless there; only isolate data dirs for locally launched browsers.
+	remoteBrowser := h.options.Options.ChromeWSUrl != ""
 	var firstErr error
 	for _, agent := range pool.All() {
-		cleanup, err := ensureAgentDataDir(agent)
-		if err != nil {
-			return err
+		cleanup := func() {}
+		if !remoteBrowser {
+			c, err := ensureAgentDataDir(agent)
+			if err != nil {
+				return err
+			}
+			cleanup = c
 		}
-		err = h.crawlWithAgent(URL, agent)
+		err := h.crawlWithAgent(URL, agent)
 		cleanup()
-		if err != nil && firstErr == nil {
-			firstErr = err
+		if err != nil {
+			gologger.Warning().Msgf("headless agent %s failed to crawl %s: %s", agent.ID, URL, err)
+			if firstErr == nil {
+				firstErr = err
+			}
 		}
 	}
 	return firstErr

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -195,6 +195,8 @@ type Options struct {
 	RewalkSample int
 	// LinkIdentityBudget is how many near-duplicate doors to enqueue (-1 disables, default 1)
 	LinkIdentityBudget int
+	// HeadlessAgents is how many isolated browser identities to run (default 1; forced to 1 with -cdd/-cwu)
+	HeadlessAgents int
 	// Debug
 	Debug bool
 	// TlsImpersonate enables experimental tls ClientHello randomization for standard crawler


### PR DESCRIPTION
Fixes #1718

Stacked on headless-link-identity.

Named agents with isolated data dirs, HeadlessAgents for N identities, single-login conflict warning. Still one agent with -cdd / -cwu.