### PR TITLE
fix(types): synchronize ConfigureOutput to eliminate global logger data race (#1752)

### DIFF
--- a/pkg/types/crawler_options_test.go
+++ b/pkg/types/crawler_options_test.go
@@ -31,6 +31,7 @@ func TestConcurrentNewCrawlerOptions(t *testing.T) {
 	const goroutines = 50
 	var wg sync.WaitGroup
 	wg.Add(goroutines)
+	errChan := make(chan error, goroutines)
 
 	for i := 0; i < goroutines; i++ {
 		go func(idx int) {
@@ -43,10 +44,18 @@ func TestConcurrentNewCrawlerOptions(t *testing.T) {
 				Debug:        idx%3 == 2,
 			}
 			co, err := NewCrawlerOptions(opts)
-			require.NoError(t, err)
+			if err != nil {
+				errChan <- err
+				return
+			}
 			_ = co.Close()
 		}(i)
 	}
 
 	wg.Wait()
+	close(errChan)
+
+	for err := range errChan {
+		require.NoError(t, err)
+	}
 }

--- a/pkg/types/crawler_options_test.go
+++ b/pkg/types/crawler_options_test.go
@@ -1,0 +1,52 @@
+package types
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConcurrentConfigureOutput(t *testing.T) {
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			opts := &Options{
+				Silent:  idx%3 == 0,
+				Verbose: idx%3 == 1,
+				Debug:   idx%3 == 2,
+			}
+			opts.ConfigureOutput()
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+func TestConcurrentNewCrawlerOptions(t *testing.T) {
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			opts := &Options{
+				MaxDepth:     1,
+				BodyReadSize: 1024,
+				Silent:       idx%3 == 0,
+				Verbose:      idx%3 == 1,
+				Debug:        idx%3 == 2,
+			}
+			co, err := NewCrawlerOptions(opts)
+			require.NoError(t, err)
+			_ = co.Close()
+		}(i)
+	}
+
+	wg.Wait()
+}

--- a/pkg/types/crawler_options_test.go
+++ b/pkg/types/crawler_options_test.go
@@ -31,7 +31,7 @@ func TestConcurrentNewCrawlerOptions(t *testing.T) {
 	const goroutines = 50
 	var wg sync.WaitGroup
 	wg.Add(goroutines)
-	errChan := make(chan error, goroutines)
+	errChan := make(chan error, goroutines*2)
 
 	for i := 0; i < goroutines; i++ {
 		go func(idx int) {
@@ -48,7 +48,9 @@ func TestConcurrentNewCrawlerOptions(t *testing.T) {
 				errChan <- err
 				return
 			}
-			_ = co.Close()
+			if err := co.Close(); err != nil {
+				errChan <- err
+			}
 		}(i)
 	}
 

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/projectdiscovery/goflags"
@@ -279,19 +280,23 @@ func (options *Options) ShouldResume() bool {
 	return options.Resume != "" && fileutil.FileExists(options.Resume)
 }
 
+var configureOutputOnce sync.Once
+
 // ConfigureOutput configures the output logging levels to be displayed on the screen
 func (options *Options) ConfigureOutput() {
-	if options.Silent {
-		gologger.DefaultLogger.SetMaxLevel(levels.LevelSilent)
-	} else if options.Verbose {
-		gologger.DefaultLogger.SetMaxLevel(levels.LevelWarning)
-	} else if options.Debug {
-		gologger.DefaultLogger.SetMaxLevel(levels.LevelDebug)
-	} else {
-		gologger.DefaultLogger.SetMaxLevel(levels.LevelInfo)
-	}
+	configureOutputOnce.Do(func() {
+		if options.Silent {
+			gologger.DefaultLogger.SetMaxLevel(levels.LevelSilent)
+		} else if options.Verbose {
+			gologger.DefaultLogger.SetMaxLevel(levels.LevelWarning)
+		} else if options.Debug {
+			gologger.DefaultLogger.SetMaxLevel(levels.LevelDebug)
+		} else {
+			gologger.DefaultLogger.SetMaxLevel(levels.LevelInfo)
+		}
 
-	logutil.DisableDefaultLogger()
+		logutil.DisableDefaultLogger()
+	})
 }
 
 // ContentSimilarityEnabled reports whether Layer-2 page content similarity is on.


### PR DESCRIPTION
### Proposed Changes
- Synchronizes `ConfigureOutput` using `sync.Once` to prevent concurrent crawlers from racing on global `gologger.DefaultLogger` mutations.
- Adds concurrent unit test verifying zero race conditions under `go test -race`.

Fixes #1752

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when crawler options are initialized or configured concurrently.
  * Ensured output and logging settings are applied consistently during setup.
  * Prevented repeated configuration from causing inconsistent logging behavior.

* **Tests**
  * Added coverage for simultaneous crawler creation, closure, and output configuration.
  * Verified consistent behavior across many concurrent crawler operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->