### PR TITLE
feat(hybrid): expose the crawl's BrowserContextID

### DIFF
--- a/pkg/engine/hybrid/hybrid.go
+++ b/pkg/engine/hybrid/hybrid.go
@@ -176,6 +176,17 @@ func ownsBrowser(browser *rod.Browser, chromeLauncher *launcher.Launcher) bool {
 	return chromeLauncher != nil || browser.BrowserContextID != ""
 }
 
+// BrowserContextID returns the id of the browser context this crawler created
+// in New, or "" if it has no browser. It lets an embedding program dispose the
+// context out of band: when a crawl dies without running Close, the context
+// otherwise stays resident in a shared, long-lived browser.
+func (c *Crawler) BrowserContextID() string {
+	if c.browser == nil {
+		return ""
+	}
+	return string(c.browser.BrowserContextID)
+}
+
 // Close closes the crawler process
 func (c *Crawler) Close() error {
 	if c.browser != nil && ownsBrowser(c.browser, c.chromeLauncher) {


### PR DESCRIPTION
## Proposed changes

`hybrid.New` creates a browser context per crawler (`Target.createBrowserContext`, since #1751) but the id is never exposed, so a program embedding katana cannot dispose that context out of band.

That matters when katana attaches to a shared, long-lived browser over `-chrome-ws-url`: if a crawl's process dies without reaching `Close`, the context stays resident and holds the browser's memory for a crawl that no longer exists. With the id recorded, a supervisor can reap orphaned contexts.

Read-only accessor, 11 lines, no behaviour change.

```go
func (c *Crawler) BrowserContextID() string
```

## Checklist

- [x] Builds (`go build ./...`, `go vet ./pkg/engine/hybrid/`)
- [x] No behaviour change, so no test added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added access to the browser context identifier associated with each crawl.
  - The identifier is available for external browser-context management when needed.
  - Returns an empty value when no browser context is available, providing predictable behavior for crawls without an active browser.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->