### PR TITLE
fix(hybrid): skip WaitStable when TimeStable is 0

### DIFF
--- a/pkg/engine/hybrid/crawl.go
+++ b/pkg/engine/hybrid/crawl.go
@@ -283,6 +283,8 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 			if err := page.WaitStable(timeStable); err != nil {
 				gologger.Warning().Msgf("could not wait for page to be stable: %s\n", err)
 			}
+		} else {
+			gologger.Debug().Msgf("time-stable is non-positive: skipping stability wait\n")
 		}
 	}
 

--- a/pkg/engine/hybrid/crawl.go
+++ b/pkg/engine/hybrid/crawl.go
@@ -279,8 +279,10 @@ func (c *Crawler) navigateRequest(s *common.CrawlSession, request *navigation.Re
 			gologger.Warning().Msgf("setting time stable to %s\n", timeStable)
 		}
 
-		if err := page.WaitStable(timeStable); err != nil {
-			gologger.Warning().Msgf("could not wait for page to be stable: %s\n", err)
+		if timeStable > 0 {
+			if err := page.WaitStable(timeStable); err != nil {
+				gologger.Warning().Msgf("could not wait for page to be stable: %s\n", err)
+			}
 		}
 	}
 

--- a/pkg/engine/hybrid/crawl_test.go
+++ b/pkg/engine/hybrid/crawl_test.go
@@ -1,12 +1,17 @@
 package hybrid
 
 import (
+	"math"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/go-rod/rod"
 	"github.com/go-rod/rod/lib/launcher"
 	"github.com/go-rod/rod/lib/proto"
+	"github.com/projectdiscovery/katana/pkg/output"
+	"github.com/projectdiscovery/katana/pkg/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -90,4 +95,37 @@ func TestDOMGetDocumentTimeoutDoesNotBlockHTML(t *testing.T) {
 	body, err := basePage.Timeout(5 * time.Second).HTML()
 	require.NoError(t, err, "HTML retrieval should succeed with fresh timeout from basePage")
 	require.NotEmpty(t, body, "HTML body should not be empty")
+}
+
+func TestZeroTimeStableDoesNotPanic(t *testing.T) {
+	if path, _ := launcher.LookPath(); path == "" {
+		t.Skip("chrome/chromium not found, skipping browser test")
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<html><body><a href="/a">a</a></body></html>`))
+	}))
+	defer srv.Close()
+
+	options, err := types.NewCrawlerOptions(&types.Options{
+		MaxDepth:     1,
+		FieldScope:   "rdn",
+		BodyReadSize: math.MaxInt,
+		Timeout:      10,
+		Concurrency:  1,
+		Parallelism:  1,
+		RateLimit:    150,
+		Strategy:     "depth-first",
+		Headless:     true,
+		OnResult:     func(output.Result) {},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = options.Close() })
+
+	crawler, err := New(options)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = crawler.Close() })
+
+	require.NoError(t, crawler.Crawl(srv.URL))
 }

--- a/pkg/engine/hybrid/crawl_test.go
+++ b/pkg/engine/hybrid/crawl_test.go
@@ -209,6 +209,7 @@ func TestZeroTimeStableDoesNotPanic(t *testing.T) {
 		FieldScope:        "rdn",
 		BodyReadSize:      math.MaxInt,
 		Timeout:           10,
+		TimeStable:        0,
 		Concurrency:       1,
 		Parallelism:       1,
 		RateLimit:         150,


### PR DESCRIPTION
Fixes #1825.

`TimeStable: 0` reached `time.NewTicker(0)` and panicked in a goroutine rod spawns, so callers could not recover. Zero now means no stability wait.

`TestZeroTimeStableDoesNotPanic` panics on `dev` and passes with this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Crawling now handles zero or negative page-stability timing without triggering unnecessary waits.
  * Canceled crawls now return promptly during blocked page interactions.
  * Closing a crawler no longer closes an externally attached browser.

* **Tests**
  * Added coverage for non-positive stability settings, cancellation behavior, browser lifecycle handling, and crawling linked pages without stability waits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->