### PR TITLE
fix(hybrid): allow disabling the onclick-click simulation

### DIFF
--- a/pkg/engine/hybrid/crawl.go
+++ b/pkg/engine/hybrid/crawl.go
@@ -291,9 +291,9 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 	case <-time.After(200 * time.Millisecond):
 	}
 
+	maxLinks := c.Options.Options.MaxOnclickLinks
 	clickableLinks, err := page.Elements("a[onclick]")
-	if err == nil && len(clickableLinks) > 0 {
-		maxLinks := c.Options.Options.MaxOnclickLinks
+	if maxLinks > 0 && err == nil && len(clickableLinks) > 0 {
 		linksToProcess := len(clickableLinks)
 		if linksToProcess > maxLinks {
 			linksToProcess = maxLinks

--- a/pkg/types/crawler_options.go
+++ b/pkg/types/crawler_options.go
@@ -213,7 +213,10 @@ func NewCrawlerOptions(options *Options) (*CrawlerOptions, error) {
 		crawlerOptions.Extractors = append(crawlerOptions.Extractors, endpoints.New())
 	}
 
-	if options.MaxOnclickLinks <= 0 {
+	// Only 0 means "unset, use the default"; a negative value explicitly
+	// DISABLES the onclick-click simulation. Treating <= 0 as unset left no way
+	// to turn the feature off, since 0 was indistinguishable from unset.
+	if options.MaxOnclickLinks == 0 {
 		options.MaxOnclickLinks = 10
 	}
 


### PR DESCRIPTION
## Proposed changes

Refs #1748.

`MaxOnclickLinks` could not be turned off: `crawler_options.go` defaulted any value `<= 0` back to `10`, so `0` was indistinguishable from unset.

- only `0` now means "unset, use the default"
- a **negative** value disables the onclick-click simulation
- `hybrid` skips the block entirely when `maxLinks <= 0`

Default behaviour is unchanged: an unset `MaxOnclickLinks` still becomes 10.

This gives users an escape hatch from the hang described in #1748, where a click that opens a new tab leaves the crawl's tab hidden, Chrome suspends `requestAnimationFrame`, and `WaitStableRAF` blocks on a CDP call that never returns.

Deliberately `Refs` and not `Fixes`: this is a mitigation, and #1748 should stay open for the real fix. The hang still affects anyone who does not set the flag, and the right way to solve it (bounding `WaitInteractable`, or detecting and closing the tab the click opened) changes rod interaction semantics for every crawl — a maintainer call rather than something to slip into this PR.

### Proof

- `MaxOnclickLinks: -1` → the click block is skipped; crawls that previously hung on the reproducer in #1748 complete normally and cover the site.
- `MaxOnclickLinks` unset → still 10, behaviour unchanged.
- `go build ./...` clean.

## Checklist

- [x] Pull request is created against the `dev` branch
- [x] All checks passed
- [ ] Tests added — happy to add one if you'd like; the change is a one-line default, and the hang itself needs a live browser to exercise
- [x] Documentation updated (n/a — no flag or user-facing surface changed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of onclick-link limits.
  * Negative limits now explicitly disable onclick-link simulation.
  * A zero limit uses the default configuration, while positive limits enable processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->