### PR TITLE
fix(hybrid): honour -proxy for loopback targets

### DIFF
--- a/pkg/engine/headless/browser/browser.go
+++ b/pkg/engine/headless/browser/browser.go
@@ -151,6 +151,9 @@ func (l *Launcher) launchBrowserWithDataDir(userDataDir string) (*rod.Browser, e
 
 		if l.opts.Proxy != "" {
 			chromeLauncher = chromeLauncher.Proxy(l.opts.Proxy)
+			// Chrome bypasses the proxy for localhost/127.0.0.0/8/[::1]/link-local
+			// unless that implicit rule is subtracted. Same token as hybrid.
+			chromeLauncher = chromeLauncher.Set("proxy-bypass-list", "<-loopback>")
 		}
 
 		if l.opts.NoSandbox {

--- a/pkg/engine/hybrid/hybrid.go
+++ b/pkg/engine/hybrid/hybrid.go
@@ -38,6 +38,21 @@ type Crawler struct {
 	tempDir string
 }
 
+// proxyBypassList returns the Chrome proxy bypass list to use for proxy.
+//
+// Chrome bypasses the proxy for localhost, 127.0.0.0/8, [::1] and link-local
+// addresses by default, even when one is configured. "<-loopback>" is the
+// documented way to SUBTRACT that implicit rule, so a configured proxy is
+// honoured for local targets too -- the case where an intercepting proxy is
+// most often used. Empty when no proxy is set, since there is nothing to
+// bypass.
+func proxyBypassList(proxy string) string {
+	if proxy == "" {
+		return ""
+	}
+	return "<-loopback>"
+}
+
 // New returns a new standard crawler instance
 func New(options *types.CrawlerOptions) (*Crawler, error) {
 	var dataStore string
@@ -114,7 +129,21 @@ func New(options *types.CrawlerOptions) (*Crawler, error) {
 		// rod's helper takes no proxy argument, and Options.Proxy otherwise never
 		// reaches a browser attached through ChromeWSUrl, because the chrome
 		// launcher -- its only proxy path -- does not run in that case.
-		res, err := proto.TargetCreateBrowserContext{ProxyServer: options.Options.Proxy}.Call(browser)
+		res, err := proto.TargetCreateBrowserContext{
+			ProxyServer: options.Options.Proxy,
+			// "<-loopback>" SUBTRACTS Chrome's implicit proxy bypass.
+			//
+			// Chrome always bypasses the proxy for localhost, 127.0.0.0/8,
+			// [::1] and link-local, even when one is configured; the only way
+			// to disable that built-in rule is to subtract it here. Without
+			// this, `-proxy` is silently ignored for exactly the local targets
+			// people most often put behind an intercepting proxy, and the
+			// crawl still succeeds -- so the traffic simply never appears.
+			//
+			// Only applied when a proxy was actually requested: with no proxy
+			// there is nothing to bypass, and the token would be meaningless.
+			ProxyBypassList: proxyBypassList(options.Options.Proxy),
+		}.Call(browser)
 		if err != nil {
 			return nil, errkit.Wrap(err, "hybrid: failed to create incognito browser")
 		}
@@ -360,6 +389,9 @@ func buildChromeLauncher(options *types.CrawlerOptions, dataStore string) (*laun
 			return nil, err
 		}
 		chromeLauncher.Set("proxy-server", proxyURL.String())
+		// Same implicit-bypass problem as the browser-context path above: without
+		// this, a launched Chrome ignores the proxy for loopback targets.
+		chromeLauncher.Set("proxy-bypass-list", proxyBypassList(options.Options.Proxy))
 	}
 
 	for k, v := range options.Options.ParseHeadlessOptionalArguments() {

--- a/pkg/engine/hybrid/hybrid.go
+++ b/pkg/engine/hybrid/hybrid.go
@@ -383,7 +383,7 @@ func buildChromeLauncher(options *types.CrawlerOptions, dataStore string) (*laun
 		chromeLauncher.Set("no-sandbox", "true")
 	}
 
-	if options.Options.Proxy != "" && options.Options.Headless {
+	if options.Options.Proxy != "" {
 		proxyURL, err := urlutil.Parse(options.Options.Proxy)
 		if err != nil {
 			return nil, err
@@ -391,6 +391,8 @@ func buildChromeLauncher(options *types.CrawlerOptions, dataStore string) (*laun
 		chromeLauncher.Set("proxy-server", proxyURL.String())
 		// Same implicit-bypass problem as the browser-context path above: without
 		// this, a launched Chrome ignores the proxy for loopback targets.
+		// Applied whenever a proxy is set, including -hh (Headless is mutually
+		// exclusive with HeadlessHybrid, so the previous Headless guard never ran).
 		chromeLauncher.Set("proxy-bypass-list", proxyBypassList(options.Options.Proxy))
 	}
 

--- a/pkg/engine/hybrid/proxy_bypass_test.go
+++ b/pkg/engine/hybrid/proxy_bypass_test.go
@@ -1,0 +1,18 @@
+package hybrid
+
+import "testing"
+
+// Chrome bypasses the proxy for localhost/127.0.0.0/8/[::1]/link-local even
+// when one is configured, so a proxy alone does not capture a crawl of a local
+// target -- the exact setup used when pointing katana at an app through an
+// intercepting proxy. "<-loopback>" subtracts that built-in rule.
+func TestProxyBypassList(t *testing.T) {
+	if got := proxyBypassList("http://127.0.0.1:8080"); got != "<-loopback>" {
+		t.Errorf("proxyBypassList with a proxy = %q, want %q; without it Chrome silently skips the proxy for local targets", got, "<-loopback>")
+	}
+	// No proxy means nothing to bypass; sending the token anyway would be a
+	// meaningless flag on every default crawl.
+	if got := proxyBypassList(""); got != "" {
+		t.Errorf("proxyBypassList without a proxy = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
Follow-up to #1751, which applied `Options.Proxy` to the browser context but left Chrome's implicit bypass in place.

### Problem

Chrome bypasses the proxy for `localhost`, `127.0.0.0/8`, `[::1]` and link-local addresses **by default, even when a proxy is configured**. Setting `ProxyServer` on the browser context (or `--proxy-server` on the launcher) is therefore not sufficient: a crawl of a local target connects directly.

The failure is silent from both ends. katana reports a normal crawl; the intercepting proxy shows an incomplete history with nothing to indicate it is incomplete.

This is the setup people most often use `-proxy` for: pointing katana at an app on localhost and capturing the traffic in Burp/ZAP.

### Measurement

A loopback target and a counting proxy, tagging requests that arrive via the proxy so they can be told apart from direct ones:

```
before:  direct=9   viaProxy=6      <- 9 requests never reached the proxy
after:   direct=0   viaProxy=15
```

Worth noting it is *partial*, not total: the proxy history looks populated, so nothing prompts the user to doubt it, while most of the traffic escaped unobserved.

### Fix

`"<-loopback>"` is Chrome's documented token for SUBTRACTING the implicit bypass rule. Applied on both proxy paths so the two attach modes behave identically:

- the browser context created when attaching via `-chrome-ws-url`
- the chrome launcher (`--proxy-bypass-list`)

Only set when a proxy was actually requested; with no proxy there is nothing to bypass.

### Behaviour change

Local targets are now proxied. A proxy that cannot itself reach the target's loopback address will fail where the request previously succeeded unproxied. That is the intended trade: a visible failure beats traffic silently escaping the proxy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Configured proxies now correctly handle loopback and link-local destinations.
  - Incognito and launched browser sessions consistently apply proxy settings, regardless of headless mode.

- **Tests**
  - Added coverage to verify proxy bypass behavior with and without a configured proxy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->