### PR TITLE
fix(hybrid): apply Options.Proxy when attaching to a remote browser

### DIFF
--- a/pkg/engine/hybrid/hybrid.go
+++ b/pkg/engine/hybrid/hybrid.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-rod/rod"
 	"github.com/go-rod/rod/lib/launcher"
 	"github.com/go-rod/rod/lib/launcher/flags"
+	"github.com/go-rod/rod/lib/proto"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/katana/pkg/engine/common"
 	"github.com/projectdiscovery/katana/pkg/navigation"
@@ -77,7 +78,11 @@ func New(options *types.CrawlerOptions) (*Crawler, error) {
 
 	// create a new browser instance (default to incognito mode)
 	if !options.Options.HeadlessNoIncognito {
-		incognito, err := browser.Incognito()
+		// Create the browser context directly rather than via browser.Incognito():
+		// rod's helper takes no proxy argument, and Options.Proxy otherwise never
+		// reaches a browser attached through ChromeWSUrl, because the chrome
+		// launcher -- its only proxy path -- does not run in that case.
+		res, err := proto.TargetCreateBrowserContext{ProxyServer: options.Options.Proxy}.Call(browser)
 		if err != nil {
 			_ = browser.Close()
 			if chromeLauncher != nil {
@@ -85,7 +90,9 @@ func New(options *types.CrawlerOptions) (*Crawler, error) {
 			}
 			return nil, errkit.Wrap(err, "hybrid: failed to create incognito browser")
 		}
-		browser = incognito
+		incognito := *browser
+		incognito.BrowserContextID = res.BrowserContextID
+		browser = &incognito
 	}
 
 	shared, err := common.NewShared(options)


### PR DESCRIPTION
## Proposed changes

Fixes #1750.

`Options.Proxy` reaches the browser only through chrome-launcher args, and the launcher does not run when `ChromeWSUrl` attaches to an already-running browser. In that configuration the proxy was silently dropped — traffic went direct to the target while the caller believed it was proxied, with no error.

Creates the browser context via `Target.createBrowserContext`, which takes a per-context proxy, instead of `browser.Incognito()`, whose helper takes no proxy argument.

**Zero behaviour change except in the broken case:** an empty `Options.Proxy` is a no-op on the CDP call, so the launcher path (and its existing `proxy-server` flag) is untouched. No double-proxying.

### Proof

- With `-chrome-ws-url` + `-proxy`: before, no traffic reaches the proxy; after, all crawl traffic does.
- Without `-chrome-ws-url`: unchanged — the launcher still applies `proxy-server`.
- `go build ./...` clean.

## Checklist

- [x] Pull request is created against the `dev` branch
- [x] All checks passed
- [ ] Tests added — exercising this needs a live browser attached over CDP; happy to add a unit test asserting the proxy is carried into the `Target.createBrowserContext` params if you'd prefer a browser-free check
- [x] Documentation updated (n/a — no flag or user-facing surface changed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy handling for browser sessions.
  * Preserved existing browser connections while creating isolated browsing contexts.
  * Maintained cleanup and error handling when context creation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->