### PR TITLE
fix(hybrid): prevent closing external browser when using chrome-ws-url (#1757)

### DIFF
--- a/pkg/engine/hybrid/crawl_test.go
+++ b/pkg/engine/hybrid/crawl_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-rod/rod"
 	"github.com/go-rod/rod/lib/launcher"
 	"github.com/go-rod/rod/lib/proto"
+	"github.com/projectdiscovery/katana/pkg/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -91,3 +92,50 @@ func TestDOMGetDocumentTimeoutDoesNotBlockHTML(t *testing.T) {
 	require.NoError(t, err, "HTML retrieval should succeed with fresh timeout from basePage")
 	require.NotEmpty(t, body, "HTML body should not be empty")
 }
+
+// TestCrawlerCloseWithChromeWSUrl verifies that Katana does not terminate an external
+// browser instance when connected via ChromeWSUrl with HeadlessNoIncognito (Issue #1757).
+func TestCrawlerCloseWithChromeWSUrl(t *testing.T) {
+	path, _ := launcher.LookPath()
+	if path == "" {
+		t.Skip("chrome/chromium not found, skipping browser test")
+	}
+
+	u, err := launcher.New().Leakless(true).Launch()
+	if err != nil {
+		t.Skipf("could not launch browser: %v", err)
+	}
+
+	externalBrowser := rod.New().ControlURL(u).MustConnect()
+	t.Cleanup(func() {
+		_ = externalBrowser.Close()
+	})
+
+	crawlerOpts := &types.CrawlerOptions{
+		Options: &types.Options{
+			ChromeWSUrl:         u,
+			HeadlessNoIncognito: true,
+		},
+	}
+
+	crawler, err := New(crawlerOpts)
+	require.NoError(t, err)
+	require.NotNil(t, crawler)
+
+	// Closing Katana crawler must not close the external browser
+	err = crawler.Close()
+	require.NoError(t, err)
+
+	// Verify the external browser is still alive and operational
+	var version *proto.BrowserGetVersionResult
+	version, err = proto.BrowserGetVersion{}.Call(externalBrowser)
+	require.NoError(t, err, "external browser should remain responsive after crawler.Close()")
+	require.NotNil(t, version)
+	require.NotEmpty(t, version.Product)
+
+	// Verify we can still create pages on the external browser
+	page, err := externalBrowser.Page(proto.TargetCreateTarget{})
+	require.NoError(t, err, "external browser should still be able to create new pages")
+	defer func() { _ = page.Close() }()
+}
+

--- a/pkg/engine/hybrid/hybrid.go
+++ b/pkg/engine/hybrid/hybrid.go
@@ -101,7 +101,9 @@ func New(options *types.CrawlerOptions) (*Crawler, error) {
 		if owned {
 			return
 		}
-		_ = browser.Close()
+		if options.Options.ChromeWSUrl == "" || browser.BrowserContextID != "" {
+			_ = browser.Close()
+		}
 		_ = cdpWS.Close()
 		if chromeLauncher != nil {
 			chromeLauncher.Kill()
@@ -144,7 +146,14 @@ func New(options *types.CrawlerOptions) (*Crawler, error) {
 // Close closes the crawler process
 func (c *Crawler) Close() error {
 	if c.browser != nil {
-		_ = c.browser.Close()
+		// Only close the root browser instance if Katana owns its lifecycle.
+		// If attached to an external browser via ChromeWSUrl in non-incognito mode (BrowserContextID == ""),
+		// closing c.browser would issue Browser.close and terminate the entire external browser process.
+		// If running in incognito mode (BrowserContextID != ""), c.browser.Close() sends Target.disposeBrowserContext,
+		// which safely closes only Katana's incognito session without terminating the external browser.
+		if c.Options.Options.ChromeWSUrl == "" || c.browser.BrowserContextID != "" {
+			_ = c.browser.Close()
+		}
 	}
 	if c.cdpWS != nil {
 		// Close AFTER browser.Close, which dispatches


### PR DESCRIPTION
### Proposed Changes
- Prevents `Close()` from terminating an external browser instance when Katana attaches via `-chrome-ws-url`.
- Preserves browser lifecycle ownership for external runners while properly cleaning up crawl contexts.
- Adds test coverage for external connection cleanup.

Fixes #1757

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser cleanup when connecting to an externally managed Chrome instance.
  * Closing the crawler no longer shuts down the external browser, which remains available for continued use.
  * Preserved cleanup for browsers and contexts owned by the crawler.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->