### PR TITLE
fix(hybrid): bind page to crawl context

### DIFF
--- a/pkg/engine/hybrid/crawl.go
+++ b/pkg/engine/hybrid/crawl.go
@@ -34,7 +34,7 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 		RootHostname: s.Hostname,
 	}
 
-	page, err := s.Browser.Page(proto.TargetCreateTarget{})
+	page, err := s.Browser.Context(s.Ctx).Page(proto.TargetCreateTarget{})
 	if err != nil {
 		return nil, errkit.Wrap(err, "hybrid: could not create target")
 	}

--- a/pkg/engine/hybrid/crawl_test.go
+++ b/pkg/engine/hybrid/crawl_test.go
@@ -1,12 +1,18 @@
 package hybrid
 
 import (
+	"context"
+	"math"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/go-rod/rod"
 	"github.com/go-rod/rod/lib/launcher"
 	"github.com/go-rod/rod/lib/proto"
+	"github.com/projectdiscovery/katana/pkg/output"
+	"github.com/projectdiscovery/katana/pkg/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -90,4 +96,50 @@ func TestDOMGetDocumentTimeoutDoesNotBlockHTML(t *testing.T) {
 	body, err := basePage.Timeout(5 * time.Second).HTML()
 	require.NoError(t, err, "HTML retrieval should succeed with fresh timeout from basePage")
 	require.NotEmpty(t, body, "HTML body should not be empty")
+}
+
+func TestCancelDuringElementInteraction(t *testing.T) {
+	if path, _ := launcher.LookPath(); path == "" {
+		t.Skip("chrome/chromium not found, skipping browser test")
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<html><body><a href="#" onclick="while(true){}">x</a></body></html>`))
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	options, err := types.NewCrawlerOptions(&types.Options{
+		Context:      ctx,
+		MaxDepth:     2,
+		FieldScope:   "rdn",
+		BodyReadSize: math.MaxInt,
+		Timeout:      600,
+		TimeStable:   1,
+		Concurrency:  1,
+		Parallelism:  1,
+		RateLimit:    150,
+		Strategy:     "depth-first",
+		Headless:     true,
+		OnResult:     func(output.Result) {},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = options.Close() })
+
+	crawler, err := New(options)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = crawler.Close() })
+
+	done := make(chan error, 1)
+	go func() { done <- crawler.Crawl(srv.URL) }()
+
+	time.Sleep(5 * time.Second)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("Crawl did not return after context cancellation")
+	}
 }

--- a/pkg/engine/hybrid/crawl_test.go
+++ b/pkg/engine/hybrid/crawl_test.go
@@ -120,9 +120,10 @@ func TestCancelDuringElementInteraction(t *testing.T) {
 		Concurrency:  1,
 		Parallelism:  1,
 		RateLimit:    150,
-		Strategy:     "depth-first",
-		Headless:     true,
-		OnResult:     func(output.Result) {},
+		Strategy:          "depth-first",
+		Headless:          true,
+		HeadlessNoSandbox: true,
+		OnResult:          func(output.Result) {},
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = options.Close() })


### PR DESCRIPTION
Fixes #1756.

Pages were created from an unbound browser, then rebound with `page.Context(s.Ctx)`. That rebinding is a shallow struct copy in rod, so the shared `Mouse` still points at the original page holding `context.Background()`. `Element.Click` dispatches through it (`input.go:372`), so cancelling `Options.Context` never reached a click in flight and `Crawl` hung.

Creating the page from a context-bound browser makes rod derive the page ctx from it (`browser.go:281`), so `Mouse`/`Keyboard` inherit cancellation.

Note the mechanism in the issue is not quite right: `cdp.Client.Call` does select on `ctx.Done()`. It was parked because the ctx it got was never cancelled, not because the read ignores context.

`TestCancelDuringElementInteraction` hangs 30s+ on `dev` and returns immediately with this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved crawl cancellation during pages with unresponsive JavaScript, allowing crawls to stop more reliably when canceled.
  - Ensured browser activity respects the crawl’s cancellation context for more responsive shutdowns.
  - Prevented closing a crawler from shutting down an externally attached browser.

- **Tests**
  - Added coverage for cancellation during prolonged page interactions and for preserving externally attached browser sessions when a crawler closes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->