### PR TITLE
Use chrome-headless-shell for headless crawls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/projectdiscovery/mapcidr v1.1.97
 	github.com/projectdiscovery/ratelimit v0.0.88
 	github.com/projectdiscovery/retryablehttp-go v1.3.21
-	github.com/projectdiscovery/utils v0.11.1
+	github.com/projectdiscovery/utils v0.11.2-0.20260815171005-eb8925425716
 	github.com/projectdiscovery/wappalyzergo v0.2.91
 	github.com/remeh/sizedwaitgroup v1.0.0
 	github.com/rs/xid v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -345,8 +345,8 @@ github.com/projectdiscovery/retryabledns v1.0.115 h1:RKV63FNIznFHUoawg/1hs53pVH3
 github.com/projectdiscovery/retryabledns v1.0.115/go.mod h1:+fEMWoPigw+M0lGNKY7AZ+g8FIgj+4sONjsinMmeL3k=
 github.com/projectdiscovery/retryablehttp-go v1.3.21 h1:HytR9e8AfhIF/4xUo6szqg213a7pOq5tE3kpNZCyYwI=
 github.com/projectdiscovery/retryablehttp-go v1.3.21/go.mod h1:0SCELxSKpkqHTy9pcZDZ2ry+5djp4geKpEURJ1uSB24=
-github.com/projectdiscovery/utils v0.11.1 h1:PWj1KjIASxt8icxommH72C0TQqNOvGkcSODRkiq0SQw=
-github.com/projectdiscovery/utils v0.11.1/go.mod h1:yktGrHGk2CTjNiccXovnvGrLHX9sV2bqz9nSnbA3V8M=
+github.com/projectdiscovery/utils v0.11.2-0.20260815171005-eb8925425716 h1:zoDnj6xAqCvIQuP/bV5COuje2kjZV7THKTuDRdvyXgI=
+github.com/projectdiscovery/utils v0.11.2-0.20260815171005-eb8925425716/go.mod h1:RtBO9urHlfN3aAEzhZz5m1/ZeJDq6U1Ka34lGWleuS8=
 github.com/projectdiscovery/wappalyzergo v0.2.91 h1:pjbEOCJKmxfEG5xK3WnUNY4SuYjPoYUuAUxa3F1QN1Y=
 github.com/projectdiscovery/wappalyzergo v0.2.91/go.mod h1:gMH0o5lBp65sKMwHx/tuUdOtW2RjodC6Ti+9QDsYMkY=
 github.com/refraction-networking/utls v1.8.2 h1:j4Q1gJj0xngdeH+Ox/qND11aEfhpgoEvV+S9iJ2IdQo=

--- a/pkg/engine/headless/browser/browser.go
+++ b/pkg/engine/headless/browser/browser.go
@@ -29,6 +29,7 @@ import (
 	"github.com/projectdiscovery/katana/pkg/navigation"
 	"github.com/projectdiscovery/katana/pkg/output"
 	"github.com/projectdiscovery/katana/pkg/utils"
+	"github.com/projectdiscovery/utils/chromeshell"
 	"github.com/rs/xid"
 )
 
@@ -53,10 +54,10 @@ type LauncherOptions struct {
 	Trace               bool
 	CookieConsentBypass bool
 	PageLoadStrategy    string
-	ChromeWSUrl         string // WebSocket URL to connect to existing Chrome
-	DOMWaitTime         int    // Time in seconds to wait for DOM (used with domcontentloaded strategy)
-	UserDataDir         string // User-provided chrome data directory to preserve sessions
-	ChromeUser          *user.User // optional chrome user to use
+	ChromeWSUrl         string            // WebSocket URL to connect to existing Chrome
+	DOMWaitTime         int               // Time in seconds to wait for DOM (used with domcontentloaded strategy)
+	UserDataDir         string            // User-provided chrome data directory to preserve sessions
+	ChromeUser          *user.User        // optional chrome user to use
 	UserArguments       map[string]string // user-supplied Chrome flags via -headless-options
 
 	ScopeValidator  ScopeValidator
@@ -71,11 +72,11 @@ func NewLauncher(opts LauncherOptions) (*Launcher, error) {
 	if opts.PageLoadStrategy == "" {
 		opts.PageLoadStrategy = "heuristic"
 	}
-	
+
 	if opts.DOMWaitTime <= 0 {
 		opts.DOMWaitTime = 5
 	}
-	
+
 	l := &Launcher{
 		opts:        opts,
 		browserPool: rod.NewPool[BrowserPage](opts.MaxBrowsers),
@@ -111,7 +112,7 @@ func (l *Launcher) shouldPreserveUserDataDir(tempDir string) bool {
 
 func (l *Launcher) launchBrowserWithDataDir(userDataDir string) (*rod.Browser, error) {
 	var launcherURL string
-	
+
 	// If ChromeWSUrl is provided, connect to existing Chrome instead of launching new one
 	if l.opts.ChromeWSUrl != "" {
 		launcherURL = l.opts.ChromeWSUrl
@@ -162,6 +163,12 @@ func (l *Launcher) launchBrowserWithDataDir(userDataDir string) (*rod.Browser, e
 
 		if l.opts.ChromiumPath != "" {
 			chromeLauncher = chromeLauncher.Bin(l.opts.ChromiumPath)
+		} else if !l.opts.ShowBrowser && chromeshell.Supported() {
+			// Prefer chrome-headless-shell on linux/amd64 for headless crawls;
+			// skip when headed since the shell binary cannot show a UI.
+			if shellPath, err := chromeshell.Ensure(); err == nil {
+				chromeLauncher = chromeLauncher.Bin(shellPath)
+			}
 		}
 
 		if userDataDir != "" {
@@ -247,17 +254,17 @@ var defaultWaitOptions = WaitOptions{
 func (b *BrowserPage) WaitPageLoadHeurisitics() error {
 	// Respect the page load strategy from launcher options
 	strategy := b.launcher.opts.PageLoadStrategy
-	
+
 	switch strategy {
 	case "none":
 		// Don't wait at all, return immediately
 		return nil
-		
+
 	case "load":
 		// Just wait for the load event
 		chained := b.Timeout(15 * time.Second)
 		return chained.WaitLoad()
-		
+
 	case "domcontentloaded":
 		// WaitLoad checks document.readyState via JS, so it's safe to call
 		// after Navigate() has already started (no race with missed events).
@@ -267,14 +274,14 @@ func (b *BrowserPage) WaitPageLoadHeurisitics() error {
 			time.Sleep(time.Duration(b.launcher.opts.DOMWaitTime) * time.Second)
 		}
 		return nil
-		
+
 	case "networkidle":
 		// Wait for network activity to stop
 		chained := b.Timeout(15 * time.Second)
 		_ = chained.WaitLoad()
 		_ = chained.WaitIdle(2 * time.Second)
 		return nil
-		
+
 	case "heuristic":
 		fallthrough
 	default:
@@ -363,7 +370,7 @@ func (l *Launcher) createBrowserPageFunc() (*BrowserPage, error) {
 	// since we're connecting to an existing browser
 	var tempDir string
 	shouldCleanupTempDir := false
-	
+
 	if l.opts.ChromeWSUrl == "" {
 		if l.opts.UserDataDir != "" {
 			// Use user-provided data directory (preserve sessions/cookies)

--- a/pkg/engine/hybrid/hybrid.go
+++ b/pkg/engine/hybrid/hybrid.go
@@ -17,6 +17,7 @@ import (
 	"github.com/projectdiscovery/katana/pkg/output"
 	"github.com/projectdiscovery/katana/pkg/types"
 	"github.com/projectdiscovery/katana/pkg/utils"
+	"github.com/projectdiscovery/utils/chromeshell"
 	"github.com/projectdiscovery/utils/errkit"
 	urlutil "github.com/projectdiscovery/utils/url"
 )
@@ -333,9 +334,14 @@ func buildChromeLauncher(options *types.CrawlerOptions, dataStore string) (*laun
 				return nil, errkit.New("hybrid: the chrome browser is not installed")
 			}
 		}
-	}
-	if options.Options.SystemChromePath != "" {
+	} else if options.Options.SystemChromePath != "" {
 		chromeLauncher.Bin(options.Options.SystemChromePath)
+	} else if !options.Options.ShowBrowser && chromeshell.Supported() {
+		// Prefer chrome-headless-shell on linux/amd64 for headless crawls; skip
+		// when headed since the shell binary cannot show a UI.
+		if shellPath, err := chromeshell.Ensure(); err == nil {
+			chromeLauncher.Bin(shellPath)
+		}
 	}
 
 	if options.Options.ShowBrowser {


### PR DESCRIPTION
Stages chrome-headless-shell on linux/amd64 for headless hybrid and headless crawls so katana skips the heavier full Chromium download when no custom or system Chrome is set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved headless browser startup by automatically using `chrome-headless-shell` when available and supported.
  * Retained fallback behavior when the optimized headless browser is unavailable.
  * Existing configured or installed Chrome paths continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->