### PR TITLE
test(files): add test coverage for robotstxt crawler boundary rules

### DIFF
--- a/pkg/engine/parser/files/robotstxt_test.go
+++ b/pkg/engine/parser/files/robotstxt_test.go
@@ -20,6 +20,9 @@ Disallow: /test/misc/known-files/robots.txt.found
 User-agent: *
 Disallow: /test/includes/
 
+User-agent: *
+Allow: /test/public/api
+
 # User-agent: Googlebot
 # Allow: /random/
 
@@ -35,5 +38,7 @@ Sitemap: https://example.com/sitemap.xml`
 	require.ElementsMatch(t, requests, []string{
 		"http://localhost/test/includes/",
 		"http://localhost/test/misc/known-files/robots.txt.found",
+		"http://localhost/test/public/api",
 	}, "could not get correct elements")
 }
+


### PR DESCRIPTION
### Summary of Changes
- Rebased and cleanly submitted against `dev` with focused test coverage as requested by @Mzack9999.
- Tests crawler parsing logic for `Allow:` directive boundary rules in `pkg/engine/parser/files`.
- `go test -v ./pkg/engine/parser/files`: **100% green PASS**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming that crawler navigation requests include paths permitted by an `Allow` rule in robots.txt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->