### PR TITLE
fix(hybrid): close the CDP websocket so its reader goroutines exit

### DIFF
--- a/pkg/engine/hybrid/hybrid.go
+++ b/pkg/engine/hybrid/hybrid.go
@@ -26,8 +26,8 @@ type Crawler struct {
 	*common.Shared
 
 	browser        *rod.Browser
-	chromeLauncher *launcher.Launcher
-	cdpWS          *cdp.WebSocket // held so Close can end the CDP read loop // nil when attached via ChromeWSUrl
+	chromeLauncher *launcher.Launcher // nil when attached via ChromeWSUrl
+	cdpWS          *cdp.WebSocket
 	// TODO: Remove the Chrome PID kill code in favor of using Leakless(true).
 	// This change will be made if there are no complaints about zombie Chrome processes.
 	// References:
@@ -95,6 +95,18 @@ func New(options *types.CrawlerOptions) (*Crawler, error) {
 		return nil, errkit.Wrap(browserErr, fmt.Sprintf("hybrid: failed to connect to chrome instance at %s", launcherURL))
 	}
 
+	owned := false
+	defer func() {
+		if owned {
+			return
+		}
+		_ = browser.Close()
+		_ = cdpWS.Close()
+		if chromeLauncher != nil {
+			chromeLauncher.Kill()
+		}
+	}()
+
 	// create a new browser instance (default to incognito mode)
 	if !options.Options.HeadlessNoIncognito {
 		// Create the browser context directly rather than via browser.Incognito():
@@ -103,10 +115,6 @@ func New(options *types.CrawlerOptions) (*Crawler, error) {
 		// launcher -- its only proxy path -- does not run in that case.
 		res, err := proto.TargetCreateBrowserContext{ProxyServer: options.Options.Proxy}.Call(browser)
 		if err != nil {
-			_ = browser.Close()
-			if chromeLauncher != nil {
-				chromeLauncher.Kill()
-			}
 			return nil, errkit.Wrap(err, "hybrid: failed to create incognito browser")
 		}
 		incognito := *browser
@@ -116,10 +124,6 @@ func New(options *types.CrawlerOptions) (*Crawler, error) {
 
 	shared, err := common.NewShared(options)
 	if err != nil {
-		_ = browser.Close()
-		if chromeLauncher != nil {
-			chromeLauncher.Kill()
-		}
 		return nil, errkit.Wrap(err, "hybrid")
 	}
 
@@ -131,6 +135,7 @@ func New(options *types.CrawlerOptions) (*Crawler, error) {
 		// previousPIDs: previousPIDs,
 		tempDir: dataStore,
 	}
+	owned = true
 
 	return crawler, nil
 }

--- a/pkg/engine/hybrid/hybrid.go
+++ b/pkg/engine/hybrid/hybrid.go
@@ -1,11 +1,13 @@
 package hybrid
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
 
 	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/cdp"
 	"github.com/go-rod/rod/lib/launcher"
 	"github.com/go-rod/rod/lib/launcher/flags"
 	"github.com/go-rod/rod/lib/proto"
@@ -24,7 +26,8 @@ type Crawler struct {
 	*common.Shared
 
 	browser        *rod.Browser
-	chromeLauncher *launcher.Launcher // nil when attached via ChromeWSUrl
+	chromeLauncher *launcher.Launcher
+	cdpWS          *cdp.WebSocket // held so Close can end the CDP read loop // nil when attached via ChromeWSUrl
 	// TODO: Remove the Chrome PID kill code in favor of using Leakless(true).
 	// This change will be made if there are no complaints about zombie Chrome processes.
 	// References:
@@ -68,8 +71,24 @@ func New(options *types.CrawlerOptions) (*Crawler, error) {
 		}
 	}
 
-	browser := rod.New().ControlURL(launcherURL)
+	// Construct the CDP client here rather than using rod.New().ControlURL(...)
+	// so the websocket handle survives into Close(). rod hides it in an
+	// unexported field, and without it the connection can never be closed --
+	// see Close() for why that leaks. StartWithURL, which Connect calls, is
+	// exactly this.
+	dialCtx, dialCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	cdpWS := &cdp.WebSocket{}
+	wsErr := cdpWS.Connect(dialCtx, launcherURL, nil)
+	dialCancel()
+	if wsErr != nil {
+		if chromeLauncher != nil {
+			chromeLauncher.Kill()
+		}
+		return nil, errkit.Wrap(wsErr, fmt.Sprintf("hybrid: failed to connect to chrome instance at %s", launcherURL))
+	}
+	browser := rod.New().Client(cdp.New().Start(cdpWS))
 	if browserErr := browser.Connect(); browserErr != nil {
+		_ = cdpWS.Close()
 		if chromeLauncher != nil {
 			chromeLauncher.Kill()
 		}
@@ -108,6 +127,7 @@ func New(options *types.CrawlerOptions) (*Crawler, error) {
 		Shared:         shared,
 		browser:        browser,
 		chromeLauncher: chromeLauncher,
+		cdpWS:          cdpWS,
 		// previousPIDs: previousPIDs,
 		tempDir: dataStore,
 	}
@@ -119,6 +139,19 @@ func New(options *types.CrawlerOptions) (*Crawler, error) {
 func (c *Crawler) Close() error {
 	if c.browser != nil {
 		_ = c.browser.Close()
+	}
+	if c.cdpWS != nil {
+		// Close AFTER browser.Close, which dispatches
+		// Target.disposeBrowserContext over this same socket.
+		//
+		// rod's initEvents goroutine blocks on `for e := range client.Event()`,
+		// and that channel closes only when cdp's read loop errors -- which
+		// happens only when the CONNECTION closes, not on context cancellation
+		// (the websocket Read is a blocking socket read). Disposing the browser
+		// context does not close the connection, so against a browser attached
+		// via ChromeWSUrl -- where there is no launcher to kill -- every crawl
+		// left the socket and its goroutines behind for the browser's lifetime.
+		_ = c.cdpWS.Close()
 	}
 	if c.chromeLauncher != nil {
 		c.chromeLauncher.Kill()


### PR DESCRIPTION
## Proposed changes

Fixes #1754.

`Close()` disposes the browser context but never closes the CDP connection. rod's `initEvents` goroutine blocks on `for e := range client.Event()`, and that channel closes only when cdp's read loop errors — which happens when the **connection** closes, not on context cancellation, since the websocket `Read` is a blocking socket read.

On the launcher path this is masked: `chromeLauncher.Kill()` takes the browser and the socket with it. When `ChromeWSUrl` attaches to an already-running browser there is no launcher, so every crawl leaves the socket and its goroutines behind for the browser's lifetime.

This constructs the CDP client directly instead of `rod.New().ControlURL(...)`, and closes the socket in `Close()` after `browser.Close()` has dispatched `Target.disposeBrowserContext` over it.

### On the approach

Taking over connection construction is the invasive part of this patch, and it is worth being explicit about why. `rod.New().ControlURL(...)` keeps the websocket in an unexported field, so there is no handle to close; `cdp.New().Start(ws)` is exactly what rod's own `StartWithURL` does internally, so the connection is built the same way, just with the socket retained.

Since rod is a separate project, "have rod expose the connection" is not a change katana can make on its own timeline — but it may still be the fix you prefer, and I would rather you reject this than carry connection-lifecycle code you are not comfortable owning.

### Proof

- With `-chrome-ws-url`, repeated crawls against one shared browser: before, ~4 goroutines plus a live websocket retained per crawl; after, goroutine count returns to baseline and the socket closes.
- Launcher path unchanged — `chromeLauncher.Kill()` still tears everything down.
- `go build ./...` clean.

## Checklist

- [x] Pull request is created against the `dev` branch
- [x] All checks passed
- [ ] Tests added — asserting goroutine cleanup needs a live browser attached over CDP; open to adding one if you want it
- [x] Documentation updated (n/a — no flag or user-facing surface changed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser connection cleanup to prevent lingering connections and background processes.
  * Ensured cleanup works reliably for both launched and externally connected Chrome instances.
  * Improved error handling when browser connections cannot be established.
  * Added more reliable shutdown behavior to ensure browser resources are released in the correct order.
  * Reduced the risk of retained connections and background activity after crawler errors or completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->