### PR TITLE
fix(hybrid): don't close a browser katana didn't launch

### DIFF
--- a/pkg/engine/hybrid/crawl_test.go
+++ b/pkg/engine/hybrid/crawl_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-rod/rod"
 	"github.com/go-rod/rod/lib/launcher"
 	"github.com/go-rod/rod/lib/proto"
+	"github.com/projectdiscovery/katana/pkg/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -90,4 +91,52 @@ func TestDOMGetDocumentTimeoutDoesNotBlockHTML(t *testing.T) {
 	body, err := basePage.Timeout(5 * time.Second).HTML()
 	require.NoError(t, err, "HTML retrieval should succeed with fresh timeout from basePage")
 	require.NotEmpty(t, body, "HTML body should not be empty")
+}
+
+func launchExternalBrowser(t *testing.T) (*rod.Browser, string) {
+	t.Helper()
+	path, _ := launcher.LookPath()
+	if path == "" {
+		t.Skip("chrome/chromium not found, skipping browser test")
+	}
+
+	wsURL, err := launcher.New().Leakless(true).Launch()
+	if err != nil {
+		t.Skipf("could not launch browser: %v", err)
+	}
+	browser := rod.New().ControlURL(wsURL).MustConnect()
+	t.Cleanup(func() { _ = browser.Close() })
+
+	return browser, wsURL
+}
+
+func TestCloseLeavesAttachedBrowserRunning(t *testing.T) {
+	for _, noIncognito := range []bool{true, false} {
+		name := "incognito"
+		if noIncognito {
+			name = "no-incognito"
+		}
+		t.Run(name, func(t *testing.T) {
+			external, wsURL := launchExternalBrowser(t)
+
+			options, err := types.NewCrawlerOptions(&types.Options{
+				ChromeWSUrl:         wsURL,
+				HeadlessNoIncognito: noIncognito,
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = options.Close() })
+
+			crawler, err := New(options)
+			require.NoError(t, err)
+			require.NoError(t, crawler.Close())
+
+			version, err := proto.BrowserGetVersion{}.Call(external)
+			require.NoError(t, err, "attached browser should outlive crawler.Close")
+			require.NotEmpty(t, version.Product)
+
+			page, err := external.Page(proto.TargetCreateTarget{})
+			require.NoError(t, err, "attached browser should still serve new pages")
+			_ = page.Close()
+		})
+	}
 }

--- a/pkg/engine/hybrid/hybrid.go
+++ b/pkg/engine/hybrid/hybrid.go
@@ -116,7 +116,9 @@ func New(options *types.CrawlerOptions) (*Crawler, error) {
 		if owned {
 			return
 		}
-		_ = browser.Close()
+		if ownsBrowser(browser, chromeLauncher) {
+			_ = browser.Close()
+		}
 		_ = cdpWS.Close()
 		if chromeLauncher != nil {
 			chromeLauncher.Kill()
@@ -170,9 +172,13 @@ func New(options *types.CrawlerOptions) (*Crawler, error) {
 	return crawler, nil
 }
 
+func ownsBrowser(browser *rod.Browser, chromeLauncher *launcher.Launcher) bool {
+	return chromeLauncher != nil || browser.BrowserContextID != ""
+}
+
 // Close closes the crawler process
 func (c *Crawler) Close() error {
-	if c.browser != nil {
+	if c.browser != nil && ownsBrowser(c.browser, c.chromeLauncher) {
 		_ = c.browser.Close()
 	}
 	if c.cdpWS != nil {


### PR DESCRIPTION
Fixes #1757.

`Crawler.Close()` calls `browser.Close()` unconditionally. rod sends `Browser.close` when `BrowserContextID` is empty, and `-headless-no-incognito` leaves us holding the root handle, so attaching over `-chrome-ws-url` ends the crawl by killing a browser katana never started. Same unconditional close sat in the `owned == false` error path in `New`.

Both now go through `ownsBrowser`: close only what we launched or a context clone we created. `cdpWS.Close()` stays unconditional (that socket is ours, #1755).

Not reachable from the CLI, which routes `-chrome-ws-url` to the headless engine. Hits library users calling `hybrid.New` directly.

`TestCloseLeavesAttachedBrowserRunning` fails on `dev` (`EOF`, no-incognito case) and passes with this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Closing a crawler no longer shuts down an externally managed browser it is attached to.
  - Attached browser sessions remain available for creating new pages after crawler shutdown.
  - Browser cleanup continues to close crawler-owned or private browser sessions appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->