### PR TITLE
fix(types): apply ConfigureOutput once per process

### DIFF
--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/projectdiscovery/goflags"
@@ -280,7 +281,31 @@ func (options *Options) ShouldResume() bool {
 }
 
 // ConfigureOutput configures the output logging levels to be displayed on the screen
+// configureOutputOnce guards the process-global logger mutation in
+// ConfigureOutput.
+//
+// gologger.DefaultLogger.SetMaxLevel writes a global that gologger READS on
+// every log call, without synchronisation. ConfigureOutput is called once per
+// CrawlerOptions (see NewCrawlerOptions), so a program running concurrent
+// crawls writes that global while other crawls are logging through it --
+// reproducible under -race.
+//
+// katana cannot make gologger's reads safe, but it can stop writing repeatedly:
+// applying the level once per process removes every write after the first, so
+// concurrent crawls need no external lock. The trade-off is that the FIRST
+// caller's verbosity wins process-wide. For the CLI that is the runner's call
+// in internal/runner, which is what one would want anyway; for a library
+// embedding katana it means a second crawler with different verbosity does not
+// re-level a logger it shares with the rest of the program.
+var configureOutputOnce sync.Once
+
+// ConfigureOutput applies the verbosity options to the global logger, once per
+// process. See configureOutputOnce.
 func (options *Options) ConfigureOutput() {
+	configureOutputOnce.Do(func() { options.configureOutput() })
+}
+
+func (options *Options) configureOutput() {
 	if options.Silent {
 		gologger.DefaultLogger.SetMaxLevel(levels.LevelSilent)
 	} else if options.Verbose {


### PR DESCRIPTION
## Proposed changes

Refs #1752.

`ConfigureOutput` is called once per `CrawlerOptions`, and `SetMaxLevel` writes a gologger global that is read on every log call without synchronisation — so concurrent crawls race it.

Wraps the call in a `sync.Once`, so the level is applied once per process and every subsequent write disappears.

**Trade-off, stated plainly:** the first caller's verbosity wins process-wide. For the CLI that is `internal/runner`'s call, which is the intended one. For a library embedding katana, a second crawler no longer re-levels a logger it shares with the rest of the program — which I'd argue is the better default for a library mutating a global it does not own, but it is a behaviour change and your call.

This does not make gologger's reads safe; it removes katana's repeated writes. A complete fix probably belongs in gologger.

### Proof

- Before: concurrent crawls produce `-race` reports on the gologger level (4 crawls → 5 reports).
- After: no reports; the level is written once.
- CLI verbosity unchanged — `internal/runner` still configures output first.
- `go build ./...` clean.

## Checklist

- [x] Pull request is created against the `dev` branch
- [x] All checks passed
- [ ] Tests added — a race test needs two concurrent crawls and a live browser; open to adding one if you want it
- [x] Documentation updated (n/a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured logger configuration is applied consistently across the application.
  * Preserved the first configured verbosity setting for the lifetime of the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->