### PR TITLE
fix(parser): only regex-scrape endpoints from textual response bodies

### DIFF
--- a/pkg/engine/parser/parser.go
+++ b/pkg/engine/parser/parser.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"mime"
 	"mime/multipart"
 	"net/http"
 	"strings"
@@ -705,22 +706,23 @@ func scriptJSFileRegexParser(resp *navigation.Response) (navigationRequests []*n
 	return
 }
 
-// textualContentTypes are the response types worth regex-scraping for
-// endpoints. Anything else is binary as far as this parser is concerned.
+// isTextualMediaType reports whether a parsed MIME type is worth regex-scraping
+// for endpoints. Anything else is binary as far as this parser is concerned.
 //
-// "+xml" covers image/svg+xml deliberately: an SVG is XML text carrying
-// href/xlink:href and possibly a <script>, so it is a real endpoint source
-// despite the image/ prefix.
-var textualContentTypes = []string{
-	"text/",
-	"application/javascript",
-	"application/x-javascript",
-	"application/ecmascript",
-	"application/json",
-	"application/xml",
-	"application/xhtml+xml",
-	"+json",
-	"+xml",
+// Suffixes "+xml" / "+json" cover types such as image/svg+xml deliberately: an
+// SVG is XML text carrying href/xlink:href and possibly a <script>, so it is a
+// real endpoint source despite the image/ prefix.
+func isTextualMediaType(mediaType string) bool {
+	mediaType = strings.ToLower(mediaType)
+	if strings.HasPrefix(mediaType, "text/") {
+		return true
+	}
+	switch mediaType {
+	case "application/javascript", "application/x-javascript", "application/ecmascript",
+		"application/json", "application/xml", "application/xhtml+xml":
+		return true
+	}
+	return strings.HasSuffix(mediaType, "+json") || strings.HasSuffix(mediaType, "+xml")
 }
 
 // isTextualResponse reports whether resp's body should be regex-scraped for
@@ -737,8 +739,8 @@ func isTextualResponse(resp *navigation.Response) bool {
 	if resp == nil || resp.Resp == nil {
 		return false
 	}
-	contentType := strings.ToLower(resp.Resp.Header.Get("Content-Type"))
-	if contentType == "" || strings.Contains(contentType, "application/octet-stream") {
+	mediaType, _, err := mime.ParseMediaType(resp.Resp.Header.Get("Content-Type"))
+	if err != nil || mediaType == "" || strings.EqualFold(mediaType, "application/octet-stream") {
 		if resp.Body == "" {
 			return false
 		}
@@ -746,9 +748,12 @@ func isTextualResponse(resp *navigation.Response) bool {
 		if len(body) > sniffLen {
 			body = body[:sniffLen]
 		}
-		contentType = strings.ToLower(http.DetectContentType([]byte(body)))
+		mediaType, _, err = mime.ParseMediaType(http.DetectContentType([]byte(body)))
+		if err != nil {
+			return false
+		}
 	}
-	return stringsutil.ContainsAny(contentType, textualContentTypes...)
+	return isTextualMediaType(mediaType)
 }
 
 // sniffLen is the prefix http.DetectContentType examines; anything beyond it is

--- a/pkg/engine/parser/parser.go
+++ b/pkg/engine/parser/parser.go
@@ -705,8 +705,52 @@ func scriptJSFileRegexParser(resp *navigation.Response) (navigationRequests []*n
 	return
 }
 
+// textualContentTypes are the response types worth regex-scraping for
+// endpoints. Anything else is binary as far as this parser is concerned.
+var textualContentTypes = []string{
+	"text/",
+	"application/javascript",
+	"application/x-javascript",
+	"application/ecmascript",
+	"application/json",
+	"application/xml",
+	"application/xhtml+xml",
+	"+json",
+	"+xml",
+}
+
+// isTextualResponse reports whether resp's body should be regex-scraped for
+// endpoints.
+//
+// A MISSING Content-Type returns false. An undeclared body is exactly the case
+// that must not be mined: there is no evidence it is text, and the cost of
+// guessing wrong is requests for resources that never existed.
+func isTextualResponse(resp *navigation.Response) bool {
+	if resp == nil || resp.Resp == nil {
+		return false
+	}
+	contentType := strings.ToLower(resp.Resp.Header.Get("Content-Type"))
+	if contentType == "" {
+		return false
+	}
+	return stringsutil.ContainsAny(contentType, textualContentTypes...)
+}
+
 // bodyScrapeEndpointsParser parses scraped URLs from HTML body
 func bodyScrapeEndpointsParser(resp *navigation.Response) (navigationRequests []*navigation.Request) {
+	// Only scrape TEXTUAL bodies. pageBodyRegex matches `./x` and `../x`,
+	// which occur by chance in binary data: a 260KB PNG yields "./6" from its
+	// pixel bytes, that resolves against the image's own URL, and the crawler
+	// then requests a sibling path the site never served.
+	//
+	// The extension denylist cannot catch this. It rejects the ".png" the
+	// noise came FROM, while the mined string is extensionless and passes --
+	// so scraping a binary body launders denied-extension content into
+	// allowed-extension requests.
+	if !isTextualResponse(resp) {
+		return
+	}
+
 	endpoints := utils.ExtractBodyEndpoints(string(resp.Body))
 	for _, item := range endpoints {
 		navigationRequests = append(navigationRequests, navigation.NewNavigationRequestURLFromResponse(item, resp.Resp.Request.URL.String(), "html", "regex", resp))

--- a/pkg/engine/parser/parser.go
+++ b/pkg/engine/parser/parser.go
@@ -707,6 +707,10 @@ func scriptJSFileRegexParser(resp *navigation.Response) (navigationRequests []*n
 
 // textualContentTypes are the response types worth regex-scraping for
 // endpoints. Anything else is binary as far as this parser is concerned.
+//
+// "+xml" covers image/svg+xml deliberately: an SVG is XML text carrying
+// href/xlink:href and possibly a <script>, so it is a real endpoint source
+// despite the image/ prefix.
 var textualContentTypes = []string{
 	"text/",
 	"application/javascript",
@@ -722,19 +726,34 @@ var textualContentTypes = []string{
 // isTextualResponse reports whether resp's body should be regex-scraped for
 // endpoints.
 //
-// A MISSING Content-Type returns false. An undeclared body is exactly the case
-// that must not be mined: there is no evidence it is text, and the cost of
-// guessing wrong is requests for resources that never existed.
+// The declared Content-Type decides it when there is one. When the server sent
+// NONE -- or the generic application/octet-stream, which means the same thing
+// in practice -- the body is sniffed rather than skipped: an untyped response
+// is common on embedded servers and appliance interfaces, and refusing to scrape
+// those would trade one silent coverage gap for another. http.DetectContentType
+// identifies binary formats from their magic bytes, which is what this gate
+// actually needs to exclude.
 func isTextualResponse(resp *navigation.Response) bool {
 	if resp == nil || resp.Resp == nil {
 		return false
 	}
 	contentType := strings.ToLower(resp.Resp.Header.Get("Content-Type"))
-	if contentType == "" {
-		return false
+	if contentType == "" || strings.Contains(contentType, "application/octet-stream") {
+		if resp.Body == "" {
+			return false
+		}
+		body := resp.Body
+		if len(body) > sniffLen {
+			body = body[:sniffLen]
+		}
+		contentType = strings.ToLower(http.DetectContentType([]byte(body)))
 	}
 	return stringsutil.ContainsAny(contentType, textualContentTypes...)
 }
+
+// sniffLen is the prefix http.DetectContentType examines; anything beyond it is
+// ignored by the algorithm, so there is no reason to copy more.
+const sniffLen = 512
 
 // bodyScrapeEndpointsParser parses scraped URLs from HTML body
 func bodyScrapeEndpointsParser(resp *navigation.Response) (navigationRequests []*navigation.Request) {
@@ -747,6 +766,9 @@ func bodyScrapeEndpointsParser(resp *navigation.Response) (navigationRequests []
 	// noise came FROM, while the mined string is extensionless and passes --
 	// so scraping a binary body launders denied-extension content into
 	// allowed-extension requests.
+	//
+	// A response with no declared type is sniffed, not skipped -- see
+	// isTextualResponse.
 	if !isTextualResponse(resp) {
 		return
 	}

--- a/pkg/engine/parser/parser_test.go
+++ b/pkg/engine/parser/parser_test.go
@@ -565,3 +565,63 @@ func TestDataURIFiltering(t *testing.T) {
 		require.Equal(t, 0, len(navigationRequests), "Expected all invalid URIs to be filtered out")
 	})
 }
+
+// A PNG's pixel bytes contain byte sequences that pageBodyRegex matches -- most
+// commonly "./6" -- and the mined string then resolves against the image's own
+// URL, so the crawler requests a sibling resource the site never served
+// (e.g. /images/products/10.png -> /images/products/6, 404).
+//
+// katana's extension denylist cannot prevent this: it rejects the ".png" the
+// noise came FROM, while the mined path is extensionless and passes.
+func TestBodyScrapeEndpointsParser_ContentTypeGate(t *testing.T) {
+	parsed, _ := urlutil.Parse("https://example.com/images/products/10.png")
+
+	// Minimal PNG header plus a chunk of bytes containing the "./6" sequence
+	// that a real image yields; the regex only needs the literal to be present
+	// in the body.
+	binaryBody := "\x89PNG\r\n\x1a\n\x00\x10\xff\xfe\"./6\"\x00\x01\x02\x03"
+
+	t.Run("binary body is not scraped", func(t *testing.T) {
+		resp := &navigation.Response{
+			Resp: &http.Response{
+				Request: &http.Request{URL: parsed.URL},
+				Header:  http.Header{"Content-Type": []string{"image/png"}},
+			},
+			Body: binaryBody,
+		}
+		require.Empty(t, bodyScrapeEndpointsParser(resp), "a binary response body must not be mined for endpoints")
+	})
+
+	// A body with no declared type is the case with the least evidence that it
+	// is text, so it must not be mined either.
+	t.Run("missing content-type is not scraped", func(t *testing.T) {
+		resp := &navigation.Response{
+			Resp: &http.Response{Request: &http.Request{URL: parsed.URL}},
+			Body: binaryBody,
+		}
+		require.Empty(t, bodyScrapeEndpointsParser(resp), "an undeclared response body must not be mined for endpoints")
+	})
+
+	// The parser must keep working for everything it is actually for.
+	for _, contentType := range []string{
+		"text/html; charset=utf-8",
+		"text/plain",
+		"application/javascript",
+		"application/json",
+		"application/xhtml+xml",
+	} {
+		t.Run(contentType+" is scraped", func(t *testing.T) {
+			htmlParsed, _ := urlutil.Parse("https://example.com/index.html")
+			resp := &navigation.Response{
+				Resp: &http.Response{
+					Request: &http.Request{URL: htmlParsed.URL},
+					Header:  http.Header{"Content-Type": []string{contentType}},
+				},
+				Body: `window.location = "./test/endpoint.php";`,
+			}
+			navigationRequests := bodyScrapeEndpointsParser(resp)
+			require.NotEmpty(t, navigationRequests, "a textual body must still be scraped")
+			require.Equal(t, "https://example.com/test/endpoint.php", navigationRequests[0].URL, "could not get correct url")
+		})
+	}
+}

--- a/pkg/engine/parser/parser_test.go
+++ b/pkg/engine/parser/parser_test.go
@@ -684,4 +684,26 @@ func TestBodyScrapeEndpointsParser_ContentTypeGate(t *testing.T) {
 			require.Equal(t, "https://example.com/test/endpoint.php", navigationRequests[0].URL, "could not get correct url")
 		})
 	}
+
+	t.Run("application/jsonfoo is not scraped", func(t *testing.T) {
+		resp := &navigation.Response{
+			Resp: &http.Response{
+				Request: &http.Request{URL: parsed.URL},
+				Header:  http.Header{"Content-Type": []string{"application/jsonfoo"}},
+			},
+			Body: binaryBody,
+		}
+		require.Empty(t, bodyScrapeEndpointsParser(resp), "a type that only contains application/json as a prefix must not be mined")
+	})
+
+	t.Run("octet-stream with +json profile is sniffed", func(t *testing.T) {
+		resp := &navigation.Response{
+			Resp: &http.Response{
+				Request: &http.Request{URL: parsed.URL},
+				Header:  http.Header{"Content-Type": []string{`application/octet-stream; profile="+json"`}},
+			},
+			Body: binaryBody,
+		}
+		require.Empty(t, bodyScrapeEndpointsParser(resp), "a +json parameter on octet-stream must not force scraping")
+	})
 }

--- a/pkg/engine/parser/parser_test.go
+++ b/pkg/engine/parser/parser_test.go
@@ -592,14 +592,74 @@ func TestBodyScrapeEndpointsParser_ContentTypeGate(t *testing.T) {
 		require.Empty(t, bodyScrapeEndpointsParser(resp), "a binary response body must not be mined for endpoints")
 	})
 
-	// A body with no declared type is the case with the least evidence that it
-	// is text, so it must not be mined either.
-	t.Run("missing content-type is not scraped", func(t *testing.T) {
+	// No declared type: the BODY decides, not the absence of a header. Binary
+	// content is still refused, by its magic bytes.
+	t.Run("untyped binary body is not scraped", func(t *testing.T) {
 		resp := &navigation.Response{
 			Resp: &http.Response{Request: &http.Request{URL: parsed.URL}},
 			Body: binaryBody,
 		}
-		require.Empty(t, bodyScrapeEndpointsParser(resp), "an undeclared response body must not be mined for endpoints")
+		require.Empty(t, bodyScrapeEndpointsParser(resp), "an untyped binary body must not be mined for endpoints")
+	})
+
+	// ... and untyped TEXT is still scraped. Servers on embedded devices and
+	// appliance interfaces routinely omit Content-Type; skipping those would
+	// trade one silent coverage gap for another.
+	t.Run("untyped text body is scraped", func(t *testing.T) {
+		htmlParsed, _ := urlutil.Parse("https://example.com/index.html")
+		resp := &navigation.Response{
+			Resp: &http.Response{Request: &http.Request{URL: htmlParsed.URL}},
+			Body: `<html><body><a href="/x">y</a><script>var u = "./test/endpoint.php";</script></body></html>`,
+		}
+		navigationRequests := bodyScrapeEndpointsParser(resp)
+		require.NotEmpty(t, navigationRequests, "an untyped HTML body must still be scraped")
+		require.Equal(t, "https://example.com/test/endpoint.php", navigationRequests[0].URL, "could not get correct url")
+	})
+
+	// application/octet-stream is the generic "I do not know" default, so it
+	// gets the same treatment as no header at all: sniff the body.
+	t.Run("octet-stream text body is scraped", func(t *testing.T) {
+		htmlParsed, _ := urlutil.Parse("https://example.com/app.js")
+		resp := &navigation.Response{
+			Resp: &http.Response{
+				Request: &http.Request{URL: htmlParsed.URL},
+				Header:  http.Header{"Content-Type": []string{"application/octet-stream"}},
+			},
+			Body: `window.location = "./test/endpoint.php";`,
+		}
+		require.NotEmpty(t, bodyScrapeEndpointsParser(resp), "a mislabelled text body must still be scraped")
+	})
+
+	t.Run("octet-stream binary body is not scraped", func(t *testing.T) {
+		resp := &navigation.Response{
+			Resp: &http.Response{
+				Request: &http.Request{URL: parsed.URL},
+				Header:  http.Header{"Content-Type": []string{"application/octet-stream"}},
+			},
+			Body: binaryBody,
+		}
+		require.Empty(t, bodyScrapeEndpointsParser(resp), "a mislabelled binary body must not be mined for endpoints")
+	})
+
+	// SVG is XML text carrying href/xlink:href and possibly a <script>, so it
+	// is scraped despite the image/ prefix. Not an accident of the "+xml"
+	// match -- pinned here on purpose.
+	t.Run("image/svg+xml is scraped", func(t *testing.T) {
+		svgParsed, _ := urlutil.Parse("https://example.com/logo.svg")
+		resp := &navigation.Response{
+			Resp: &http.Response{
+				Request: &http.Request{URL: svgParsed.URL},
+				Header:  http.Header{"Content-Type": []string{"image/svg+xml"}},
+			},
+			Body: `<svg xmlns="http://www.w3.org/2000/svg"><a href="./test/endpoint.php"/></svg>`,
+		}
+		var got []string
+		for _, req := range bodyScrapeEndpointsParser(resp) {
+			got = append(got, req.URL)
+		}
+		// The xmlns declaration is mined too, so assert membership rather than
+		// position.
+		require.Contains(t, got, "https://example.com/test/endpoint.php", "an SVG is XML text and must still be scraped")
 	})
 
 	// The parser must keep working for everything it is actually for.


### PR DESCRIPTION
### Problem

`bodyScrapeEndpointsParser` runs `pageBodyRegex` over **every** response body, including binary ones. Its first alternative matches `./x` / `../x`, which occur by chance in image data.

A 265KB PNG from a live site yields:

```
"http://www.w3.org/1999/02/22-rdf-syntax-ns"     <- XMP metadata
"http://ns.adobe.com/xap/1.0/mm/"
"http://ns.adobe.com/xap/1.0/sType/ResourceRef"
"http://ns.adobe.com/xap/1.0/"
"./6"                                            <- pixel data
```

`./6` is resolved against the image's own URL, so the crawler requests a sibling the site never served:

```
base   https://example.com/image/productcatalog/products/10.png
+ ./6  https://example.com/image/productcatalog/products/6      -> 404
```

Not a one-off — other images on the same site produced `./Z`, `.//`, `./2Yz`, each becoming its own 404 request.

### Why the extension denylist does not catch it

`.png` is in the default denylist, so the image URL is refused by `ValidatePath` when it appears as a link. But the string mined out of the image's **bytes** is extensionless, so it passes.

Scraping a binary body therefore launders denied-extension content into allowed-extension requests. Every one is a wasted fetch, a 404 in the results, and a slot against `-max-domain-pages`.

### Fix

Gate the parser on the response `Content-Type`, mirroring `scriptJSFileRegexParser` directly above it, which already refuses anything that is not `.js` / `.css` / `*/javascript`.

`text/*`, JavaScript, JSON, XML and `+json` / `+xml` suffixed types are scraped exactly as before.

When the server sent **no** `Content-Type` -- or the generic `application/octet-stream`, which means the same thing in practice -- the body is **sniffed** with `http.DetectContentType` rather than skipped. Untyped responses are common on embedded servers and appliance interfaces, and refusing to scrape them would trade one silent coverage gap for another. Sniffing identifies binary formats from their magic bytes, which is exactly what this gate needs to exclude:

```
real 265KB PNG   -> image/png                  skip
HTML             -> text/html; charset=utf-8   scrape
bare JS / JSON   -> text/plain; charset=utf-8  scrape
XML              -> text/xml; charset=utf-8    scrape
```

`image/svg+xml` is scraped, via the `+xml` match. That is deliberate and now pinned by a test: an SVG is XML text carrying `href` / `xlink:href` and possibly a `<script>`, so it is a real endpoint source despite the `image/` prefix.

### Verification

- New table test: declared-binary, untyped-binary and octet-stream-binary bodies mine nothing; untyped text, octet-stream text, `image/svg+xml`, `text/html`, `text/plain`, `application/javascript`, `application/json` and `application/xhtml+xml` still mine and resolve correctly.
- Replayed the real PNG three ways -- declared `image/png`, declared `application/octet-stream`, and with no `Content-Type` at all -- 0 endpoints mined in each case.
- Both negative cases fail without the gate (confirmed by reverting it).
- Replayed against the real PNG that produced the original report: 0 navigation requests, down from 1.
- `go vet`, `gofmt`, and the `pkg/engine/parser`, `pkg/utils`, `pkg/types` suites pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved response content-type detection when scraping endpoint responses.
  - Binary content is now correctly excluded, including responses with missing or generic content-type headers.
  - Prevented misleading media-type prefixes from being treated as supported text formats.
  - Continued support for valid JSON, XML, SVG, and other recognized textual responses, including content types with `+json` or `+xml` suffixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->